### PR TITLE
Added libqt5opengl5-dev package dependency for ubuntu-setup.

### DIFF
--- a/util/ubuntu-packages.txt
+++ b/util/ubuntu-packages.txt
@@ -11,6 +11,7 @@ ninja
 # QT
 qt5-default
 qttools5-dev-tools
+libqt5opengl5-dev
 
 # required for compiling gcc
 libgmp3-dev


### PR DESCRIPTION
Probably a Linux Mint issue, as the package is installed normally for Ubuntu folks
