### PR TITLE
Replace cmake ppa with a debian backport that is more frequently updated (and generally better)

### DIFF
--- a/util/ubuntu-packages.txt
+++ b/util/ubuntu-packages.txt
@@ -6,6 +6,7 @@
 
 # Build system
 ninja
+cmake
 
 # QT
 qt5-default
@@ -81,5 +82,3 @@ python-numpy
 python-matplotlib
 python-usb
 freeglut3-dev
-cmake3
-

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -6,14 +6,11 @@ if [ $UID -ne 0 ]; then
 	exec sudo $0
 fi
 
-# add repo for backport of cmake3
+# add repo for backport of cmake3 from debian testing
 # TODO remove this once ubuntu ships cmake3
-apt-add-repository -y ppa:andykimpe/cmake3
+apt-add-repository -y ppa:packetlost/cmake
 
-#TODO dont run this if running cmake3. This dosent hurt for now
-#apt-get -y purge cmake
-# apt get install cmake3 is taken care of by requiremnets.
-# When removing this, change cmake3 to cmake in dependencies
+# apt get install cmake is taken care of by requirements
 
 apt-get update
 


### PR DESCRIPTION
This ppa also doesn't build from source, and names cmake properly, so we can keep our requirements as they are! (ubuntu != gentoo)

This commit has been tested on both stock 14.04 dockerimages and 14.04 dockerimages of the previous commit (and compiled soccer with no errors), so it shouldn't cause any trouble.

Removing the other ppa is not necessary as this ppa has a newer version of cmake.
This command will remove the old ppa, if you want to do that anyway:

```
sudo apt-add-repository -y --remove ppa:andykimpe/cmake3
```
