### PR TITLE
Add python-serial package for debian systems

### DIFF
--- a/util/ubuntu-packages.txt
+++ b/util/ubuntu-packages.txt
@@ -54,6 +54,7 @@ python3-pip
 python3-dev
 python3-setuptools
 python3-pyqt5
+python-serial
 
 # for the high-level python interface for soccer
 libboost-python-dev


### PR DESCRIPTION
Debian does not come with this package pre-installed, so this commit adds this package to the dependencies. 

The python-serial package is needed for moving firmware to the robot.

On ubuntu systems, this does nothing.
