### PR TITLE
Fixed error on current build of robot2015-prog

### DIFF
--- a/util/arch-packages-aur.txt
+++ b/util/arch-packages-aur.txt
@@ -2,4 +2,5 @@
 # we'll install from the AUR using yaourt
 
 # to drive robots with the SpaceNavigator 3d mouse
+gcc-arm-none-eabi-bin
 #spacenavd #TODO fix spacenavd. Once fixed, uncomment yaourt in arch-setup

--- a/util/arch-packages.txt
+++ b/util/arch-packages.txt
@@ -12,7 +12,6 @@ clang
 mpfr
 gmp
 libmpc
-arm-none-eabi-gcc
 
 qt5-base
 qt5-tools

--- a/util/arch-setup
+++ b/util/arch-setup
@@ -9,6 +9,6 @@ echo "-- Installing required packages"
 sudo pacman -S --needed --noconfirm $(sed 's/#.*//;/^$/d' $BASE/util/arch-packages.txt)
 
 #echo "-- Installing required AUR packages"
-#yaourt -S --needed --noconfirm $(sed 's/#.*//;/^$/d' $BASE/util/arch-packages-aur.txt)
+yaourt -S --needed --noconfirm $(sed 's/#.*//;/^$/d' $BASE/util/arch-packages-aur.txt)
 
 sudo pip install -r $BASE/util/requirements3.txt

--- a/util/robot2015-prog.sh
+++ b/util/robot2015-prog.sh
@@ -39,7 +39,10 @@ for i in $MBED_DEVICES_PATH; do
     sudo mkdir -p /mnt/script/MBED
     sudo mount $i /mnt/script/MBED
     sudo cp $1 /mnt/script/MBED/
-    sudo umount /mnt/script/MBED/
+    sudo umount -l /mnt/script/MBED/
+    if [ $? -eq 0 ]; then
+        echo Unmount successful! Do not remove mbed until write light stops blinking!
+    fi
     sudo rmdir /mnt/script/MBED
 done
 


### PR DESCRIPTION
Changed unmount to a 'lazy' unmount, which will remove the device from the filesystem regardless if the device is busy or not. It will be properly unmounted once it becomes free again.

This has not been tested with multiple mbeds yet.