### PR TITLE
Changed Simulator's Ball damping to 0.25 from 0.5

### DIFF
--- a/simulator/physics/Ball.cpp
+++ b/simulator/physics/Ball.cpp
@@ -51,7 +51,7 @@ void Ball::initPhysics() {
 	_ball->setActivationState(DISABLE_DEACTIVATION);
 
 	_ball->setFriction(10.f); // doesn't work?
-	_ball->setDamping(0.5f,0.5f); // use damping for friction
+	_ball->setDamping(0.25f,0.25f); // use damping for friction
 
 	//_ball->setCollisionFlags(_ball->getCollisionFlags() | btCollisionObject::CF_CUSTOM_MATERIAL_CALLBACK);
 


### PR DESCRIPTION
After much painful measuring of real-life deceleration of the ball, I found out the damping values for our Simulator's ball was set twice too high.

Data:
REAL BALL:
time: 1421196020129756 us, speed: 1.234951702 m/s
time: 1421196022092275 us, speed: 0.684793973 m/s
diff:          1962519 us,  diff: −0.550157729 m/s
speed: −0.280332434 m/s^2

time: 1421196020129756 us, speed: 1.234951702 m/s
time: 1421196021136150 us, speed: 0.958510312 m/s
diff:          1006394 us, speed: −0.27644139 m/s
speed: −0.274685054 m/s^2


SIMULATOR BALL
(damping value: 0.5)
time: 1421194802934936 us, speed: 1.28608 m/s
time: 1421194803689187 us, speed: 0.913999 m/s
diff:           754251 us,  diff: −0.372081 m/s
speed: −0.493311908 m/s^2

time: 1421194802934936 us, speed: 1.28608 m/s
time: 1421194804411725 us, speed: 0.515193 m/s
diff:          1476789 us,  diff: −0.770887 m/s
speed: −0.522002128 m/s^2

(damping value: 0.25)
time: 1421196516224770 us, speed: 1.40196 m/s
time: 1421196517736014 us, speed: 0.912104 m/s
diff:          1511244 us,  diff: −0.489856 m/s
speed: −0.324140906 m/s^2

time: 1421196516224770 us, speed: 1.40196 m/s
time: 1421196519163970 us, speed: 0.602802 m/s
diff:          2939200 us,  diff: −0.799158 m/s
speed: −0.271896434 m/s^2
