### PR TITLE
Adds qt5-svg package to arch setup packages.

### DIFF
--- a/util/arch-packages.txt
+++ b/util/arch-packages.txt
@@ -18,6 +18,7 @@ libmpc
 
 qt5-base
 qt5-tools
+qt5-svg
 qwtplot3d
 
 python-pyqt5


### PR DESCRIPTION
This fixes icons not showing up.