### PR TITLE
Added option flags to ubuntu-setup

### DIFF
--- a/util/travis-setup
+++ b/util/travis-setup
@@ -54,7 +54,8 @@ freeglut3-dev \
 libbfd-dev \
 libspnav-dev \
 libsdl1.2-dev \
-gcc-arm-none-eabi
+gcc-arm-none-eabi \
+libqt5svg5-dev
 
 # install CMake from source b/c we need >= 3.0.0
 wget http://www.cmake.org/files/v3.0/cmake-3.0.2.tar.gz

--- a/util/ubuntu-packages.txt
+++ b/util/ubuntu-packages.txt
@@ -14,7 +14,6 @@ qt5-default
 qttools5-dev-tools
 libqt5opengl5-dev
 libqt5svg5-dev
-python3-pyqt5
 
 # required for compiling gcc
 libgmp3-dev

--- a/util/ubuntu-packages.txt
+++ b/util/ubuntu-packages.txt
@@ -13,6 +13,8 @@ ccache
 qt5-default
 qttools5-dev-tools
 libqt5opengl5-dev
+libqt5svg5-dev
+python3-pyqt5
 
 # required for compiling gcc
 libgmp3-dev

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -68,8 +68,6 @@ fi
 
 if $FIRMWARE; then
     add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
-    apt-get update
-    sudo apt-get install gcc-arm-none-eabi
 fi
 
 # apt get install cmake is taken care of by requirements
@@ -90,6 +88,12 @@ echo "-- Installing required packages"
 ARGS=""
 if $YES; then
     ARGS="-y"
+fi
+
+if $FIRMWARE; then
+    # This is kind of hacky and could produce unwanted side effects
+    # If the firmware switch does more things, it may be better to make a firmware-deps file!
+    ARGS="$ARGS gcc-arm-none-eabi"
 fi
 
 # install all of the packages listed in required_packages.txt

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -14,7 +14,7 @@ This script will need root privileges"
 YES=false
 
 # if we change this to true, please put it in the below if statment, as debian already has a good version...
-if [ -z "$(cat /etc/os-release | grep 'Debian')" ]; then # dont add repositories on debian, compatability issues?
+if [ -z "$(cat /etc/os-release | grep -i '^NAME=.*Debian')" ]; then # dont add repositories on debian, compatability issues?
     ADD_REPOS=true
     FIRMWARE=true
 else

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -3,12 +3,60 @@
 # Become root
 if [ $UID -ne 0 ]; then
 	echo "-- Becoming root"
-	exec sudo $0
+	exec sudo $0 $@
 fi
+
+HELP_STR="Usage: ./ubuntu-setup [-y | --yes] [-n | --noclobber] [-c | --clobber] [-h | --help]
+
+\tyes:\t\tassume no user input
+\tnoclobber:\tdont install 3rd party repositories
+\tclobber:\tInstall 3rd party repositories
+\thelp:\t\tprint this message!
+
+This script will need root privileges"
+
+# defaults!
+YES=false
+if [ -z "$(uname -a | grep -i "Debian")" ]; then # dont add repositories on debian, compatability issues?
+    ADD_REPOS=true
+else
+    ADD_REPOS=false
+fi
+
+
+# parse command line args
+for i in "$@"
+do
+    case $i in
+        -y|--yes)
+            YES=true
+            ;;
+        -n|--noclobber)
+            # This option omits the addition of the fake repos
+            ADD_REPOS=false
+            ;;
+        -c|--clobber)
+            # This option forces addition of the custom repos
+            ADD_REPOS=true
+            ;;
+        -h|--help)
+            echo -e "$HELP_STR"
+            exit 1
+            ;;
+        *)
+            echo "Unrecognized Option: $i"
+            echo -e "\n$HELP_STR"
+            exit 1
+            # unknown options
+            ;;
+    esac
+done
 
 # add repo for backport of cmake3 from debian testing
 # TODO remove this once ubuntu ships cmake3
-apt-add-repository -y ppa:packetlost/cmake
+if $ADD_REPOS; then
+    apt-add-repository -y ppa:packetlost/cmake
+fi
 
 # apt get install cmake is taken care of by requirements
 
@@ -23,8 +71,15 @@ echo "-- Installing udev rules"
 cp -f $BASE/util/robocup.rules /etc/udev/rules.d/
 
 echo "-- Installing required packages"
+
+# if yes option is checked, add  a -y
+ARGS=""
+if $YES; then
+    ARGS="-y"
+fi
+
 # install all of the packages listed in required_packages.txt
-apt-get install $(sed 's/#.*//;/^$/d' $BASE/util/ubuntu-packages.txt)
+apt-get install $ARGS $(sed 's/#.*//;/^$/d' $BASE/util/ubuntu-packages.txt)
 
 # install python3 requirements
 pip3 install -r $BASE/util/requirements3.txt

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -1,11 +1,5 @@
 #!/bin/bash -e
 
-# Become root
-if [ $UID -ne 0 ]; then
-	echo "-- Becoming root"
-	exec sudo $0 $@
-fi
-
 HELP_STR="Usage: ./ubuntu-setup [-y | --yes] [-n | --noclobber] [-c | --clobber] [-f | --firmware] [-h | --help]
 
 \tyes:\t\tassume no user input
@@ -21,7 +15,7 @@ YES=false
 
 # if we change this to true, please put it in the below if statment, as debian already has a good version...
 FIRMWARE=false
-if [ -z "$(cat /etc/lsb-release | grep -i "Debian")" ]; then # dont add repositories on debian, compatability issues?
+if [ -z "$(cat /etc/os-release | grep -i "Debian")" ]; then # dont add repositories on debian, compatability issues?
     ADD_REPOS=true
 else
     ADD_REPOS=false
@@ -59,6 +53,12 @@ do
             ;;
     esac
 done
+
+# Become root
+if [ $UID -ne 0 ]; then
+	echo "-- Becoming root"
+	exec sudo $0 $@
+fi
 
 # add repo for backport of cmake3 from debian testing
 # TODO remove this once ubuntu ships cmake3

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -14,11 +14,12 @@ This script will need root privileges"
 YES=false
 
 # if we change this to true, please put it in the below if statment, as debian already has a good version...
-FIRMWARE=false
-if [ -z "$(cat /etc/os-release | grep -i "Debian")" ]; then # dont add repositories on debian, compatability issues?
+if [ -z "$(cat /etc/os-release | grep 'Debian')" ]; then # dont add repositories on debian, compatability issues?
     ADD_REPOS=true
+    FIRMWARE=true
 else
     ADD_REPOS=false
+    FIRMWARE=false
 fi
 
 

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -6,17 +6,21 @@ if [ $UID -ne 0 ]; then
 	exec sudo $0 $@
 fi
 
-HELP_STR="Usage: ./ubuntu-setup [-y | --yes] [-n | --noclobber] [-c | --clobber] [-h | --help]
+HELP_STR="Usage: ./ubuntu-setup [-y | --yes] [-n | --noclobber] [-c | --clobber] [-f | --firmware] [-h | --help]
 
 \tyes:\t\tassume no user input
 \tnoclobber:\tdont install 3rd party repositories
 \tclobber:\tInstall 3rd party repositories
+\tfirmware:\tInstall firmware repository
 \thelp:\t\tprint this message!
 
 This script will need root privileges"
 
 # defaults!
 YES=false
+
+# if we change this to true, please put it in the below if statment, as debian already has a good version...
+FIRMWARE=false
 if [ -z "$(uname -a | grep -i "Debian")" ]; then # dont add repositories on debian, compatability issues?
     ADD_REPOS=true
 else
@@ -32,12 +36,16 @@ do
             YES=true
             ;;
         -n|--noclobber)
-            # This option omits the addition of the fake repos
+            # This option omits the addition of the 3rd party repos
             ADD_REPOS=false
             ;;
         -c|--clobber)
             # This option forces addition of the custom repos
             ADD_REPOS=true
+            ;;
+        -f|--firmware)
+            # This option forces the addition of the firmware repositories
+            FIRMWARE=true
             ;;
         -h|--help)
             echo -e "$HELP_STR"
@@ -56,6 +64,12 @@ done
 # TODO remove this once ubuntu ships cmake3
 if $ADD_REPOS; then
     apt-add-repository -y ppa:packetlost/cmake
+fi
+
+if $FIRMWARE; then
+    add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
+    apt-get update
+    sudo apt-get install gcc-arm-none-eabi
 fi
 
 # apt get install cmake is taken care of by requirements

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -21,7 +21,7 @@ YES=false
 
 # if we change this to true, please put it in the below if statment, as debian already has a good version...
 FIRMWARE=false
-if [ -z "$(uname -a | grep -i "Debian")" ]; then # dont add repositories on debian, compatability issues?
+if [ -z "$(cat /etc/lsb-release | grep -i "Debian")" ]; then # dont add repositories on debian, compatability issues?
     ADD_REPOS=true
 else
     ADD_REPOS=false


### PR DESCRIPTION
I added a bunch of flags that should help with automation (especially in docker). In addition, I added the svg binaries. 

I'm still testing this on a clean ubuntu install, but it seems to work fin if you have previously run the script

Currently, on ubuntu installs, it installs only the cmake repo by default, and the firmware if provided the --firmware flag. On debian, no repos are added by default, but that can be forced with the -c flag. See -h for more details.

Partially solves #191 