### PR TITLE
Switch reboot command on firmware to breaks, and check sha hashes

### DIFF
--- a/util/requirements3.txt
+++ b/util/requirements3.txt
@@ -5,3 +5,4 @@ enum34
 watchdog # file-system event notifications
 munkres	# provides the 'hungarian algorithm', which we use for robot role assignment
 pylint #static checker for python
+pyserial

--- a/util/robot2015-prog.sh
+++ b/util/robot2015-prog.sh
@@ -53,7 +53,7 @@ done
 
 # here's hoping the copy takes less than 5 seconds
 # TODO find a better solution...
-sleep 5
+sleep 1
 
 # restart mbed code
 MBED_SERIAL_PATH="$(ls /dev/ | grep ttyACM | sed 's\.*\/dev/&\g')"
@@ -61,7 +61,10 @@ MBED_SERIAL_PATH="$(ls /dev/ | grep ttyACM | sed 's\.*\/dev/&\g')"
 for i in $MBED_SERIAL_PATH; do
     echo Attempting reboot on $i ...
     # clear buffer, send reboot, enter
-    sudo bash -c "echo -ne '\rreboot\r' > $i"
+
+    # send break signal to all mbeds
+    sudo python3 -c "import serial; serial.Serial(\"$i\").sendBreak()"
+    # sudo bash -c "echo -ne '\rreboot\r' > $i"
 done
 
 

--- a/util/robot2015-prog.sh
+++ b/util/robot2015-prog.sh
@@ -19,6 +19,8 @@ MBED_DEVICES="$(ls /dev/disk/by-id/ | grep -i mbed)"
 # This prepends the directory structure to all found mbed devices
 MBED_DEVICES_PATH="$(ls /dev/disk/by-id/ | grep -i mbed | sed 's\.*\/dev/disk/by-id/&\g')"
 
+SHA2="$(sha256sum $1 | awk '{print $1}')"
+
 # errors out if no mbed devices were found
 if [ -z $MBED_DEVICES ]; then
     echo "No mbed device detected!"
@@ -39,6 +41,15 @@ for i in $MBED_DEVICES_PATH; do
     sudo mkdir -p /mnt/script/MBED
     sudo mount $i /mnt/script/MBED
     sudo cp $1 /mnt/script/MBED/
+
+
+    if [ "$SHA2" != "$(sha256sum /mnt/script/MBED/$(echo "$1" | awk 'BEGIN {FS = "/"}; {print $NF}') | awk '{print $1}')" ]; then
+        echo ERROR: Sha Hashes do not match. Exiting...
+        exit 1
+    else
+        echo Sha256sums of binary files match!
+    fi
+
     sudo umount -l /mnt/script/MBED/
     if [ $? -eq 0 ]; then
         echo Unmount successful! Do not remove mbed until write light stops blinking!
@@ -53,7 +64,7 @@ done
 
 # here's hoping the copy takes less than 5 seconds
 # TODO find a better solution...
-sleep 1
+sleep 4
 
 # restart mbed code
 MBED_SERIAL_PATH="$(ls /dev/ | grep ttyACM | sed 's\.*\/dev/&\g')"

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -1,11 +1,12 @@
 #!/bin/bash -e
 
-HELP_STR="Usage: ./ubuntu-setup [-y | --yes] [-n | --noclobber] [-c | --clobber] [-f | --firmware] [-h | --help]
+HELP_STR="Usage: ./ubuntu-setup [-y | --yes] [-n | --noclobber] [-c | --clobber] [-f | --firmware] [-nf | --nofirmware] [-h | --help]
 
 \tyes:\t\tassume no user input
 \tnoclobber:\tdont install 3rd party repositories
 \tclobber:\tInstall 3rd party repositories
 \tfirmware:\tInstall firmware repository
+\tnofirmware:\tPrevents installation of firmware deps firmware repository
 \thelp:\t\tprint this message!
 
 This script will need root privileges"
@@ -41,6 +42,10 @@ do
         -f|--firmware)
             # This option forces the addition of the firmware repositories
             FIRMWARE=true
+            ;;
+        -nf|--nofirmware)
+            # This option turns off the addition of the firmware repositories
+            FIRMWARE=false
             ;;
         -h|--help)
             echo -e "$HELP_STR"


### PR DESCRIPTION
I switched the reboot command being sent to the mbed to a break command being sent by python. 

In addition, I also added a check to see if the SHA hashes of the copied files are the same, as we had problems in the past with that. 

I'm pretty sure I added all the dependencies for this, but let me know if anything was missed.

This is another attempted solution of #231.

Also I added a nofirmware option to ubuntu-setup