### PR TITLE
Kill background simulators when running make run-sim

### DIFF
--- a/makefile
+++ b/makefile
@@ -10,6 +10,7 @@ static-analysis:
 run: all
 	cd run; ./soccer
 run-sim: all
+	-pkill -f './simulator --headless'
 	cd run; ./simulator --headless &
 	cd run; ./soccer -sim
 

--- a/makefile
+++ b/makefile
@@ -10,7 +10,8 @@ static-analysis:
 run: all
 	cd run; ./soccer
 run-sim: all
-	-pkill -f './simulator --headless'
+	# Kill simulator if running
+	-if [ -n "$$(ps -A -o args | grep './[s]imulator --headless')" ]; then kill "$$(ps -A -o pid,args | grep './[s]imulator --headless' | awk '{print $$1}')"; fi
 	cd run; ./simulator --headless &
 	cd run; ./soccer -sim
 


### PR DESCRIPTION
I got really sick of the headless simulator being reused when running `make run-sim`, so I added a line to the makefile to kill the headless simulator when run-sim starts. Should I add it to run after the execution instead?

The line should be ignored if it fails

Also, I'm not sure if macs have pkill installed (its not posix). If thats the case, then I can convert this to use standard ps and kill.