### PR TITLE
Refactored FieldView into FieldView and FieldBackgroundView

### DIFF
--- a/soccer/CMakeLists.txt
+++ b/soccer/CMakeLists.txt
@@ -13,6 +13,7 @@ set(ROBOCUP_LIB_SRC
     "BatteryWidget.cpp"
     "Configuration.cpp"
     "FieldView.cpp"
+    "FieldBackgroundView.cpp"
     "gameplay/GameplayModule.cpp"
     "gameplay/robocup-py.cpp"
     "joystick/GamepadJoystick.cpp"
@@ -145,6 +146,7 @@ qt5_wrap_ui(LOG_VIEWER_UI ui/LogViewer.ui)
 set(LOG_VIEWER_SRC
     "LogViewer.cpp"
     "FieldView.cpp"
+    "FieldBackgroundView.cpp"
    	"ProtobufTree.cpp"
    	"StripChart.cpp"
 )

--- a/soccer/FieldBackgroundView.cpp
+++ b/soccer/FieldBackgroundView.cpp
@@ -1,0 +1,163 @@
+#include "FieldBackgroundView.hpp"
+
+#include <math.h>
+
+FieldBackgroundView::FieldBackgroundView(QWidget* parent)
+    : QWidget(parent),
+      _fieldOrientation(FieldOrientationPortrait),
+      _transformsValid(false), _blueTeam(false), _defendingPlusX(true) {
+    // Green background color
+    QPalette p = palette();
+    p.setColor(QPalette::Window, QColor(0, 85, 0));
+    setPalette(p);
+    setAutoFillBackground(true);
+}
+
+void FieldBackgroundView::setupWorldSpace(QPainter* painter) const {
+    painter->translate(width() / 2.0, height() / 2.0);
+    painter->scale(width(), -height());
+    painter->rotate(static_cast<int>(fieldOrientation()) * 90);
+    painter->scale(1.0 / fieldDimensions().FloorLength(), 1.0 / fieldDimensions().FloorWidth());
+}
+
+void FieldBackgroundView::setFieldOrientation(FieldOrientation orientation) {
+    _fieldOrientation = orientation;
+
+    invalidateTransforms();
+    updateGeometry();   //  Fix size
+    update();           //  trigger a redraw
+}
+
+void FieldBackgroundView::recalculateTransformsIfNeeded() const {
+    _screenToWorld = Geometry2d::TransformMatrix();
+    _screenToWorld *= Geometry2d::TransformMatrix::scale(
+        fieldDimensions().FloorLength(), fieldDimensions().FloorWidth());
+    _screenToWorld *= Geometry2d::TransformMatrix::rotate(
+        -static_cast<int>(fieldOrientation()) * M_PI / 2.0);
+    _screenToWorld *=
+        Geometry2d::TransformMatrix::scale(1.0 / width(), -1.0 / height());
+    _screenToWorld *=
+        Geometry2d::TransformMatrix::translate(-width() / 2.0, -height() / 2.0);
+
+    _worldToTeam = Geometry2d::TransformMatrix();
+    _worldToTeam *= Geometry2d::TransformMatrix::translate(
+        0, fieldDimensions().Length() / 2.0f);
+    if (_defendingPlusX) {
+        _worldToTeam *= Geometry2d::TransformMatrix::rotate(-M_PI / 2.0);
+    } else {
+        _worldToTeam *= Geometry2d::TransformMatrix::rotate(M_PI / 2.0);
+    }
+
+    _teamToWorld = Geometry2d::TransformMatrix();
+    if (_defendingPlusX) {
+        _teamToWorld *= Geometry2d::TransformMatrix::rotate(M_PI / 2.0);
+    } else {
+        _teamToWorld *= Geometry2d::TransformMatrix::rotate(-M_PI / 2.0);
+    }
+    _teamToWorld *= Geometry2d::TransformMatrix::translate(
+        0, -fieldDimensions().Length() / 2.0f);
+
+
+    _textRotationWorldSpace = -static_cast<int>(fieldOrientation()) * 90;
+    _textRotationTeamSpace =
+        _textRotationWorldSpace + (_defendingPlusX ? -90 : 90);
+
+    _transformsValid = true;
+}
+
+void FieldBackgroundView::resizeEvent(QResizeEvent* e) {
+    int givenW = e->size().width();
+    int givenH = e->size().height();
+    int needW, needH;
+    if (FieldOrientationIsPortrait(fieldOrientation())) {
+        needH = roundf(givenW * fieldDimensions().FloorLength() /
+                       fieldDimensions().FloorWidth());
+        needW = roundf(givenH * fieldDimensions().FloorWidth() /
+                       fieldDimensions().FloorLength());
+    } else {
+        needH = roundf(givenW * fieldDimensions().FloorWidth() /
+                       fieldDimensions().FloorLength());
+        needW = roundf(givenH * fieldDimensions().FloorLength() /
+                       fieldDimensions().FloorWidth());
+    }
+
+    QSize size = needW < givenW ? QSize(needW, givenH) : QSize(givenW, needH);
+
+    if (size != e->size()) {
+        resize(size);
+        invalidateTransforms();
+    }
+    e->accept();
+}
+
+// Draws the field including white lines, goal zones, goals, etc
+void FieldBackgroundView::paintEvent(QPaintEvent* e) {
+    recalculateTransformsIfNeeded();
+
+    //  setup painter with antialiasing for drastically improved rendering
+    //  quality
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+
+    setupWorldSpace(&p);
+
+    //reset to center
+    p.translate(-fieldDimensions().FloorLength() /2.0, -fieldDimensions().FloorWidth() /2.0);
+
+    p.translate(fieldDimensions().Border(), fieldDimensions().Border());
+
+    p.setPen(QPen(Qt::white, fieldDimensions().LineWidth() *2.0));  //  double-width pen for visibility (although its less accurate)
+    p.setBrush(Qt::NoBrush);
+    p.drawRect(QRectF(0, 0, fieldDimensions().Length(), fieldDimensions().Width()));
+
+    //set brush alpha to 0
+    p.setBrush(QColor(0,130,0, 0));
+
+    //reset to center
+    p.translate(fieldDimensions().Length() /2.0, fieldDimensions().Width() /2.0);
+
+    //centerline
+    p.drawLine(QLineF(0, fieldDimensions().Width() /2,0, -fieldDimensions().Width() /2.0));
+
+    //center circle
+    p.drawEllipse(QRectF(-fieldDimensions().CenterRadius(), -fieldDimensions().CenterRadius(),
+        fieldDimensions().CenterDiameter(), fieldDimensions().CenterDiameter()));
+
+    p.translate(-fieldDimensions().Length() /2.0, 0);
+
+    //goal areas
+    p.drawArc(QRectF(-fieldDimensions().ArcRadius(), -fieldDimensions().ArcRadius() + fieldDimensions().GoalFlat() /2.f, 2.f * fieldDimensions().ArcRadius(), 2.f * fieldDimensions().ArcRadius()), -90*16, 90*16);
+    p.drawArc(QRectF(-fieldDimensions().ArcRadius(), -fieldDimensions().ArcRadius() - fieldDimensions().GoalFlat() /2.f, 2.f * fieldDimensions().ArcRadius(), 2.f * fieldDimensions().ArcRadius()), 90*16, -90*16);
+    p.drawLine(QLineF(fieldDimensions().ArcRadius(), -fieldDimensions().GoalFlat() /2.f, fieldDimensions().ArcRadius(), fieldDimensions().GoalFlat() /2.f));
+    // Penalty Mark
+    p.drawEllipse(QRectF(-fieldDimensions().PenaltyDiam() /2.0f + fieldDimensions().PenaltyDist(), -fieldDimensions().PenaltyDiam() /2.0f, fieldDimensions().PenaltyDiam(), fieldDimensions().PenaltyDiam()));
+
+    p.translate(fieldDimensions().Length(), 0);
+
+    p.drawArc(QRectF(-fieldDimensions().ArcRadius(), -fieldDimensions().ArcRadius() + fieldDimensions().GoalFlat() /2.f, 2.f * fieldDimensions().ArcRadius(), 2.f * fieldDimensions().ArcRadius()), -90*16, -90*16);
+    p.drawArc(QRectF(-fieldDimensions().ArcRadius(), -fieldDimensions().ArcRadius() - fieldDimensions().GoalFlat() /2.f, 2.f * fieldDimensions().ArcRadius(), 2.f * fieldDimensions().ArcRadius()), 90*16, 90*16);
+    p.drawLine(QLineF(-fieldDimensions().ArcRadius(), -fieldDimensions().GoalFlat() /2.f, -fieldDimensions().ArcRadius(), fieldDimensions().GoalFlat() /2.f));
+    // Penalty Mark
+    p.drawEllipse(QRectF(-fieldDimensions().PenaltyDiam() /2.0f - fieldDimensions().PenaltyDist(), -fieldDimensions().PenaltyDiam() /2.0f, fieldDimensions().PenaltyDiam(), fieldDimensions().PenaltyDiam()));
+
+    // goals
+    float x[2] = {0, fieldDimensions().GoalDepth()};
+    float y[2] = {fieldDimensions().GoalWidth() /2.0f, -fieldDimensions().GoalWidth() /2.0f};
+
+    bool flip = _blueTeam ^ _defendingPlusX;
+
+    QColor goalColor = flip ? Qt::yellow : Qt::blue;
+    p.setPen(QPen(goalColor, fieldDimensions().LineWidth() * 2.0)); //  double-width for visibility, not real-life accuracy
+    p.drawLine(QLineF(x[0], y[0], x[1], y[0]));
+    p.drawLine(QLineF(x[0], y[1], x[1], y[1]));
+    p.drawLine(QLineF(x[1], y[1], x[1], y[0]));
+
+    x[0] -= fieldDimensions().Length();
+    x[1] -= fieldDimensions().Length() + 2 * fieldDimensions().GoalDepth();
+
+    goalColor = flip ? Qt::blue : Qt::yellow;
+    p.setPen(QPen(goalColor, fieldDimensions().LineWidth() * 2.0));
+    p.drawLine(QLineF(x[0], y[0], x[1], y[0]));
+    p.drawLine(QLineF(x[0], y[1], x[1], y[1]));
+    p.drawLine(QLineF(x[1], y[1], x[1], y[0]));
+}

--- a/soccer/FieldBackgroundView.cpp
+++ b/soccer/FieldBackgroundView.cpp
@@ -29,6 +29,8 @@ void FieldBackgroundView::setFieldOrientation(FieldOrientation orientation) {
 }
 
 void FieldBackgroundView::recalculateTransformsIfNeeded() const {
+    if (_transformsValid) return;
+
     _screenToWorld = Geometry2d::TransformMatrix();
     _screenToWorld *= Geometry2d::TransformMatrix::scale(
         fieldDimensions().FloorLength(), fieldDimensions().FloorWidth());

--- a/soccer/FieldBackgroundView.hpp
+++ b/soccer/FieldBackgroundView.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <QtWidgets>
+
+#include "Field_Dimensions.hpp"
+#include <Geometry2d/TransformMatrix.hpp>
+
+
+/// Orientation of the drawn field, with our goal as the reference point.
+/// Each orientation is 90-degrees counter-clockwise from the previous.
+typedef enum {
+    FieldOrientationLandscapeLeft = 0,
+    FieldOrientationPortrait,
+    FieldOrientationLandscapeRight,
+    FieldOrientationPortraitUpsideDown
+} FieldOrientation;
+
+inline bool FieldOrientationIsPortrait(FieldOrientation orientation) {
+    return orientation == FieldOrientationPortraitUpsideDown ||
+           orientation == FieldOrientationPortrait;
+}
+
+inline FieldOrientation FieldOrientationRotate180(
+    FieldOrientation orientation) {
+    static FieldOrientation flippedOrientations[] = {
+        FieldOrientationLandscapeRight,
+        FieldOrientationPortraitUpsideDown,
+        FieldOrientationLandscapeLeft,
+        FieldOrientationPortrait
+    };
+    return flippedOrientations[orientation];
+}
+
+/// This class draws the field including lines, goals, goal zones, etc.
+/// It also handles coordinate conversions related to drawing.
+class FieldBackgroundView : public QWidget {
+public:
+    FieldBackgroundView(QWidget* parent = nullptr);
+
+    const Field_Dimensions& fieldDimensions() const {
+        return _fieldDimensions;
+    }
+    void setFieldDimensions(const Field_Dimensions& fieldDimensions) {
+        _fieldDimensions = fieldDimensions;
+    }
+
+    /// Set which team we are (for the team transformations).
+    /// Defaults to false (us as the yellow team).
+    void setBlueTeam(bool blue) {
+        _blueTeam = blue;
+        invalidateTransforms();
+        update();
+    }
+    bool isBlueTeam() const {
+        return _blueTeam;
+    }
+
+    /// Which end of the field we're defending (relative to global coordinates).
+    /// Defaults to true
+    void setDefendingPlusX(bool defendingPlusX) {
+        _defendingPlusX = defendingPlusX;
+        invalidateTransforms();
+        update();
+    }
+    bool defendingPlusX() const {
+        return _defendingPlusX;
+    }
+
+    /// Transforms the painter's coordinates so that (0, 0) is the field center,
+    /// drawing units correspond to meters, and the field rotation is applied.
+    void setupWorldSpace(QPainter* painter) const;
+
+    /// Field orientation - relative to the world coordinate
+    void setFieldOrientation(FieldOrientation orientation);
+    FieldOrientation fieldOrientation() const {
+        return _fieldOrientation;
+    }
+
+    /// Get geometry transformations.  Ensure they're valid by calling
+    /// recalculateTransformsIfNeeded() first.
+    const Geometry2d::TransformMatrix& screenToWorld() const {
+        return _screenToWorld;
+    }
+    const Geometry2d::TransformMatrix& worldToTeam() const {
+        return _worldToTeam;
+    }
+    const Geometry2d::TransformMatrix& teamToWorld() const {
+        return _teamToWorld;
+    }
+    int textRotationForWorldSpace() const {
+        return _textRotationWorldSpace;
+    }
+    int textRotationForTeamSpace() const {
+        return _textRotationTeamSpace;
+    }
+
+    /// Recalculates all transforms if @_transformsValid is false.
+    void recalculateTransformsIfNeeded() const;
+
+
+protected:
+    virtual void paintEvent(QPaintEvent* e);
+
+    /// Override resizeEvent() so we can enforce proper x-y aspect ratio
+    virtual void resizeEvent(QResizeEvent* e);
+
+    /// Set transforms to be recalculated.
+    void invalidateTransforms() {
+        _transformsValid = false;
+    }
+
+private:
+    Field_Dimensions _fieldDimensions;
+
+    bool _blueTeam;
+    bool _defendingPlusX;
+
+    mutable bool _transformsValid;
+
+    /// Coordinate transformations
+    mutable Geometry2d::TransformMatrix _screenToWorld;
+    mutable Geometry2d::TransformMatrix _worldToTeam;
+    mutable Geometry2d::TransformMatrix _teamToWorld;
+
+    // How many degrees to rotate text (in world space) so it draws upright on
+    // screen.
+    mutable int _textRotationWorldSpace;
+    mutable int _textRotationTeamSpace;
+
+    /// Defaults to FieldOrientationPortrait
+    FieldOrientation _fieldOrientation;
+};

--- a/soccer/FieldView.cpp
+++ b/soccer/FieldView.cpp
@@ -22,36 +22,28 @@ using namespace std;
 using namespace boost;
 using namespace Packet;
 
-static QPen redPen(Qt::red, 0);
-static QPen bluePen(Qt::blue, 0);
-static QPen yellowPen(Qt::yellow, 0);
-static QPen blackPen(Qt::black, 0);
-static QPen whitePen(Qt::white, 0);
-static QPen greenPen(Qt::green, 0);
-static QPen grayPen(Qt::gray, 0);
+static const QPen redPen(Qt::red, 0);
+static const QPen bluePen(Qt::blue, 0);
+static const QPen yellowPen(Qt::yellow, 0);
+static const QPen blackPen(Qt::black, 0);
+static const QPen whitePen(Qt::white, 0);
+static const QPen greenPen(Qt::green, 0);
+static const QPen grayPen(Qt::gray, 0);
 
 static QPen tempPen(Qt::white, 0);
 
-static QColor ballColor(0xff, 0x90, 0);
-static QPen ballPen(ballColor, 0);
+static const QColor ballColor(0xff, 0x90, 0);
+static const QPen ballPen(ballColor, 0);
 
 FieldView::FieldView(QWidget* parent) :
-	QWidget(parent)
+	FieldBackgroundView(parent)
 {
-
 	showRawRobots = false;
 	showRawBalls = false;
 	showCoords = false;
     showDotPatterns = false;
     showTeamNames = false;
-	_rotate = 1;
 	_history = 0;
-
-	// Green background
-	QPalette p = palette();
-	p.setColor(QPalette::Window, QColor(0, 85.0, 0));
-	setPalette(p);
-	setAutoFillBackground(true);
 }
 
 std::shared_ptr<LogFrame> FieldView::currentFrame()
@@ -64,94 +56,83 @@ std::shared_ptr<LogFrame> FieldView::currentFrame()
 	}
 }
 
-void FieldView::rotate(int value)
+void FieldView::layerVisible(int i, bool value)
 {
-	_rotate = value;
-	
-	// Fix size
-	updateGeometry();
-	
-	update();
+    if (i >= 0 && i < _layerVisible.size())
+    {
+        _layerVisible[i] = value;
+    }
+    else if (i >= _layerVisible.size())
+    {
+        _layerVisible.resize(i+1);
+        _layerVisible[i] = value;
+    }
+}
+
+bool FieldView::layerVisible(int i) const
+{
+    if (i < _layerVisible.size())
+    {
+        return _layerVisible[i];
+    } else {
+        return false;
+    }
 }
 
 void FieldView::paintEvent(QPaintEvent* e)
 {
+    // Get the latest LogFrame
+    const std::shared_ptr<LogFrame> frame = currentFrame();
+    if (!frame)
+    {
+        // No data available yet
+        return;
+    }
+
+    // Set FieldBackgroundView settings
+    setBlueTeam(frame->blue_team());
+    setDefendingPlusX(frame->defend_plus_x());
+
+    // Call superclass method to draw field
+    FieldBackgroundView::paintEvent(e);
+
 	QPainter p(this);
 
 	//	antialiasing drastically improves rendering quality
 	p.setRenderHint(QPainter::Antialiasing);
-	
+
 	if (!live)
 	{
 		// Non-live border
 		p.setPen(QPen(Qt::red, 4));
 		p.drawRect(rect());
 	}
-	
-	// Set up world space
-	p.translate(width() / 2.0, height() / 2.0);
-	p.scale(width(), -height());
-	p.rotate(_rotate * 90);
-	p.scale(1.0 / Field_Dimensions::Current_Dimensions.FloorLength(), 1.0 / Field_Dimensions::Current_Dimensions.FloorWidth());
-	
-	// Set text rotation for world space
-	_textRotation = -_rotate * 90;
-	
+
+    // Make sure coordinate transforms are valid
+    recalculateTransformsIfNeeded();
+
+	// Transform coordinate system
+    setupWorldSpace(&p);
+
 	if (showCoords)
 	{
-		drawCoords(p);
+		drawCoords(p, true);
 	}
-	
-	// Get the latest LogFrame
-	const std::shared_ptr<LogFrame> frame = currentFrame();
-	
-	if (!frame)
-	{
-		// No data available yet
-		return;
-	}
-	
-	// Make coordinate transformations
-	_screenToWorld = Geometry2d::TransformMatrix();
-	_screenToWorld *= Geometry2d::TransformMatrix::scale(Field_Dimensions::Current_Dimensions.FloorLength(), Field_Dimensions::Current_Dimensions.FloorWidth());
-	_screenToWorld *= Geometry2d::TransformMatrix::rotate(-_rotate * M_PI / 2.0);
-	_screenToWorld *= Geometry2d::TransformMatrix::scale(1.0 / width(), -1.0 / height());
-	_screenToWorld *= Geometry2d::TransformMatrix::translate(-width() / 2.0, -height() / 2.0);
-	
-	_worldToTeam = Geometry2d::TransformMatrix();
-	_worldToTeam *= Geometry2d::TransformMatrix::translate(0, Field_Dimensions::Current_Dimensions.Length() / 2.0f);
-	if (frame->defend_plus_x())
-	{
-		_worldToTeam *= Geometry2d::TransformMatrix::rotate(-M_PI / 2.0);
-	} else {
-		_worldToTeam *= Geometry2d::TransformMatrix::rotate(M_PI / 2.0);
-	}
-	
-	_teamToWorld = Geometry2d::TransformMatrix();
-	if (frame->defend_plus_x())
-	{
-		_teamToWorld *= Geometry2d::TransformMatrix::rotate(M_PI / 2.0);
-	} else {
-		_teamToWorld *= Geometry2d::TransformMatrix::rotate(-M_PI / 2.0);
-	}
-	_teamToWorld *= Geometry2d::TransformMatrix::translate(0, -Field_Dimensions::Current_Dimensions.Length() / 2.0f);
-	
+
+
 	// Draw world-space graphics
 	drawWorldSpace(p);
-	
+
 	// Everything after this point is drawn in team space.
 	// Transform that into world space depending on defending goal.
-	if (frame->defend_plus_x())
+    if (defendingPlusX())
 	{
 		p.rotate(90);
 	} else {
 		p.rotate(-90);
 	}
-	p.translate(0, -Field_Dimensions::Current_Dimensions.Length() / 2.0f);
+	p.translate(0, -fieldDimensions().Length() / 2.0f);
 
-	// Text has to be rotated so it is always upright on screen
-	_textRotation = -_rotate * 90 + (frame->defend_plus_x() ? -90 : 90);
-	
 	drawTeamSpace(p);
 }
 
@@ -159,61 +140,6 @@ void FieldView::drawWorldSpace(QPainter& p)
 {
 	// Get the latest LogFrame
 	const LogFrame *frame = _history->at(0).get();
-	
-	// Draw the field
-	drawField(p, frame);
-
-	//	maps robots to their comet trails, so we can draw a path of where each robot has been over the past X frames
-	//	the pair used as a key is of the form (team, robot_id).  Blue team = 1, yellow = 2.
-	//	we only draw trails for robots that exist in the current frame
-	map<pair<int, int>, QPainterPath> cometTrails;
-
-	///	populate @cometTrails with the past locations of each robot
-	int pastLocationCount = 50;	//	number of past locations to show
-	const float prev_loc_scale = 0.4;
-	for (int i = 0; i < pastLocationCount + 1 && i < _history->size(); i++) {
-		const LogFrame *oldFrame = _history->at(i).get();
-		if (oldFrame) {
-			for (const SSL_WrapperPacket &wrapper : oldFrame->raw_vision()) {
-				if (!wrapper.has_detection()) {
-					//	useless
-					continue;
-				}
-
-				const SSL_DetectionFrame &detect = wrapper.detection();
-
-				for (const SSL_DetectionRobot &r : detect.robots_blue()) {
-					pair<int, int> key(1, r.robot_id());
-					if (cometTrails.find(key) != cometTrails.end() || i == 0) {
-						QPointF pt(r.x() / 1000, r.y() / 1000);
-						if (i == 0) cometTrails[key].moveTo(pt);
-						else cometTrails[key].lineTo(pt);
-					}
-				}
-
-				for (const SSL_DetectionRobot &r : detect.robots_yellow()) {
-					pair<int, int> key(2, r.robot_id());
-					if (cometTrails.find(key) != cometTrails.end() || i == 0) {
-						QPointF pt(r.x() / 1000, r.y() / 1000);
-						if (i == 0) cometTrails[key].moveTo(pt);
-						else cometTrails[key].lineTo(pt);
-					}
-				}
-			}
-		}
-	}
-
-
-	//	draw robot comet trails
-	const float cometTrailPenSize = 0.05;
-	for (auto &kv : cometTrails) {
-		QColor color = kv.first.first == 1 ? Qt::blue : Qt::yellow;
-		QPen pen(color, cometTrailPenSize);
-		pen.setCapStyle(Qt::RoundCap);
-		p.setPen(pen);
-		p.drawPath(kv.second);
-	}
-
 
 	// Raw vision
 	if (showRawBalls || showRawRobots)
@@ -227,26 +153,26 @@ void FieldView::drawWorldSpace(QPainter& p)
 				// Useless
 				continue;
 			}
-			
+
 			const SSL_DetectionFrame &detect = wrapper.detection();
-			
+
 			if (showRawRobots)
 			{
 				for (const SSL_DetectionRobot& r :  detect.robots_blue())
 				{
 					QPointF pos(r.x() / 1000, r.y() / 1000);
-					drawRobot(p, true, r.robot_id(), pos, r.orientation());
-// 					p.drawEllipse(QPointF(r.x() / 1000, r.y() / 1000), Robot_Radius, Robot_Radius);
+					// drawRobot(p, true, r.robot_id(), pos, r.orientation());
+                    p.drawEllipse(QPointF(r.x() / 1000, r.y() / 1000), Robot_Radius, Robot_Radius);
 				}
-				
+
 				for (const SSL_DetectionRobot& r :  detect.robots_yellow())
 				{
 					QPointF pos(r.x() / 1000, r.y() / 1000);
-					drawRobot(p, false, r.robot_id(), pos, r.orientation());
-// 					p.drawEllipse(QPointF(r.x() / 1000, r.y() / 1000), Robot_Radius, Robot_Radius);
+					// drawRobot(p, false, r.robot_id(), pos, r.orientation());
+                    p.drawEllipse(QPointF(r.x() / 1000, r.y() / 1000), Robot_Radius, Robot_Radius);
 				}
 			}
-			
+
 			if (showRawBalls)
 			{
 				for (const SSL_DetectionBall& b :  detect.balls())
@@ -262,7 +188,7 @@ void FieldView::drawTeamSpace(QPainter& p)
 {
 	// Get the latest LogFrame
 	const LogFrame *frame = _history->at(0).get();
-	
+
 	if(showTeamNames)
     {
     	//Draw Team Names
@@ -271,33 +197,33 @@ void FieldView::drawTeamSpace(QPainter& p)
 		fontstyle.setPointSize(20);
 		p.setFont(fontstyle);
 		p.setPen(bluePen);
-		drawText(p,QPointF(0,4.75), QString(frame->team_name_blue().c_str()), true); //Blue
+		drawText(p,QPointF(0,4.75), QString(frame->team_name_blue().c_str()), true, false); //Blue
 		p.setPen(yellowPen);
-		drawText(p,QPointF(0,1.75), QString(frame->team_name_yellow().c_str()), true); //Yellow
+		drawText(p,QPointF(0,1.75), QString(frame->team_name_yellow().c_str()), true, false); //Yellow
     	p.setFont(savedFont);
     }
 
 	// Block off half the field
 	if (!frame->use_our_half())
 	{
-		const float FX = Field_Dimensions::Current_Dimensions.FloorWidth() / 2;
-		const float FY1 = -Field_Dimensions::Current_Dimensions.Border();
-		const float FY2 = Field_Dimensions::Current_Dimensions.Length() / 2;
+		const float FX = fieldDimensions().FloorWidth() / 2;
+		const float FY1 = -fieldDimensions().Border();
+		const float FY2 = fieldDimensions().Length() / 2;
 		p.fillRect(QRectF(QPointF(-FX, FY1), QPointF(FX, FY2)), QColor(0, 0, 0, 128));
 	}
 	if (!frame->use_opponent_half())
 	{
-		const float FX = Field_Dimensions::Current_Dimensions.FloorWidth() / 2;
-		const float FY1 = Field_Dimensions::Current_Dimensions.Length() / 2;
-		const float FY2 = Field_Dimensions::Current_Dimensions.Length() + Field_Dimensions::Current_Dimensions.Border();
+		const float FX = fieldDimensions().FloorWidth() / 2;
+		const float FY1 = fieldDimensions().Length() / 2;
+		const float FY2 = fieldDimensions().Length() + fieldDimensions().Border();
 		p.fillRect(QRectF(QPointF(-FX, FY1), QPointF(FX, FY2)), QColor(0, 0, 0, 128));
 	}
-	
+
 	if (showCoords)
 	{
-		drawCoords(p);
+		drawCoords(p, false);
 	}
-	
+
 	// History
 	p.setBrush(Qt::NoBrush);
 	QPainterPath ballTrail;
@@ -306,7 +232,7 @@ void FieldView::drawTeamSpace(QPainter& p)
 		const LogFrame *oldFrame = _history->at(i).get();
 		if (oldFrame && oldFrame->has_ball()) {
 			QPointF pos = qpointf(oldFrame->ball().pos());
-			
+
 			if (i == 0) ballTrail.moveTo(pos);
 			else ballTrail.lineTo(pos);
 		}
@@ -315,7 +241,7 @@ void FieldView::drawTeamSpace(QPainter& p)
 	ballTrailPen.setCapStyle(Qt::RoundCap);
 	p.setPen(ballTrailPen);
 	p.drawPath(ballTrail);
-	
+
 	// Debug lines
 	for (const DebugPath& path :  frame->debug_paths())
 	{
@@ -350,7 +276,7 @@ void FieldView::drawTeamSpace(QPainter& p)
 		{
 			tempPen.setColor(text.color());
 			p.setPen(tempPen);
-			drawText(p, qpointf(text.pos()), QString::fromStdString(text.text()), text.center());
+			drawText(p, qpointf(text.pos()), QString::fromStdString(text.text()), text.center(), false);
 		}
 	}
 
@@ -365,7 +291,7 @@ void FieldView::drawTeamSpace(QPainter& p)
 				fprintf(stderr, "Ignoring DebugPolygon with %d points\n", path.points_size());
 				continue;
 			}
-			
+
 			QColor color = qcolor(path.color());
 			color.setAlpha(64);
 			p.setBrush(color);
@@ -379,22 +305,73 @@ void FieldView::drawTeamSpace(QPainter& p)
 	}
 	p.setBrush(Qt::NoBrush);
 
+
+    //  maps robots to their comet trails, so we can draw a path of where each robot has been over the past X frames
+    //  the pair used as a key is of the form (our_team?, robot_id).
+    //  we only draw trails for robots that exist in the current frame
+    map<pair<bool, int>, QPainterPath> cometTrails;
+
+    //  populate @cometTrails with the past locations of each robot
+    int pastLocationCount = 50; //  number of past locations to show
+    bool prev_defend_plus_x;
+    const float prev_loc_scale = 0.4;
+    for (int i = 0; i < pastLocationCount + 1 && i < _history->size(); i++) {
+        const LogFrame *oldFrame = _history->at(i).get();
+        if (oldFrame) {
+            // If we switch from defending +x to -x, cut off comet trail b/c it won't make sense
+            if (i == 0) prev_defend_plus_x = oldFrame->defend_plus_x();
+            else if (prev_defend_plus_x != oldFrame->defend_plus_x()) break;
+            // Their robots
+            for (const LogFrame::Robot& r : oldFrame->opp()) {
+                pair<int, int> key(false, r.shell());
+                if (cometTrails.find(key) != cometTrails.end() || i == 0) {
+                    if (i == 0) cometTrails[key].moveTo(qpointf(r.pos()));
+                    else cometTrails[key].lineTo(qpointf(r.pos()));
+                }
+            }
+
+            //  Our robots
+            for (const LogFrame::Robot& r : oldFrame->self()) {
+                pair<int, int> key(true, r.shell());
+                if (cometTrails.find(key) != cometTrails.end() || i == 0) {
+                    if (i == 0) cometTrails[key].moveTo(qpointf(r.pos()));
+                    else cometTrails[key].lineTo(qpointf(r.pos()));
+                }
+            }
+
+
+        }
+    }
+
+    //  draw robot comet trails
+    const float cometTrailPenSize = 0.05;
+    const QColor ourColor(isBlueTeam() ? Qt::blue : Qt::yellow);
+    const QColor theirColor(isBlueTeam() ? Qt::yellow : Qt::blue);
+    for (auto &kv : cometTrails) {
+        QColor color = kv.first.first ? ourColor : theirColor;
+        QPen pen(color, cometTrailPenSize);
+        pen.setCapStyle(Qt::RoundCap);
+        p.setPen(pen);
+        p.drawPath(kv.second);
+    }
+
+
 	// Text positioning vectors
-	QPointF rtX = qpointf(Geometry2d::Point(0, 1).rotated(-_rotate * 90));
-	QPointF rtY = qpointf(Geometry2d::Point(-1, 0).rotated(-_rotate * 90));
-	
+	QPointF rtX = qpointf(Geometry2d::Point(0, 1).rotated(-static_cast<int>(fieldOrientation()) * 90));
+	QPointF rtY = qpointf(Geometry2d::Point(-1, 0).rotated(-static_cast<int>(fieldOrientation()) * 90));
+
 	// Opponent robots
 	for (const LogFrame::Robot &r :  frame->opp())
 	{
 		drawRobot(p, !frame->blue_team(), r.shell(), qpointf(r.pos()), r.angle(), r.ball_sense_status() == HasBall);
 	}
-	
+
 	// Our robots
 	int manualID = frame->manual_id();
 	for (const LogFrame::Robot &r :  frame->self())
 	{
 		QPointF center = qpointf(r.pos());
-		
+
 		bool faulty = false;
 		if (r.has_ball_sense_status() && (r.ball_sense_status() == Dazzled || r.ball_sense_status() == Failed))
 		{
@@ -415,9 +392,9 @@ void FieldView::drawTeamSpace(QPainter& p)
 		{
 			faulty = true;
 		}
-		
+
 		drawRobot(p, frame->blue_team(), r.shell(), center, r.angle(), r.ball_sense_status() == HasBall, faulty);
-		
+
 		// Highlight the manually controlled robot
 		if (manualID == r.shell())
 		{
@@ -425,7 +402,7 @@ void FieldView::drawTeamSpace(QPainter& p)
 			const float r = Robot_Radius + .05;
 			p.drawEllipse(center, r, r);
 		}
-		
+
 		// Robot text
 		QPointF textPos = center - rtX * 0.2 - rtY * (Robot_Radius + 0.1);
 		for (const DebugText& text :  r.text())
@@ -434,7 +411,7 @@ void FieldView::drawTeamSpace(QPainter& p)
 			{
 				tempPen.setColor(text.color());
 				p.setPen(tempPen);
-				drawText(p, textPos, QString::fromStdString(text.text()), false);
+				drawText(p, textPos, QString::fromStdString(text.text()), false, false);
 				textPos -= rtY * 0.1;
 			}
 		}
@@ -445,12 +422,12 @@ void FieldView::drawTeamSpace(QPainter& p)
 	{
 		QPointF pos = qpointf(frame->ball().pos());
 		QPointF vel = qpointf(frame->ball().vel());
-		
+
 		p.setPen(ballPen);
 		p.setBrush(ballColor);
 		p.drawEllipse(QRectF(-Ball_Radius + pos.x(), -Ball_Radius + pos.y(),
 				Ball_Diameter, Ball_Diameter));
-		
+
 		if (!vel.isNull())
 		{
 			p.drawLine(pos, QPointF(pos.x() + vel.x(), pos.y() + vel.y()));
@@ -458,13 +435,13 @@ void FieldView::drawTeamSpace(QPainter& p)
 	}
 }
 
-void FieldView::drawText(QPainter &p, QPointF pos, QString text, bool center)
+void FieldView::drawText(QPainter &p, QPointF pos, QString text, bool center, bool worldSpace)
 {
 	p.save();
 	p.translate(pos);
-	p.rotate(_textRotation);
+	p.rotate(worldSpace ? textRotationForWorldSpace() : textRotationForTeamSpace());
 	p.scale(0.008, -0.008);
-	
+
 	if (center)
 	{
 		int flags = Qt::AlignHCenter | Qt::AlignVCenter;
@@ -473,104 +450,37 @@ void FieldView::drawText(QPainter &p, QPointF pos, QString text, bool center)
 	} else {
 		p.drawText(QPointF(), text);
 	}
-	
+
 	p.restore();
 }
 
-void FieldView::drawCoords(QPainter& p)
+// Called in world space
+void FieldView::drawCoords(QPainter& p, bool worldSpace)
 {
 	p.setPen(grayPen);
-	
+
 	// X
 	p.drawLine(QPointF(0, 0), QPointF(0.25, 0));
 	p.drawLine(QPointF(0.25, 0), QPointF(0.20, -0.05));
 	p.drawLine(QPointF(0.25, 0), QPointF(0.20, 0.05));
-	drawText(p, QPointF(0.25, 0.1), "+X");
-	
+	drawText(p, QPointF(0.25, 0.1), "+X", true, worldSpace);
+
 	// Y
 	p.drawLine(QPointF(0, 0), QPointF(0, 0.25));
 	p.drawLine(QPointF(0, 0.25), QPointF(-0.05, 0.20));
 	p.drawLine(QPointF(0, 0.25), QPointF(0.05, 0.20));
-	drawText(p, QPointF(0.1, 0.25), "+Y");
-}
-
-void FieldView::drawField(QPainter& p, const LogFrame *frame)
-{
-	p.save();
-	
-	//reset to center
-	p.translate(-Field_Dimensions::Current_Dimensions.FloorLength() /2.0, -Field_Dimensions::Current_Dimensions.FloorWidth() /2.0);
-	
-	p.translate(Field_Dimensions::Current_Dimensions.Border(), Field_Dimensions::Current_Dimensions.Border());
-	
-	p.setPen(QPen(Qt::white, Field_Dimensions::Current_Dimensions.LineWidth() *2.0));	//	double-width pen for visibility (although its less accurate)
-	p.setBrush(Qt::NoBrush);
-	p.drawRect(QRectF(0, 0, Field_Dimensions::Current_Dimensions.Length(), Field_Dimensions::Current_Dimensions.Width()));
-	
-	//set brush alpha to 0
-	p.setBrush(QColor(0,130,0, 0));
-	
-	//reset to center
-	p.translate(Field_Dimensions::Current_Dimensions.Length() /2.0, Field_Dimensions::Current_Dimensions.Width() /2.0);
-	
-	//centerline
-	p.drawLine(QLineF(0, Field_Dimensions::Current_Dimensions.Width() /2,0, -Field_Dimensions::Current_Dimensions.Width() /2.0));
-	
-	//center circle
-	p.drawEllipse(QRectF(-Field_Dimensions::Current_Dimensions.CenterRadius(), -Field_Dimensions::Current_Dimensions.CenterRadius(),
-		Field_Dimensions::Current_Dimensions.CenterDiameter(), Field_Dimensions::Current_Dimensions.CenterDiameter()));
-	
-	p.translate(-Field_Dimensions::Current_Dimensions.Length() /2.0, 0);
-	
-	//goal areas
-	p.drawArc(QRectF(-Field_Dimensions::Current_Dimensions.ArcRadius(), -Field_Dimensions::Current_Dimensions.ArcRadius() + Field_Dimensions::Current_Dimensions.GoalFlat() /2.f, 2.f * Field_Dimensions::Current_Dimensions.ArcRadius(), 2.f * Field_Dimensions::Current_Dimensions.ArcRadius()), -90*16, 90*16);
-	p.drawArc(QRectF(-Field_Dimensions::Current_Dimensions.ArcRadius(), -Field_Dimensions::Current_Dimensions.ArcRadius() - Field_Dimensions::Current_Dimensions.GoalFlat() /2.f, 2.f * Field_Dimensions::Current_Dimensions.ArcRadius(), 2.f * Field_Dimensions::Current_Dimensions.ArcRadius()), 90*16, -90*16);
-	p.drawLine(QLineF(Field_Dimensions::Current_Dimensions.ArcRadius(), -Field_Dimensions::Current_Dimensions.GoalFlat() /2.f, Field_Dimensions::Current_Dimensions.ArcRadius(), Field_Dimensions::Current_Dimensions.GoalFlat() /2.f));
-	// Penalty Mark
-	p.drawEllipse(QRectF(-Field_Dimensions::Current_Dimensions.PenaltyDiam() /2.0f + Field_Dimensions::Current_Dimensions.PenaltyDist(), -Field_Dimensions::Current_Dimensions.PenaltyDiam() /2.0f, Field_Dimensions::Current_Dimensions.PenaltyDiam(), Field_Dimensions::Current_Dimensions.PenaltyDiam()));
-	
-	p.translate(Field_Dimensions::Current_Dimensions.Length(), 0);
-	
-	p.drawArc(QRectF(-Field_Dimensions::Current_Dimensions.ArcRadius(), -Field_Dimensions::Current_Dimensions.ArcRadius() + Field_Dimensions::Current_Dimensions.GoalFlat() /2.f, 2.f * Field_Dimensions::Current_Dimensions.ArcRadius(), 2.f * Field_Dimensions::Current_Dimensions.ArcRadius()), -90*16, -90*16);
-	p.drawArc(QRectF(-Field_Dimensions::Current_Dimensions.ArcRadius(), -Field_Dimensions::Current_Dimensions.ArcRadius() - Field_Dimensions::Current_Dimensions.GoalFlat() /2.f, 2.f * Field_Dimensions::Current_Dimensions.ArcRadius(), 2.f * Field_Dimensions::Current_Dimensions.ArcRadius()), 90*16, 90*16);
-	p.drawLine(QLineF(-Field_Dimensions::Current_Dimensions.ArcRadius(), -Field_Dimensions::Current_Dimensions.GoalFlat() /2.f, -Field_Dimensions::Current_Dimensions.ArcRadius(), Field_Dimensions::Current_Dimensions.GoalFlat() /2.f));
-	// Penalty Mark
-	p.drawEllipse(QRectF(-Field_Dimensions::Current_Dimensions.PenaltyDiam() /2.0f - Field_Dimensions::Current_Dimensions.PenaltyDist(), -Field_Dimensions::Current_Dimensions.PenaltyDiam() /2.0f, Field_Dimensions::Current_Dimensions.PenaltyDiam(), Field_Dimensions::Current_Dimensions.PenaltyDiam()));
-		
-	// goals
-	float x[2] = {0, Field_Dimensions::Current_Dimensions.GoalDepth()};
-	float y[2] = {Field_Dimensions::Current_Dimensions.GoalWidth() /2.0f, -Field_Dimensions::Current_Dimensions.GoalWidth() /2.0f};
-	
-	bool flip = frame->blue_team() ^ frame->defend_plus_x();
-	
-	QColor goalColor = flip ? Qt::yellow : Qt::blue;
-	p.setPen(QPen(goalColor, Field_Dimensions::Current_Dimensions.LineWidth() * 2.0));	//	double-width for visibility, not real-life accuracy
-	p.drawLine(QLineF(x[0], y[0], x[1], y[0]));
-	p.drawLine(QLineF(x[0], y[1], x[1], y[1]));
-	p.drawLine(QLineF(x[1], y[1], x[1], y[0]));
-	
-	x[0] -= Field_Dimensions::Current_Dimensions.Length();
-	x[1] -= Field_Dimensions::Current_Dimensions.Length() + 2 * Field_Dimensions::Current_Dimensions.GoalDepth();
-	
-	goalColor = flip ? Qt::blue : Qt::yellow;
-	p.setPen(QPen(goalColor, Field_Dimensions::Current_Dimensions.LineWidth() * 2.0));
-	p.drawLine(QLineF(x[0], y[0], x[1], y[0]));
-	p.drawLine(QLineF(x[0], y[1], x[1], y[1]));
-	p.drawLine(QLineF(x[1], y[1], x[1], y[0]));
-		
-
-	p.restore();
+	drawText(p, QPointF(0.1, 0.25), "+Y", true, worldSpace);
 }
 
 void FieldView::drawRobot(QPainter& painter, bool blueRobot, int ID, QPointF pos, float theta, bool hasBall, bool faulty)
 {
 	painter.setPen(Qt::NoPen);
 	painter.setBrush(Qt::NoBrush);
-	
+
 	painter.save();
 
 	painter.translate(pos.x(), pos.y());
-	
+
 	if (faulty)
 	{
 		painter.setPen(redPen);
@@ -582,13 +492,13 @@ void FieldView::drawRobot(QPainter& painter, bool blueRobot, int ID, QPointF pos
 		painter.setPen(yellowPen);
 		painter.setBrush(Qt::yellow);
 	}
-	
+
 	painter.rotate(theta * RadiansToDegrees + 90);
-	
-	int span = 40;
-	
-	int start = span*16 + 90*16;
-	int end = 360*16 - (span*2)*16;
+
+    // Draw body shape
+	const int span = 40;
+	const int start = span*16 + 90*16;
+	const int end = 360*16 - (span*2)*16;
 	const float r = Robot_Radius;
 	painter.drawChord(QRectF(-r, -r, r * 2, r * 2), start, end);
 
@@ -613,7 +523,7 @@ void FieldView::drawRobot(QPainter& painter, bool blueRobot, int ID, QPointF pos
 		const float r = Robot_Radius * 0.75f;
 		painter.drawChord(QRectF(-r, -r, r * 2, r * 2), start, end);
 	}
-	
+
 	painter.restore();
 
 	//	draw shell number
@@ -624,35 +534,6 @@ void FieldView::drawRobot(QPainter& painter, bool blueRobot, int ID, QPointF pos
 	} else {
 		painter.setPen(blackPen);
 	}
-	drawText(painter, QPointF(), QString::number(ID));
+	drawText(painter, QPointF(), QString::number(ID), true, false);
 	painter.restore();
-}
-
-void FieldView::resizeEvent(QResizeEvent* e)
-{
-	int givenW = e->size().width();
-	int givenH = e->size().height();
-	int needW, needH;
-	if (_rotate & 1)
-	{
-		needH = roundf(givenW * Field_Dimensions::Current_Dimensions.FloorLength() / Field_Dimensions::Current_Dimensions.FloorWidth());
-		needW = roundf(givenH * Field_Dimensions::Current_Dimensions.FloorWidth() / Field_Dimensions::Current_Dimensions.FloorLength());
-	} else {
-		needH = roundf(givenW * Field_Dimensions::Current_Dimensions.FloorWidth() / Field_Dimensions::Current_Dimensions.FloorLength());
-		needW = roundf(givenH * Field_Dimensions::Current_Dimensions.FloorLength() / Field_Dimensions::Current_Dimensions.FloorWidth());
-	}
-	
-	QSize size;
-	if (needW < givenW)
-	{
-		size = QSize(needW, givenH);
-	} else {
-		size = QSize(givenW, needH);
-	}
-	
-	if (size != e->size())
-	{
-		resize(size);
-	}
-    e->accept();
 }

--- a/soccer/FieldView.hpp
+++ b/soccer/FieldView.hpp
@@ -1,10 +1,8 @@
-
 #pragma once
 
-#include <QGLWidget>
+#include "FieldBackgroundView.hpp"
 
 #include <Geometry2d/Point.hpp>
-#include <Geometry2d/TransformMatrix.hpp>
 #include <protobuf/LogFrame.pb.h>
 
 #include <set>
@@ -13,79 +11,45 @@
 class Logger;
 
 /** class that performs drawing of log data onto the field */
-class FieldView : public QWidget
+class FieldView : public FieldBackgroundView
 {
 	public:
-		FieldView(QWidget* parent = 0);
-		
-		void layerVisible(int i, bool value)
-		{
-			if (i >= 0 && i < _layerVisible.size())
-			{
-				_layerVisible[i] = value;
-			}
-			else if (i >= _layerVisible.size())
-			{
-				_layerVisible.resize(i+1);
-				_layerVisible[i] = value;
-			}
-		}
-		
-		bool layerVisible(int i) const
-		{
-			if (i < _layerVisible.size())
-			{
-				return _layerVisible[i];
-			} else {
-				return false;
-			}
-		}
-		
+		FieldView(QWidget* parent = nullptr);
+
+        /// Visibility of debug layers
+		void layerVisible(int i, bool value);
+		bool layerVisible(int i) const;
+
 		void history(const std::vector<std::shared_ptr<Packet::LogFrame> > *value)
 		{
 			_history = value;
 		}
-		
-		void rotate(int value);
-		
+
 		// True if this control is showing live (vs. historical) data.
 		// If false, it will draw a red border.
 		bool live;
-		
+
 		bool showRawRobots;
 		bool showRawBalls;
 		bool showCoords;
 		bool showDotPatterns;
 		bool showTeamNames;
-		
+
 	protected:
 		virtual void paintEvent(QPaintEvent* e);
-		virtual void resizeEvent(QResizeEvent *e);
-		
+
 		virtual void drawWorldSpace(QPainter &p);
 		virtual void drawTeamSpace(QPainter &p);
-		
-		void drawText(QPainter& p, QPointF pos, QString text, bool center = true);
-		void drawField(QPainter& p, const Packet::LogFrame *frame);
+
+		void drawText(QPainter& p, QPointF pos, QString text, bool center, bool worldSpace);
 		void drawRobot(QPainter& p, bool blueRobot, int ID, QPointF pos, float theta, bool hasBall = false, bool faulty = false);
-		void drawCoords(QPainter& p);
+		void drawCoords(QPainter& p, bool worldSpace);
 
 	protected:
 		// Returns a pointer to the most recent frame, or null if none is available.
 		std::shared_ptr<Packet::LogFrame> currentFrame();
-		
-		// Coordinate transformations
-		Geometry2d::TransformMatrix _screenToWorld;
-		Geometry2d::TransformMatrix _worldToTeam;
-		Geometry2d::TransformMatrix _teamToWorld;
-		
-		// Rotation of the field in 90-degree increments (0 to 3).
-		int _rotate;
-		
-		// How many degrees to rotate text so it shows up the right way on screen
-		int _textRotation;
-		
+
 		const std::vector<std::shared_ptr<Packet::LogFrame> > *_history;
-		
+
 		QVector<bool> _layerVisible;
 };

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -35,905 +35,906 @@ static const std::vector<QString> defaultHiddenLayers{"MotionControl", "Planning
 
 void calcMinimumWidth(QWidget *widget, QString text)
 {
-	QRect rect = QFontMetrics(widget->font()).boundingRect(text);
-	widget->setMinimumWidth(rect.width());
+    QRect rect = QFontMetrics(widget->font()).boundingRect(text);
+    widget->setMinimumWidth(rect.width());
 }
 
 MainWindow::MainWindow(QWidget *parent):
-	QMainWindow(parent)
+    QMainWindow(parent)
 {
-	qRegisterMetaType<QVector<int> >("QVector<int>");
+    qRegisterMetaType<QVector<int> >("QVector<int>");
 
-	_quaternion_demo = 0;
+    _quaternion_demo = 0;
 
-	_updateCount = 0;
-	_processor = 0;
-	_autoExternalReferee = true;
-	_doubleFrameNumber = -1;
+    _updateCount = 0;
+    _processor = 0;
+    _autoExternalReferee = true;
+    _doubleFrameNumber = -1;
 
-	_lastUpdateTime = timestamp();
-	_history.resize(2 * 60);
+    _lastUpdateTime = timestamp();
+    _history.resize(2 * 60);
 
-	_ui.setupUi(this);
-	_ui.fieldView->history(&_history);
+    _ui.setupUi(this);
+    _ui.fieldView->history(&_history);
+    _ui.fieldView->setFieldDimensions(Field_Dimensions::Current_Dimensions);
 
-	_ui.logTree->history(&_history);
-	_ui.logTree->mainWindow = this;
-	_ui.logTree->updateTimer = &updateTimer;
+    _ui.logTree->history(&_history);
+    _ui.logTree->mainWindow = this;
+    _ui.logTree->updateTimer = &updateTimer;
 
-	// Initialize live/non-live control styles
-	_live = false;
-	live(true);
+    // Initialize live/non-live control styles
+    _live = false;
+    live(true);
 
-	_currentPlay = new QLabel();
-	_currentPlay->setFrameStyle(QFrame::StyledPanel | QFrame::Sunken);
-	_currentPlay->setToolTip("Current Play");
-	_currentPlay->setAlignment(Qt::AlignCenter);
-	_currentPlay->setObjectName("current_play_name");
-	calcMinimumWidth(_currentPlay, "XXXXXXXXXXXXXXXX");
-	statusBar()->addPermanentWidget(_currentPlay);
+    _currentPlay = new QLabel();
+    _currentPlay->setFrameStyle(QFrame::StyledPanel | QFrame::Sunken);
+    _currentPlay->setToolTip("Current Play");
+    _currentPlay->setAlignment(Qt::AlignCenter);
+    _currentPlay->setObjectName("current_play_name");
+    calcMinimumWidth(_currentPlay, "XXXXXXXXXXXXXXXX");
+    statusBar()->addPermanentWidget(_currentPlay);
 
-	_logFile = new QLabel();
-	_logFile->setFrameStyle(QFrame::StyledPanel | QFrame::Sunken);
-	_logFile->setToolTip("Log File");
-	statusBar()->addPermanentWidget(_logFile);
+    _logFile = new QLabel();
+    _logFile->setFrameStyle(QFrame::StyledPanel | QFrame::Sunken);
+    _logFile->setToolTip("Log File");
+    statusBar()->addPermanentWidget(_logFile);
 
-	_viewFPS = new QLabel();
-	_viewFPS->setFrameStyle(QFrame::StyledPanel | QFrame::Sunken);
-	_viewFPS->setToolTip("Display Framerate");
-	calcMinimumWidth(_viewFPS, "View: 00.0 fps");
-	statusBar()->addPermanentWidget(_viewFPS);
+    _viewFPS = new QLabel();
+    _viewFPS->setFrameStyle(QFrame::StyledPanel | QFrame::Sunken);
+    _viewFPS->setToolTip("Display Framerate");
+    calcMinimumWidth(_viewFPS, "View: 00.0 fps");
+    statusBar()->addPermanentWidget(_viewFPS);
 
-	_procFPS = new QLabel();
-	_procFPS->setFrameStyle(QFrame::StyledPanel | QFrame::Sunken);
-	_procFPS->setToolTip("Processing Framerate");
-	calcMinimumWidth(_procFPS, "Proc: 00.0 fps");
-	statusBar()->addPermanentWidget(_procFPS);
+    _procFPS = new QLabel();
+    _procFPS->setFrameStyle(QFrame::StyledPanel | QFrame::Sunken);
+    _procFPS->setToolTip("Processing Framerate");
+    calcMinimumWidth(_procFPS, "Proc: 00.0 fps");
+    statusBar()->addPermanentWidget(_procFPS);
 
-	_logMemory = new QLabel();
-	_logMemory->setFrameStyle(QFrame::StyledPanel | QFrame::Sunken);
-	_logMemory->setToolTip("Log Memory Usage");
-	_logMemory->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-	calcMinimumWidth(_logMemory, "Log: 000000/000000 000000 kiB");
-	statusBar()->addPermanentWidget(_logMemory);
+    _logMemory = new QLabel();
+    _logMemory->setFrameStyle(QFrame::StyledPanel | QFrame::Sunken);
+    _logMemory->setToolTip("Log Memory Usage");
+    _logMemory->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    calcMinimumWidth(_logMemory, "Log: 000000/000000 000000 kiB");
+    statusBar()->addPermanentWidget(_logMemory);
 
-	_frameNumberItem = new QTreeWidgetItem(_ui.logTree);
-	_frameNumberItem->setText(ProtobufTree::Column_Field, "Frame");
-	_frameNumberItem->setData(ProtobufTree::Column_Tag, Qt::DisplayRole, -2);
+    _frameNumberItem = new QTreeWidgetItem(_ui.logTree);
+    _frameNumberItem->setText(ProtobufTree::Column_Field, "Frame");
+    _frameNumberItem->setData(ProtobufTree::Column_Tag, Qt::DisplayRole, -2);
 
-	_elapsedTimeItem = new QTreeWidgetItem(_ui.logTree);
-	_elapsedTimeItem->setText(ProtobufTree::Column_Field, "Elapsed Time");
-	_elapsedTimeItem->setData(ProtobufTree::Column_Tag, Qt::DisplayRole, -1);
+    _elapsedTimeItem = new QTreeWidgetItem(_ui.logTree);
+    _elapsedTimeItem->setText(ProtobufTree::Column_Field, "Elapsed Time");
+    _elapsedTimeItem->setData(ProtobufTree::Column_Tag, Qt::DisplayRole, -1);
 
-	_ui.debugLayers->setContextMenuPolicy(Qt::CustomContextMenu);
+    _ui.debugLayers->setContextMenuPolicy(Qt::CustomContextMenu);
 
-	QActionGroup *teamGroup = new QActionGroup(this);
-	teamGroup->addAction(_ui.actionTeamBlue);
-	teamGroup->addAction(_ui.actionTeamYellow);
+    QActionGroup *teamGroup = new QActionGroup(this);
+    teamGroup->addAction(_ui.actionTeamBlue);
+    teamGroup->addAction(_ui.actionTeamYellow);
 
-	QActionGroup *goalGroup = new QActionGroup(this);
-	goalGroup->addAction(_ui.actionDefendMinusX);
-	goalGroup->addAction(_ui.actionDefendPlusX);
+    QActionGroup *goalGroup = new QActionGroup(this);
+    goalGroup->addAction(_ui.actionDefendMinusX);
+    goalGroup->addAction(_ui.actionDefendPlusX);
 
-	QActionGroup *rotateGroup = new QActionGroup(this);
-	rotateGroup->addAction(_ui.action0);
-	rotateGroup->addAction(_ui.action90);
-	rotateGroup->addAction(_ui.action180);
-	rotateGroup->addAction(_ui.action270);
+    QActionGroup *rotateGroup = new QActionGroup(this);
+    rotateGroup->addAction(_ui.action0);
+    rotateGroup->addAction(_ui.action90);
+    rotateGroup->addAction(_ui.action180);
+    rotateGroup->addAction(_ui.action270);
 
-	connect(_ui.manualID, SIGNAL(currentIndexChanged(int)), this, SLOT(on_manualID_currentIndexChanged(int)));
+    connect(_ui.manualID, SIGNAL(currentIndexChanged(int)), this, SLOT(on_manualID_currentIndexChanged(int)));
 
-	channel(0);
+    channel(0);
 
-	updateTimer.setSingleShot(true);
-	connect(&updateTimer, SIGNAL(timeout()), SLOT(updateViews()));
-	updateTimer.start(30);
+    updateTimer.setSingleShot(true);
+    connect(&updateTimer, SIGNAL(timeout()), SLOT(updateViews()));
+    updateTimer.start(30);
 
-	//	put all log playback buttons into a vector for easy access later
-	_logPlaybackButtons.push_back(_ui.logPlaybackRewind);
-	_logPlaybackButtons.push_back(_ui.logPlaybackPrevFrame);
-	_logPlaybackButtons.push_back(_ui.logPlaybackPause);
-	_logPlaybackButtons.push_back(_ui.logPlaybackNextFrame);
-	_logPlaybackButtons.push_back(_ui.logPlaybackPlay);
-	_logPlaybackButtons.push_back(_ui.logPlaybackLive);
+    //  put all log playback buttons into a vector for easy access later
+    _logPlaybackButtons.push_back(_ui.logPlaybackRewind);
+    _logPlaybackButtons.push_back(_ui.logPlaybackPrevFrame);
+    _logPlaybackButtons.push_back(_ui.logPlaybackPause);
+    _logPlaybackButtons.push_back(_ui.logPlaybackNextFrame);
+    _logPlaybackButtons.push_back(_ui.logPlaybackPlay);
+    _logPlaybackButtons.push_back(_ui.logPlaybackLive);
 }
 
 void MainWindow::configuration(Configuration* config)
 {
-	_config = config;
-	_config->tree(_ui.configTree);
+    _config = config;
+    _config->tree(_ui.configTree);
 }
 
 void MainWindow::processor(Processor* value)
 {
-	// This should only happen once
-	assert(!_processor);
+    // This should only happen once
+    assert(!_processor);
 
-	_processor = value;
+    _processor = value;
 
-	// External referee
-	//on_externalReferee_toggled(_ui.externalReferee->isChecked());
+    // External referee
+    //on_externalReferee_toggled(_ui.externalReferee->isChecked());
 
-	// Team
-	if (_processor->blueTeam())
-	{
-		_ui.actionTeamBlue->trigger();
-	} else {
-		_ui.actionTeamYellow->trigger();
-	}
+    // Team
+    if (_processor->blueTeam())
+    {
+        _ui.actionTeamBlue->trigger();
+    } else {
+        _ui.actionTeamYellow->trigger();
+    }
 
-	_ui.logHistoryLocation->setMaximum(_processor->logger().maxFrames());
-	_ui.logHistoryLocation->setTickInterval(60*60);	//	interval is ~ 1 minute
+    _ui.logHistoryLocation->setMaximum(_processor->logger().maxFrames());
+    _ui.logHistoryLocation->setTickInterval(60*60); //  interval is ~ 1 minute
 }
 
 void MainWindow::logFileChanged()
 {
-	if (_processor->logger().recording())
-	{
-		_logFile->setText(_processor->logger().filename());
-	} else {
-		_logFile->setText("Not Recording");
-	}
+    if (_processor->logger().recording())
+    {
+        _logFile->setText(_processor->logger().filename());
+    } else {
+        _logFile->setText("Not Recording");
+    }
 }
 
 void MainWindow::live(bool value)
 {
-	if (_live != value)
-	{
-		_live = value;
+    if (_live != value)
+    {
+        _live = value;
 
-		// Change styles for controls that can show historical data
-		_ui.fieldView->live = _live;
-		if (_live)
-		{
-			_ui.logTree->setStyleSheet(QString("QTreeWidget{%1}").arg(LiveStyle));
-		} else {
-			_ui.logTree->setStyleSheet(QString("QTreeWidget{%1}").arg(NonLiveStyle));
-		}
-	}
+        // Change styles for controls that can show historical data
+        _ui.fieldView->live = _live;
+        if (_live)
+        {
+            _ui.logTree->setStyleSheet(QString("QTreeWidget{%1}").arg(LiveStyle));
+        } else {
+            _ui.logTree->setStyleSheet(QString("QTreeWidget{%1}").arg(NonLiveStyle));
+        }
+    }
 }
 
 void MainWindow::addLayer(int i, QString name, bool checked) {
-	QListWidgetItem *item = new QListWidgetItem(name);
-	Qt::CheckState checkState = checked? Qt::Checked : Qt::Unchecked;
-	item->setCheckState(checkState);
-	item->setData(Qt::UserRole, i);
-	_ui.debugLayers->addItem(item);
-	on_debugLayers_itemChanged(item);
+    QListWidgetItem *item = new QListWidgetItem(name);
+    Qt::CheckState checkState = checked? Qt::Checked : Qt::Unchecked;
+    item->setCheckState(checkState);
+    item->setData(Qt::UserRole, i);
+    _ui.debugLayers->addItem(item);
+    on_debugLayers_itemChanged(item);
 }
 
 void MainWindow::updateViews()
 {
-	int manual =_processor->manualID();
-	if ((manual >= 0 || _ui.manualID->isEnabled()) && !_processor->joystickValid())
-	{
-		// Joystick is gone - turn off manual control
-		_ui.manualID->setCurrentIndex(0);
-		_processor->manualID(-1);
-		_ui.manualID->setEnabled(false);
-		_ui.tabWidget->setTabEnabled(_ui.tabWidget->indexOf(_ui.joystickTab), false);
-	} else if (!_ui.manualID->isEnabled() && _processor->joystickValid())
-	{
-		// Joystick reconnected
-		_ui.manualID->setEnabled(true);
-		_ui.joystickTab->setVisible(true);
-		_ui.tabWidget->setTabEnabled(_ui.tabWidget->indexOf(_ui.joystickTab), true);
-	}
-	if(manual >= 0) {
-		JoystickControlValues vals = _processor->getJoystickControlValues();
-		_ui.joystickBodyXLabel->setText(tr("%1").arg(vals.translation.x));
-		_ui.joystickBodyYLabel->setText(tr("%1").arg(vals.translation.y));
-		_ui.joystickBodyWLabel->setText(tr("%1").arg(vals.rotation));
-		_ui.joystickKickPowerLabel->setText(tr("%1").arg(vals.kickPower));
-		_ui.joystickDibblerPowerLabel->setText(tr("%1").arg(vals.dribblerPower));
-		_ui.joystickKickCheckBox->setChecked(vals.kick);
-		_ui.joystickChipCheckBox->setChecked(vals.chip);
-		_ui.joystickDribblerCheckBox->setChecked(vals.dribble);
-	}
+    int manual =_processor->manualID();
+    if ((manual >= 0 || _ui.manualID->isEnabled()) && !_processor->joystickValid())
+    {
+        // Joystick is gone - turn off manual control
+        _ui.manualID->setCurrentIndex(0);
+        _processor->manualID(-1);
+        _ui.manualID->setEnabled(false);
+        _ui.tabWidget->setTabEnabled(_ui.tabWidget->indexOf(_ui.joystickTab), false);
+    } else if (!_ui.manualID->isEnabled() && _processor->joystickValid())
+    {
+        // Joystick reconnected
+        _ui.manualID->setEnabled(true);
+        _ui.joystickTab->setVisible(true);
+        _ui.tabWidget->setTabEnabled(_ui.tabWidget->indexOf(_ui.joystickTab), true);
+    }
+    if(manual >= 0) {
+        JoystickControlValues vals = _processor->getJoystickControlValues();
+        _ui.joystickBodyXLabel->setText(tr("%1").arg(vals.translation.x));
+        _ui.joystickBodyYLabel->setText(tr("%1").arg(vals.translation.y));
+        _ui.joystickBodyWLabel->setText(tr("%1").arg(vals.rotation));
+        _ui.joystickKickPowerLabel->setText(tr("%1").arg(vals.kickPower));
+        _ui.joystickDibblerPowerLabel->setText(tr("%1").arg(vals.dribblerPower));
+        _ui.joystickKickCheckBox->setChecked(vals.kick);
+        _ui.joystickChipCheckBox->setChecked(vals.chip);
+        _ui.joystickDribblerCheckBox->setChecked(vals.dribble);
+    }
 
-	// Time since last update
-	Time time = timestamp();
-	int delta_us = time - _lastUpdateTime;
-	_lastUpdateTime = time;
-	double framerate = 1000000.0 / delta_us;
+    // Time since last update
+    Time time = timestamp();
+    int delta_us = time - _lastUpdateTime;
+    _lastUpdateTime = time;
+    double framerate = 1000000.0 / delta_us;
 
-	++_updateCount;
-	if (_updateCount == 4)
-	{
-		_updateCount = 0;
+    ++_updateCount;
+    if (_updateCount == 4)
+    {
+        _updateCount = 0;
 
-		_viewFPS->setText(QString("View: %1 fps").arg(framerate, 0, 'f', 1));
-		_procFPS->setText(QString("Proc: %1 fps").arg(_processor->framerate(), 0, 'f', 1));
+        _viewFPS->setText(QString("View: %1 fps").arg(framerate, 0, 'f', 1));
+        _procFPS->setText(QString("Proc: %1 fps").arg(_processor->framerate(), 0, 'f', 1));
 
-		_logMemory->setText(QString("Log: %1/%2 %3 kiB").arg(
-			QString::number(_processor->logger().numFrames()),
-			QString::number(_processor->logger().maxFrames()),
-			QString::number((_processor->logger().spaceUsed() + 512) / 1024)
-		));
-	}
+        _logMemory->setText(QString("Log: %1/%2 %3 kiB").arg(
+            QString::number(_processor->logger().numFrames()),
+            QString::number(_processor->logger().maxFrames()),
+            QString::number((_processor->logger().spaceUsed() + 512) / 1024)
+        ));
+    }
 
-	// Advance log history
-	int liveFrameNumber = _processor->logger().lastFrameNumber();
-	if (_live)
-	{
-		_doubleFrameNumber = liveFrameNumber;
-	} else {
-		_doubleFrameNumber += _playbackRate;
+    // Advance log history
+    int liveFrameNumber = _processor->logger().lastFrameNumber();
+    if (_live)
+    {
+        _doubleFrameNumber = liveFrameNumber;
+    } else {
+        _doubleFrameNumber += _playbackRate;
 
-		int minFrame = _processor->logger().firstFrameNumber();
-		int maxFrame = _processor->logger().lastFrameNumber();
+        int minFrame = _processor->logger().firstFrameNumber();
+        int maxFrame = _processor->logger().lastFrameNumber();
 
-		if (_doubleFrameNumber < minFrame)
-		{
-			_doubleFrameNumber = minFrame;
-		} else if (_doubleFrameNumber > maxFrame)
-		{
-			_doubleFrameNumber = maxFrame;
-		}
-	}
+        if (_doubleFrameNumber < minFrame)
+        {
+            _doubleFrameNumber = minFrame;
+        } else if (_doubleFrameNumber > maxFrame)
+        {
+            _doubleFrameNumber = maxFrame;
+        }
+    }
 
-	//	update history slider in ui
-	emit historyLocationChanged(_doubleFrameNumber - _processor->logger().firstFrameNumber());
+    //  update history slider in ui
+    emit historyLocationChanged(_doubleFrameNumber - _processor->logger().firstFrameNumber());
 
-	// Read recent history from the log
-	_processor->logger().getFrames(frameNumber(), _history);
+    // Read recent history from the log
+    _processor->logger().getFrames(frameNumber(), _history);
 
-	// Update field view
-	_ui.fieldView->update();
+    // Update field view
+    _ui.fieldView->update();
 
 
-	//	enable playback buttons based on playback rate
-	for (QPushButton *playbackBtn : _logPlaybackButtons) playbackBtn->setEnabled(true);
-	if (_live) _ui.logPlaybackLive->setEnabled(false);
-	else if (_playbackRate < -0.1) _ui.logPlaybackRewind->setEnabled(false);
-	else if (abs<float>(_playbackRate) < 0.01) _ui.logPlaybackPause->setEnabled(false);
-	if (_playbackRate > 0.1 || _live) _ui.logPlaybackPlay->setEnabled(false);
+    //  enable playback buttons based on playback rate
+    for (QPushButton *playbackBtn : _logPlaybackButtons) playbackBtn->setEnabled(true);
+    if (_live) _ui.logPlaybackLive->setEnabled(false);
+    else if (_playbackRate < -0.1) _ui.logPlaybackRewind->setEnabled(false);
+    else if (abs<float>(_playbackRate) < 0.01) _ui.logPlaybackPause->setEnabled(false);
+    if (_playbackRate > 0.1 || _live) _ui.logPlaybackPlay->setEnabled(false);
 
     //  enable previous frame button based on position in the log
     _ui.logPlaybackPrevFrame->setEnabled(_doubleFrameNumber >= 1);
     _ui.logPlaybackNextFrame->setEnabled(!_live);
 
 
-	// Update status indicator
-	updateStatus();
+    // Update status indicator
+    updateStatus();
 
-	// Check if any debug layers have been added
-	// (layers should never be removed)
-	const std::shared_ptr<LogFrame> liveFrame = _processor->logger().lastFrame();
-	if (liveFrame && liveFrame->debug_layers_size() > _ui.debugLayers->count())
-	{
-		// Add the missing layers and turn them on
-		for (int i = _ui.debugLayers->count(); i < liveFrame->debug_layers_size(); ++i)
-		{
-			const QString name = QString::fromStdString(liveFrame->debug_layers(i));
-			bool enabled = !std::any_of(defaultHiddenLayers.begin(), defaultHiddenLayers.end(), [&](QString string){return string==name;});
-			addLayer(i, name, enabled);
-		}
+    // Check if any debug layers have been added
+    // (layers should never be removed)
+    const std::shared_ptr<LogFrame> liveFrame = _processor->logger().lastFrame();
+    if (liveFrame && liveFrame->debug_layers_size() > _ui.debugLayers->count())
+    {
+        // Add the missing layers and turn them on
+        for (int i = _ui.debugLayers->count(); i < liveFrame->debug_layers_size(); ++i)
+        {
+            const QString name = QString::fromStdString(liveFrame->debug_layers(i));
+            bool enabled = !std::any_of(defaultHiddenLayers.begin(), defaultHiddenLayers.end(), [&](QString string){return string==name;});
+            addLayer(i, name, enabled);
+        }
 
-		_ui.debugLayers->sortItems();
-	}
+        _ui.debugLayers->sortItems();
+    }
 
-	// Get the frame at the log playback time
-	const std::shared_ptr<LogFrame> currentFrame = _history[0];
+    // Get the frame at the log playback time
+    const std::shared_ptr<LogFrame> currentFrame = _history[0];
 
-	if (currentFrame)
-	{
-		// Update the orientation demo view
-		if (_quaternion_demo && manual >= 0 && currentFrame->radio_rx().size() && currentFrame->radio_rx(0).has_quaternion())
-		{
-			const RadioRx *manualRx = 0;
-			for (const RadioRx &rx :  currentFrame->radio_rx())
-			{
-				if ((int)rx.robot_id() == manual)
-				{
-					manualRx = &rx;
-					break;
-				}
-			}
-			if (manualRx)
-			{
-				const Packet::Quaternion &q = manualRx->quaternion();
-				_quaternion_demo->q = Quaternionf(q.q0(), q.q1(), q.q2(), q.q3());
-				if (!_quaternion_demo->initialized)
-				{
-					_quaternion_demo->ref = _quaternion_demo->q;
-					_quaternion_demo->initialized = true;
-				}
-				_quaternion_demo->update();
-			}
-		}
+    if (currentFrame)
+    {
+        // Update the orientation demo view
+        if (_quaternion_demo && manual >= 0 && currentFrame->radio_rx().size() && currentFrame->radio_rx(0).has_quaternion())
+        {
+            const RadioRx *manualRx = 0;
+            for (const RadioRx &rx :  currentFrame->radio_rx())
+            {
+                if ((int)rx.robot_id() == manual)
+                {
+                    manualRx = &rx;
+                    break;
+                }
+            }
+            if (manualRx)
+            {
+                const Packet::Quaternion &q = manualRx->quaternion();
+                _quaternion_demo->q = Quaternionf(q.q0(), q.q1(), q.q2(), q.q3());
+                if (!_quaternion_demo->initialized)
+                {
+                    _quaternion_demo->ref = _quaternion_demo->q;
+                    _quaternion_demo->initialized = true;
+                }
+                _quaternion_demo->update();
+            }
+        }
 
-		// Update non-message tree items
-		_frameNumberItem->setData(ProtobufTree::Column_Value, Qt::DisplayRole, frameNumber());
-		int elapsedMillis = (currentFrame->command_time() - _processor->firstLogTime + 500) / 1000;
-		QTime elapsedTime = QTime().addMSecs(elapsedMillis);
-		_elapsedTimeItem->setText(ProtobufTree::Column_Value, elapsedTime.toString("hh:mm:ss.zzz"));
+        // Update non-message tree items
+        _frameNumberItem->setData(ProtobufTree::Column_Value, Qt::DisplayRole, frameNumber());
+        int elapsedMillis = (currentFrame->command_time() - _processor->firstLogTime + 500) / 1000;
+        QTime elapsedTime = QTime().addMSecs(elapsedMillis);
+        _elapsedTimeItem->setText(ProtobufTree::Column_Value, elapsedTime.toString("hh:mm:ss.zzz"));
 
-		// Sort the tree by tag if items have been added
-		if (_ui.logTree->message(*currentFrame))
-		{
-			// Items have been added, so sort again on tag number
-			_ui.logTree->sortItems(ProtobufTree::Column_Tag, Qt::AscendingOrder);
-		}
+        // Sort the tree by tag if items have been added
+        if (_ui.logTree->message(*currentFrame))
+        {
+            // Items have been added, so sort again on tag number
+            _ui.logTree->sortItems(ProtobufTree::Column_Tag, Qt::AscendingOrder);
+        }
 
-		//	update the behavior tree view
-		_ui.behaviorTree->setPlainText(QString::fromStdString(currentFrame->behavior_tree()));
-	}
+        //  update the behavior tree view
+        _ui.behaviorTree->setPlainText(QString::fromStdString(currentFrame->behavior_tree()));
+    }
 
-	if(std::time(0) - (_processor->refereeModule()->received_time/1000000) > 1)
-	{
-		_ui.fastHalt->setEnabled(true);
-		_ui.fastStop->setEnabled(true);
-		_ui.fastReady->setEnabled(true);
-		_ui.fastForceStart->setEnabled(true);
-		_ui.fastKickoffBlue->setEnabled(true);
-		_ui.fastKickoffYellow->setEnabled(true);
-	}
-	else
-	{
-		_ui.fastHalt->setEnabled(false);
-		_ui.fastStop->setEnabled(false);
-		_ui.fastReady->setEnabled(false);
-		_ui.fastForceStart->setEnabled(false);
-		_ui.fastKickoffBlue->setEnabled(false);
-		_ui.fastKickoffYellow->setEnabled(false);
-	}
+    if(std::time(0) - (_processor->refereeModule()->received_time/1000000) > 1)
+    {
+        _ui.fastHalt->setEnabled(true);
+        _ui.fastStop->setEnabled(true);
+        _ui.fastReady->setEnabled(true);
+        _ui.fastForceStart->setEnabled(true);
+        _ui.fastKickoffBlue->setEnabled(true);
+        _ui.fastKickoffYellow->setEnabled(true);
+    }
+    else
+    {
+        _ui.fastHalt->setEnabled(false);
+        _ui.fastStop->setEnabled(false);
+        _ui.fastReady->setEnabled(false);
+        _ui.fastForceStart->setEnabled(false);
+        _ui.fastKickoffBlue->setEnabled(false);
+        _ui.fastKickoffYellow->setEnabled(false);
+    }
 
-	_ui.refStage->setText(NewRefereeModuleEnums::stringFromStage(_processor->refereeModule()->stage).c_str());
-	_ui.refCommand->setText(NewRefereeModuleEnums::stringFromCommand(_processor->refereeModule()->command).c_str());
+    _ui.refStage->setText(NewRefereeModuleEnums::stringFromStage(_processor->refereeModule()->stage).c_str());
+    _ui.refCommand->setText(NewRefereeModuleEnums::stringFromCommand(_processor->refereeModule()->command).c_str());
 
-	//	convert time left from ms to s and display it to two decimal places
-	_ui.refTimeLeft->setText(tr("%1 s").arg(QString::number(_processor->refereeModule()->stage_time_left / 1000.0f, 'f', 2)));
+    //  convert time left from ms to s and display it to two decimal places
+    _ui.refTimeLeft->setText(tr("%1 s").arg(QString::number(_processor->refereeModule()->stage_time_left / 1000.0f, 'f', 2)));
 
-	const char *blueName = _processor->refereeModule()->blue_info.name.c_str();
-	_ui.refBlueName->setText(strlen(blueName) == 0 ? "<Blue Team>" : blueName);
-	_ui.refBlueScore->setText(tr("%1").arg(_processor->refereeModule()->blue_info.score));
-	_ui.refBlueRedCards->setText(tr("%1").arg(_processor->refereeModule()->blue_info.red_cards));
-	_ui.refBlueYellowCards->setText(tr("%1").arg(_processor->refereeModule()->blue_info.yellow_cards));
-	_ui.refBlueTimeoutsLeft->setText(tr("%1").arg(_processor->refereeModule()->blue_info.timeouts_left));
-	_ui.refBlueGoalie->setText(tr("%1").arg(_processor->refereeModule()->blue_info.goalie));
+    const char *blueName = _processor->refereeModule()->blue_info.name.c_str();
+    _ui.refBlueName->setText(strlen(blueName) == 0 ? "<Blue Team>" : blueName);
+    _ui.refBlueScore->setText(tr("%1").arg(_processor->refereeModule()->blue_info.score));
+    _ui.refBlueRedCards->setText(tr("%1").arg(_processor->refereeModule()->blue_info.red_cards));
+    _ui.refBlueYellowCards->setText(tr("%1").arg(_processor->refereeModule()->blue_info.yellow_cards));
+    _ui.refBlueTimeoutsLeft->setText(tr("%1").arg(_processor->refereeModule()->blue_info.timeouts_left));
+    _ui.refBlueGoalie->setText(tr("%1").arg(_processor->refereeModule()->blue_info.goalie));
 
-	const char *yellowName = _processor->refereeModule()->yellow_info.name.c_str();
-	_ui.refYellowName->setText(strlen(yellowName) == 0 ? "<Yellow Team>" : yellowName);
-	_ui.refYellowScore->setText(tr("%1").arg(_processor->refereeModule()->yellow_info.score));
-	_ui.refYellowRedCards->setText(tr("%1").arg(_processor->refereeModule()->yellow_info.red_cards));
-	_ui.refYellowYellowCards->setText(tr("%1").arg(_processor->refereeModule()->yellow_info.yellow_cards));
-	_ui.refYellowTimeoutsLeft->setText(tr("%1").arg(_processor->refereeModule()->yellow_info.timeouts_left));
-	_ui.refYellowGoalie->setText(tr("%1").arg(_processor->refereeModule()->yellow_info.goalie));
-
-
-	//	update robot status list
-	for (const OurRobot *robot : _processor->state()->self) {
-		//	a robot shows up in the status list if it's reachable via radio
-		bool shouldDisplay = robot->rxIsFresh();
-
-		//	see if it's already in the robot status list widget
-		bool displaying = _robotStatusItemMap.find(robot->shell()) != _robotStatusItemMap.end();
-
-		if (shouldDisplay && !displaying) {
-			//	add a widget to the list for this robot
-
-			QListWidgetItem *item = new QListWidgetItem();
-			_robotStatusItemMap[robot->shell()] = item;
-			_ui.robotStatusList->addItem(item);
-
-			RobotStatusWidget *statusWidget = new RobotStatusWidget();
-			item->setSizeHint(statusWidget->minimumSizeHint());
-			_ui.robotStatusList->setItemWidget(item, statusWidget);
-
-			//	set shell ID
-			statusWidget->setShellID(robot->shell());
-
-			//	set team
-			statusWidget->setBlueTeam(processor()->blueTeam());
-
-			//	TODO: set board ID
-
-			//	set robot model
-			QString robotModel;
-			switch (robot->radioRx().hardware_version()) {
-				case RJ2008: robotModel = "RJ2008"; break;
-				case RJ2011: robotModel = "RJ2011"; break;
-				case RJ2015: robotModel = "RJ2015"; break;
-				default: robotModel = "Unknown Bot";
-			}
-			statusWidget->setRobotModel(robotModel);
+    const char *yellowName = _processor->refereeModule()->yellow_info.name.c_str();
+    _ui.refYellowName->setText(strlen(yellowName) == 0 ? "<Yellow Team>" : yellowName);
+    _ui.refYellowScore->setText(tr("%1").arg(_processor->refereeModule()->yellow_info.score));
+    _ui.refYellowRedCards->setText(tr("%1").arg(_processor->refereeModule()->yellow_info.red_cards));
+    _ui.refYellowYellowCards->setText(tr("%1").arg(_processor->refereeModule()->yellow_info.yellow_cards));
+    _ui.refYellowTimeoutsLeft->setText(tr("%1").arg(_processor->refereeModule()->yellow_info.timeouts_left));
+    _ui.refYellowGoalie->setText(tr("%1").arg(_processor->refereeModule()->yellow_info.goalie));
 
 
-//	uncomment this #define to test the display of a variety of different errors
+    //  update robot status list
+    for (const OurRobot *robot : _processor->state()->self) {
+        //  a robot shows up in the status list if it's reachable via radio
+        bool shouldDisplay = robot->rxIsFresh();
+
+        //  see if it's already in the robot status list widget
+        bool displaying = _robotStatusItemMap.find(robot->shell()) != _robotStatusItemMap.end();
+
+        if (shouldDisplay && !displaying) {
+            //  add a widget to the list for this robot
+
+            QListWidgetItem *item = new QListWidgetItem();
+            _robotStatusItemMap[robot->shell()] = item;
+            _ui.robotStatusList->addItem(item);
+
+            RobotStatusWidget *statusWidget = new RobotStatusWidget();
+            item->setSizeHint(statusWidget->minimumSizeHint());
+            _ui.robotStatusList->setItemWidget(item, statusWidget);
+
+            //  set shell ID
+            statusWidget->setShellID(robot->shell());
+
+            //  set team
+            statusWidget->setBlueTeam(processor()->blueTeam());
+
+            //  TODO: set board ID
+
+            //  set robot model
+            QString robotModel;
+            switch (robot->radioRx().hardware_version()) {
+                case RJ2008: robotModel = "RJ2008"; break;
+                case RJ2011: robotModel = "RJ2011"; break;
+                case RJ2015: robotModel = "RJ2015"; break;
+                default: robotModel = "Unknown Bot";
+            }
+            statusWidget->setRobotModel(robotModel);
+
+
+//  uncomment this #define to test the display of a variety of different errors
 // #define DEMO_ROBOT_STATUS
 
 #ifdef DEMO_ROBOT_STATUS
-			//	set board ID
-			QString hex("");
-			for (int i = 0; i < 4; i++) hex += QString::number(rand() % 16, 16).toUpper();
-			statusWidget->setBoardID(hex);
+            //  set board ID
+            QString hex("");
+            for (int i = 0; i < 4; i++) hex += QString::number(rand() % 16, 16).toUpper();
+            statusWidget->setBoardID(hex);
 
-			//	fake vision
-			bool vision = rand() % 5 != 0;
-			statusWidget->setHasVision(vision);
+            //  fake vision
+            bool vision = rand() % 5 != 0;
+            statusWidget->setHasVision(vision);
 
-			//	fake battery
-			float battery = robot->shell() / 6.0f;
-			statusWidget->setBatteryLevel(battery);
+            //  fake battery
+            float battery = robot->shell() / 6.0f;
+            statusWidget->setBatteryLevel(battery);
 
-			//	fake radio
-			bool radio = rand() % 5 != 0;
-			statusWidget->setHasRadio(radio);
+            //  fake radio
+            bool radio = rand() % 5 != 0;
+            statusWidget->setHasRadio(radio);
 
-			// fake error text
-			QString error = "Kicker Fault, Hall Fault FR, Ball Sense Fault";
-			statusWidget->setErrorText(error);
+            // fake error text
+            QString error = "Kicker Fault, Hall Fault FR, Ball Sense Fault";
+            statusWidget->setErrorText(error);
 
-			//	fake ball status
-			bool ball = rand() % 4 == 0;
-			statusWidget->setHasBall(ball);
+            //  fake ball status
+            bool ball = rand() % 4 == 0;
+            statusWidget->setHasBall(ball);
 
-			//	fake ball sense error
-			bool ballFault = rand() % 4 == 0;
-			statusWidget->setBallSenseFault(ballFault);
-			bool hasWheelFault = false;
-			if (rand() % 4 == 0) {
-				statusWidget->setWheelFault(rand() % 4);
-				hasWheelFault = true;
-			}
+            //  fake ball sense error
+            bool ballFault = rand() % 4 == 0;
+            statusWidget->setBallSenseFault(ballFault);
+            bool hasWheelFault = false;
+            if (rand() % 4 == 0) {
+                statusWidget->setWheelFault(rand() % 4);
+                hasWheelFault = true;
+            }
 
-			bool showstopper = !vision || !radio || hasWheelFault || battery < 0.25;
-			statusWidget->setShowstopper(showstopper);
+            bool showstopper = !vision || !radio || hasWheelFault || battery < 0.25;
+            statusWidget->setShowstopper(showstopper);
 #endif
-		} else if (!shouldDisplay && displaying) {
-			//	remove the widget for this robot from the list
+        } else if (!shouldDisplay && displaying) {
+            //  remove the widget for this robot from the list
 
-			QListWidgetItem *item = _robotStatusItemMap[robot->shell()];
+            QListWidgetItem *item = _robotStatusItemMap[robot->shell()];
 
-			//	delete widget from list
-			for (int row = 0; row < _ui.robotStatusList->count(); row++) {
-				if (_ui.robotStatusList->item(row) == item) {
-					_ui.robotStatusList->takeItem(row);
-					break;
-				}
-			}
+            //  delete widget from list
+            for (int row = 0; row < _ui.robotStatusList->count(); row++) {
+                if (_ui.robotStatusList->item(row) == item) {
+                    _ui.robotStatusList->takeItem(row);
+                    break;
+                }
+            }
 
-			_robotStatusItemMap.erase(robot->shell());
-			delete item;
-		}
+            _robotStatusItemMap.erase(robot->shell());
+            delete item;
+        }
 
-		//	update displayed attributes for valid robots
-		if (shouldDisplay) {
-			QListWidgetItem *item = _robotStatusItemMap[robot->shell()];
-			RobotStatusWidget *statusWidget = (RobotStatusWidget *)_ui.robotStatusList->itemWidget(item);
+        //  update displayed attributes for valid robots
+        if (shouldDisplay) {
+            QListWidgetItem *item = _robotStatusItemMap[robot->shell()];
+            RobotStatusWidget *statusWidget = (RobotStatusWidget *)_ui.robotStatusList->itemWidget(item);
 
-			// We make a copy of the robot's RadioRx package b/c the original might change
-			// during the course of this method b/c radio comm happens on a different thread.
-			RadioRx rx(robot->radioRx());
+            // We make a copy of the robot's RadioRx package b/c the original might change
+            // during the course of this method b/c radio comm happens on a different thread.
+            RadioRx rx(robot->radioRx());
 
 
 #ifndef DEMO_ROBOT_STATUS
-			//	radio status
-			bool hasRadio = robot->rxIsFresh();
-			statusWidget->setHasRadio(hasRadio);
+            //  radio status
+            bool hasRadio = robot->rxIsFresh();
+            statusWidget->setHasRadio(hasRadio);
 
-			//	vision status
-			bool hasVision = robot->visible;
-			statusWidget->setHasVision(hasVision);
+            //  vision status
+            bool hasVision = robot->visible;
+            statusWidget->setHasVision(hasVision);
 
-			//	build a list of errors to display in the widget
-			QStringList errorList;
+            //  build a list of errors to display in the widget
+            QStringList errorList;
 
-			//	motor faults
-			//	each motor fault is shown as text in the error text display as well as being drawn as a red X on the graphic of a robot
-			bool hasMotorFault = false;
-			if (rx.motor_status().size() == 5)
-			{
-				const char *motorNames[] = {
-					"FR",
-					"FL",
-					"BL",
-					"BR",
-					"Dribbler"
-				};
+            //  motor faults
+            //  each motor fault is shown as text in the error text display as well as being drawn as a red X on the graphic of a robot
+            bool hasMotorFault = false;
+            if (rx.motor_status().size() == 5)
+            {
+                const char *motorNames[] = {
+                    "FR",
+                    "FL",
+                    "BL",
+                    "BR",
+                    "Dribbler"
+                };
 
-				//	examine status of each motor (including the dribbler)
-				for (int i = 0; i < 5; ++i)
-				{
-					bool motorIFault = true;
-					switch (rx.motor_status(i))
-					{
-						case Packet::Hall_Failure:
-							errorList << QString("Hall Fault %1").arg(motorNames[i]);
-							break;
-						case Packet::Stalled:
-							errorList << QString("Stall %1").arg(motorNames[i]);
-							break;
-						case Packet::Encoder_Failure:
-							errorList << QString("Encoder Fault %1").arg(motorNames[i]);
-							break;
+                //  examine status of each motor (including the dribbler)
+                for (int i = 0; i < 5; ++i)
+                {
+                    bool motorIFault = true;
+                    switch (rx.motor_status(i))
+                    {
+                        case Packet::Hall_Failure:
+                            errorList << QString("Hall Fault %1").arg(motorNames[i]);
+                            break;
+                        case Packet::Stalled:
+                            errorList << QString("Stall %1").arg(motorNames[i]);
+                            break;
+                        case Packet::Encoder_Failure:
+                            errorList << QString("Encoder Fault %1").arg(motorNames[i]);
+                            break;
 
-						default:
-							motorIFault = false;
-							break;
-					}
+                        default:
+                            motorIFault = false;
+                            break;
+                    }
 
-					//	show wheel faults (exluding the dribbler, which is index 4)
-					if (i != 4) statusWidget->setWheelFault(i, motorIFault);
+                    //  show wheel faults (exluding the dribbler, which is index 4)
+                    if (i != 4) statusWidget->setWheelFault(i, motorIFault);
 
-					hasMotorFault = hasMotorFault || motorIFault;
+                    hasMotorFault = hasMotorFault || motorIFault;
 
-					//	show dribbler fault on painted robot widget
-					if (i == 4) statusWidget->setBallSenseFault(motorIFault);
-				}
-			}
+                    //  show dribbler fault on painted robot widget
+                    if (i == 4) statusWidget->setBallSenseFault(motorIFault);
+                }
+            }
 
-			bool kickerFault = rx.has_kicker_status() && (rx.kicker_status() & 0x80);	//	check for kicker error code
-			bool ballSenseFault = rx.has_ball_sense_status() && !(rx.ball_sense_status() == Packet::NoBall || rx.ball_sense_status() == Packet::HasBall);
-			if (kickerFault) errorList << "Kicker Fault";
-			if (ballSenseFault) errorList << "Ball Sense Fault";
-			statusWidget->setBallSenseFault(ballSenseFault);
+            bool kickerFault = rx.has_kicker_status() && (rx.kicker_status() & 0x80);   //  check for kicker error code
+            bool ballSenseFault = rx.has_ball_sense_status() && !(rx.ball_sense_status() == Packet::NoBall || rx.ball_sense_status() == Packet::HasBall);
+            if (kickerFault) errorList << "Kicker Fault";
+            if (ballSenseFault) errorList << "Ball Sense Fault";
+            statusWidget->setBallSenseFault(ballSenseFault);
 
-			//	display error text
-			statusWidget->setErrorText(errorList.join(", "));
+            //  display error text
+            statusWidget->setErrorText(errorList.join(", "));
 
-			//	show the ball in the robot's mouth if it has one
-			bool hasBall = rx.has_ball_sense_status() && rx.ball_sense_status() == Packet::HasBall;
-			statusWidget->setHasBall(hasBall);
+            //  show the ball in the robot's mouth if it has one
+            bool hasBall = rx.has_ball_sense_status() && rx.ball_sense_status() == Packet::HasBall;
+            statusWidget->setHasBall(hasBall);
 
-			//	battery
-			//	convert battery voltage to a percentage and show it with the battery indicator
-			float batteryLevel = 1;
-			if (rx.has_battery()) {
-				if (rx.hardware_version() == RJ2008 || rx.hardware_version() == RJ2011) {
-					batteryLevel = RJ2008BatteryProfile.getChargeLevel(rx.battery());
-				} else if (rx.hardware_version() == RJ2015) {
-					batteryLevel = RJ2015BatteryProfile.getChargeLevel(rx.battery());
-				} else {
-					cerr << "Unknown hardware revision " << rx.hardware_version() << ", unable to calculate battery %" << endl;
-				}
-			}
-			statusWidget->setBatteryLevel(batteryLevel);
+            //  battery
+            //  convert battery voltage to a percentage and show it with the battery indicator
+            float batteryLevel = 1;
+            if (rx.has_battery()) {
+                if (rx.hardware_version() == RJ2008 || rx.hardware_version() == RJ2011) {
+                    batteryLevel = RJ2008BatteryProfile.getChargeLevel(rx.battery());
+                } else if (rx.hardware_version() == RJ2015) {
+                    batteryLevel = RJ2015BatteryProfile.getChargeLevel(rx.battery());
+                } else {
+                    cerr << "Unknown hardware revision " << rx.hardware_version() << ", unable to calculate battery %" << endl;
+                }
+            }
+            statusWidget->setBatteryLevel(batteryLevel);
 
 
-			//	if there is an error bad enough that we should get this robot off the field, alert the user through the UI that there is a "showstopper"
-			bool showstopper = !hasVision || !hasRadio || hasMotorFault || kickerFault || ballSenseFault || (batteryLevel < 0.25);
-			statusWidget->setShowstopper(showstopper);
+            //  if there is an error bad enough that we should get this robot off the field, alert the user through the UI that there is a "showstopper"
+            bool showstopper = !hasVision || !hasRadio || hasMotorFault || kickerFault || ballSenseFault || (batteryLevel < 0.25);
+            statusWidget->setShowstopper(showstopper);
 
 #endif
-		}
-	}
+        }
+    }
 
 
-	// We restart this timer repeatedly instead of using a single shot timer in order
-	// to guarantee a minimum time between redraws.  This will limit the CPU usage on a fast computer.
-	updateTimer.start(20);
+    // We restart this timer repeatedly instead of using a single shot timer in order
+    // to guarantee a minimum time between redraws.  This will limit the CPU usage on a fast computer.
+    updateTimer.start(20);
 }
 
 void MainWindow::updateStatus()
 {
-	// Guidelines:
-	//    Status_Fail is used for severe, usually external, errors such as hardware or network failures.
-	//    Status_Warning is used for configuration problems that prevent competition operation.
-	//        These can be easily changed within the soccer program.
-	//    Status_OK shall only be used for "COMPETITION".
-	//
-	// The order of these checks is important to help debugging.
-	// More specific or unlikely problems should be tested earlier.
+    // Guidelines:
+    //    Status_Fail is used for severe, usually external, errors such as hardware or network failures.
+    //    Status_Warning is used for configuration problems that prevent competition operation.
+    //        These can be easily changed within the soccer program.
+    //    Status_OK shall only be used for "COMPETITION".
+    //
+    // The order of these checks is important to help debugging.
+    // More specific or unlikely problems should be tested earlier.
 
-	if (!_processor)
-	{
-		status("NO PROCESSOR", Status_Fail);
-		return;
-	}
+    if (!_processor)
+    {
+        status("NO PROCESSOR", Status_Fail);
+        return;
+    }
 
-	// Some conditions are different in simulation
-	bool sim = _processor->simulation();
+    // Some conditions are different in simulation
+    bool sim = _processor->simulation();
 
-	// Get processing thread status
-	Processor::Status ps = _processor->status();
-	Time curTime = timestamp();
+    // Get processing thread status
+    Processor::Status ps = _processor->status();
+    Time curTime = timestamp();
 
-	// Determine if we are receiving packets from an external referee
-	bool haveExternalReferee = (curTime - ps.lastRefereeTime) < 500 * 1000;
+    // Determine if we are receiving packets from an external referee
+    bool haveExternalReferee = (curTime - ps.lastRefereeTime) < 500 * 1000;
 
-	/*if (_autoExternalReferee && haveExternalReferee && !_ui.externalReferee->isChecked())
-	{
-		_ui.externalReferee->setChecked(true);
-	}*/
+    /*if (_autoExternalReferee && haveExternalReferee && !_ui.externalReferee->isChecked())
+    {
+        _ui.externalReferee->setChecked(true);
+    }*/
 
-	// Is the processing thread running?
-	if (curTime - ps.lastLoopTime > 100 * 1000)
-	{
-		// Processing loop hasn't run recently.
-		// Likely causes:
-		//    Mutex deadlock (need a recursive mutex?)
-		//    Excessive computation
-		status("PROCESSING HUNG", Status_Fail);
-		return;
-	}
+    // Is the processing thread running?
+    if (curTime - ps.lastLoopTime > 100 * 1000)
+    {
+        // Processing loop hasn't run recently.
+        // Likely causes:
+        //    Mutex deadlock (need a recursive mutex?)
+        //    Excessive computation
+        status("PROCESSING HUNG", Status_Fail);
+        return;
+    }
 
-	// Check network activity
-	if (curTime - ps.lastVisionTime > 100 * 1000)
-	{
-		// We must always have vision
-		status("NO VISION", Status_Fail);
-		return;
-	}
+    // Check network activity
+    if (curTime - ps.lastVisionTime > 100 * 1000)
+    {
+        // We must always have vision
+        status("NO VISION", Status_Fail);
+        return;
+    }
 
-	if (_processor->manualID() >= 0)
-	{
-		// Mixed auto/manual control
-		status("MANUAL", Status_Warning);
-		return;
-	}
+    if (_processor->manualID() >= 0)
+    {
+        // Mixed auto/manual control
+        status("MANUAL", Status_Warning);
+        return;
+    }
 
-	// Driving the robots helps isolate radio problems by verifying radio TX,
-	// so test this after manual driving.
-	if (curTime - ps.lastRadioRxTime > 1000 * 1000)
-	{
-		// Allow a long timeout in case of poor radio performance
-		status("NO RADIO RX", Status_Fail);
-		return;
-	}
+    // Driving the robots helps isolate radio problems by verifying radio TX,
+    // so test this after manual driving.
+    if (curTime - ps.lastRadioRxTime > 1000 * 1000)
+    {
+        // Allow a long timeout in case of poor radio performance
+        status("NO RADIO RX", Status_Fail);
+        return;
+    }
 
-	if ((!sim || _processor->externalReferee()) && !haveExternalReferee)
-	{
-		if (_autoExternalReferee && _processor->externalReferee())
-		{
-			// Automatically turn off external referee
-			//_ui.externalReferee->setChecked(false);
-		} else {
-			// In simulation, we will often run without a referee, so just make it a warning.
-			// There is a separate status for non-simulation with internal referee.
-			status("NO REFEREE", Status_Fail);
-		}
-		return;
-	}
+    if ((!sim || _processor->externalReferee()) && !haveExternalReferee)
+    {
+        if (_autoExternalReferee && _processor->externalReferee())
+        {
+            // Automatically turn off external referee
+            //_ui.externalReferee->setChecked(false);
+        } else {
+            // In simulation, we will often run without a referee, so just make it a warning.
+            // There is a separate status for non-simulation with internal referee.
+            status("NO REFEREE", Status_Fail);
+        }
+        return;
+    }
 
-	if (sim)
-	{
-		// Everything is good for simulation, but not for competition.
-		status("SIMULATION", Status_Warning);
-		return;
-	}
+    if (sim)
+    {
+        // Everything is good for simulation, but not for competition.
+        status("SIMULATION", Status_Warning);
+        return;
+    }
 
-	if (!sim && !_processor->externalReferee())
-	{
-		// Competition must use external referee
-		status("INTERNAL REF", Status_Warning);
-		return;
-	}
+    if (!sim && !_processor->externalReferee())
+    {
+        // Competition must use external referee
+        status("INTERNAL REF", Status_Warning);
+        return;
+    }
 
-	if (!sim && !_processor->logger().recording())
-	{
-		// We should record logs during competition
-		status("NOT RECORDING", Status_Warning);
-		return;
-	}
+    if (!sim && !_processor->logger().recording())
+    {
+        // We should record logs during competition
+        status("NOT RECORDING", Status_Warning);
+        return;
+    }
 
-	status("COMPETITION", Status_OK);
+    status("COMPETITION", Status_OK);
 }
 
 void MainWindow::status(QString text, MainWindow::StatusType status)
 {
-	// Assume that the status type alone won't change.
-	if (_ui.statusLabel->text() != text)
-	{
-		_ui.statusLabel->setText(text);
+    // Assume that the status type alone won't change.
+    if (_ui.statusLabel->text() != text)
+    {
+        _ui.statusLabel->setText(text);
 
-		switch (status)
-		{
-			case Status_OK:
-				_ui.statusLabel->setStyleSheet("background-color: #00ff00");
-				break;
+        switch (status)
+        {
+            case Status_OK:
+                _ui.statusLabel->setStyleSheet("background-color: #00ff00");
+                break;
 
-			case Status_Warning:
-				_ui.statusLabel->setStyleSheet("background-color: #ffff00");
-				break;
+            case Status_Warning:
+                _ui.statusLabel->setStyleSheet("background-color: #ffff00");
+                break;
 
-			case Status_Fail:
-				_ui.statusLabel->setStyleSheet("background-color: #ff4040");
-				break;
-		}
-	}
+            case Status_Fail:
+                _ui.statusLabel->setStyleSheet("background-color: #ff4040");
+                break;
+        }
+    }
 }
 
 void MainWindow::on_fieldView_robotSelected(int shell)
 {
-	if (_processor->joystickValid())
-	{
-		_ui.manualID->setCurrentIndex(shell + 1);
-		_processor->manualID(shell);
-	}
+    if (_processor->joystickValid())
+    {
+        _ui.manualID->setCurrentIndex(shell + 1);
+        _processor->manualID(shell);
+    }
 }
 
 void MainWindow::on_actionRawBalls_toggled(bool state)
 {
-	_ui.fieldView->showRawBalls = state;
-	_ui.fieldView->update();
+    _ui.fieldView->showRawBalls = state;
+    _ui.fieldView->update();
 }
 
 void MainWindow::on_actionRawRobots_toggled(bool state)
 {
-	_ui.fieldView->showRawRobots = state;
-	_ui.fieldView->update();
+    _ui.fieldView->showRawRobots = state;
+    _ui.fieldView->update();
 }
 
 void MainWindow::on_actionCoords_toggled(bool state)
 {
-	_ui.fieldView->showCoords = state;
-	_ui.fieldView->update();
+    _ui.fieldView->showCoords = state;
+    _ui.fieldView->update();
 }
 
 void MainWindow::on_actionDotPatterns_toggled(bool state)
 {
-	_ui.fieldView->showDotPatterns = state;
-	_ui.fieldView->update();
+    _ui.fieldView->showDotPatterns = state;
+    _ui.fieldView->update();
 }
 
 void MainWindow::on_actionTeam_Names_toggled(bool state)
 {
-	_ui.fieldView->showTeamNames = state;
-	_ui.fieldView->update();
+    _ui.fieldView->showTeamNames = state;
+    _ui.fieldView->update();
 }
 
 
 void MainWindow::on_actionDefendMinusX_triggered()
 {
-	_processor->defendPlusX(false);
+    _processor->defendPlusX(false);
 }
 
 void MainWindow::on_actionDefendPlusX_triggered()
 {
-	_processor->defendPlusX(true);
+    _processor->defendPlusX(true);
 }
 
 void MainWindow::on_action0_triggered()
 {
-	_ui.fieldView->rotate(0);
+    _ui.fieldView->setFieldOrientation(FieldOrientationLandscapeLeft);
 }
 
 void MainWindow::on_action90_triggered()
 {
-	_ui.fieldView->rotate(1);
+    _ui.fieldView->setFieldOrientation(FieldOrientationPortrait);
 }
 
 void MainWindow::on_action180_triggered()
 {
-	_ui.fieldView->rotate(2);
+    _ui.fieldView->setFieldOrientation(FieldOrientationLandscapeRight);
 }
 
 void MainWindow::on_action270_triggered()
 {
-	_ui.fieldView->rotate(3);
+    _ui.fieldView->setFieldOrientation(FieldOrientationPortraitUpsideDown);
 }
 
 void MainWindow::on_actionUseOurHalf_toggled(bool value)
 {
-	_processor->useOurHalf(value);
+    _processor->useOurHalf(value);
 }
 
 void MainWindow::on_actionUseOpponentHalf_toggled(bool value)
 {
-	_processor->useOpponentHalf(value);
+    _processor->useOpponentHalf(value);
 }
 
 void MainWindow::on_action904MHz_triggered()
 {
-	channel(0);
-	_ui.action904MHz->setChecked(true);
-	_ui.action906MHz->setChecked(false);
+    channel(0);
+    _ui.action904MHz->setChecked(true);
+    _ui.action906MHz->setChecked(false);
 }
 
 void MainWindow::on_action906MHz_triggered()
 {
-	channel(10);
-	_ui.action904MHz->setChecked(false);
-	_ui.action906MHz->setChecked(true);
+    channel(10);
+    _ui.action904MHz->setChecked(false);
+    _ui.action906MHz->setChecked(true);
 }
 
 void MainWindow::channel(int n)
 {
-	if (_processor && _processor->radio())
-	{
-		_processor->radio()->channel(n);
-	}
-	_ui.radioLabel->setText(QString("%1MHz").arg(904.0 + 0.2 * n, 0, 'f', 1));
+    if (_processor && _processor->radio())
+    {
+        _processor->radio()->channel(n);
+    }
+    _ui.radioLabel->setText(QString("%1MHz").arg(904.0 + 0.2 * n, 0, 'f', 1));
 }
 
 // Simulator commands
 
 void MainWindow::on_actionCenterBall_triggered()
 {
-	SimCommand cmd;
-	cmd.mutable_ball_pos()->set_x(0);
-	cmd.mutable_ball_pos()->set_y(0);
-	cmd.mutable_ball_vel()->set_x(0);
-	cmd.mutable_ball_vel()->set_y(0);
-	_ui.fieldView->sendSimCommand(cmd);
+    SimCommand cmd;
+    cmd.mutable_ball_pos()->set_x(0);
+    cmd.mutable_ball_pos()->set_y(0);
+    cmd.mutable_ball_vel()->set_x(0);
+    cmd.mutable_ball_vel()->set_y(0);
+    _ui.fieldView->sendSimCommand(cmd);
 }
 
 void MainWindow::on_actionStopBall_triggered()
 {
-	SimCommand cmd;
-	cmd.mutable_ball_vel()->set_x(0);
-	cmd.mutable_ball_vel()->set_y(0);
-	_ui.fieldView->sendSimCommand(cmd);
+    SimCommand cmd;
+    cmd.mutable_ball_vel()->set_x(0);
+    cmd.mutable_ball_vel()->set_y(0);
+    _ui.fieldView->sendSimCommand(cmd);
 }
 
 void MainWindow::on_actionResetField_triggered() {
-	SimCommand cmd;
-	cmd.set_reset(true);
-	_ui.fieldView->sendSimCommand(cmd);
+    SimCommand cmd;
+    cmd.set_reset(true);
+    _ui.fieldView->sendSimCommand(cmd);
 }
 
 void MainWindow::on_actionStopRobots_triggered() {
-	SimCommand cmd;
-	// TODO: check that this handles threads properly
-	for (OurRobot* robot :  state()->self)
-	{
-		SimCommand::Robot *r = cmd.add_robots();
-		r->set_shell(robot->shell());
-		r->set_blue_team(processor()->blueTeam());
-		r->mutable_vel()->set_x(0);
-		r->mutable_vel()->set_y(0);
-		r->set_w(0);
-	}
-	for (OpponentRobot* robot :  state()->opp)
-	{
-		SimCommand::Robot *r = cmd.add_robots();
-		r->set_shell(robot->shell());
-		r->set_blue_team(processor()->blueTeam());
-		r->mutable_vel()->set_x(0);
-		r->mutable_vel()->set_y(0);
-		r->set_w(0);
-	}
-	_ui.fieldView->sendSimCommand(cmd);
+    SimCommand cmd;
+    // TODO: check that this handles threads properly
+    for (OurRobot* robot :  state()->self)
+    {
+        SimCommand::Robot *r = cmd.add_robots();
+        r->set_shell(robot->shell());
+        r->set_blue_team(processor()->blueTeam());
+        r->mutable_vel()->set_x(0);
+        r->mutable_vel()->set_y(0);
+        r->set_w(0);
+    }
+    for (OpponentRobot* robot :  state()->opp)
+    {
+        SimCommand::Robot *r = cmd.add_robots();
+        r->set_shell(robot->shell());
+        r->set_blue_team(processor()->blueTeam());
+        r->mutable_vel()->set_x(0);
+        r->mutable_vel()->set_y(0);
+        r->set_w(0);
+    }
+    _ui.fieldView->sendSimCommand(cmd);
 }
 
 // Manual control commands
 
 void MainWindow::on_actionDampedRotation_toggled(bool value)
 {
-	cout << "DampedRotation is ";
-	if (value)
-		cout << "Enabled" << endl;
-	else
-		cout << "Disabled" << endl;
-	_processor->dampedRotation(value);
+    cout << "DampedRotation is ";
+    if (value)
+        cout << "Enabled" << endl;
+    else
+        cout << "Disabled" << endl;
+    _processor->dampedRotation(value);
 }
 
 void MainWindow::on_actionDampedTranslation_toggled(bool value)
 {
-	cout << "DampedTranslation is ";
-	if (value)
-		cout << "Enabled" << endl;
-	else
-		cout << "Disabled" << endl;
-	_processor->dampedTranslation(value);
+    cout << "DampedTranslation is ";
+    if (value)
+        cout << "Enabled" << endl;
+    else
+        cout << "Disabled" << endl;
+    _processor->dampedTranslation(value);
 }
 
 // Debug commands
 
 void MainWindow::on_actionRestartUpdateTimer_triggered()
 {
-	printf("Update timer: active %d, singleShot %d, interval %d\n", updateTimer.isActive(), updateTimer.isSingleShot(), updateTimer.interval());
-	updateTimer.stop();
-	updateTimer.start(30);
+    printf("Update timer: active %d, singleShot %d, interval %d\n", updateTimer.isActive(), updateTimer.isSingleShot(), updateTimer.interval());
+    updateTimer.stop();
+    updateTimer.start(30);
 }
 
 void MainWindow::on_actionQuaternion_Demo_toggled(bool value)
 {
-	if (value)
-	{
-		if (_quaternion_demo)
-			delete _quaternion_demo;
-		cout << "Starting Quaternion Demo" << endl;
-		_quaternion_demo = new QuaternionDemo(this);
-		_quaternion_demo->resize(640, 480);
-	} else
-	{
-		cout << "Stopping Quaternion Demo" << endl;
-		if (_quaternion_demo)
-			delete _quaternion_demo;
-	}
+    if (value)
+    {
+        if (_quaternion_demo)
+            delete _quaternion_demo;
+        cout << "Starting Quaternion Demo" << endl;
+        _quaternion_demo = new QuaternionDemo(this);
+        _quaternion_demo->resize(640, 480);
+    } else
+    {
+        cout << "Stopping Quaternion Demo" << endl;
+        if (_quaternion_demo)
+            delete _quaternion_demo;
+    }
 }
 
 // Gameplay commands
@@ -944,30 +945,30 @@ void MainWindow::on_menu_Gameplay_aboutToShow()
 
 void MainWindow::on_actionSeed_triggered()
 {
-	QString text = QInputDialog::getText(this, "Set Random Seed", "Hexadecimal seed:");
-	if (!text.isNull())
-	{
-		long seed = strtol(text.toLatin1(), 0, 16);
-		printf("seed %016lx\n", seed);
-		srand48(seed);
-	}
+    QString text = QInputDialog::getText(this, "Set Random Seed", "Hexadecimal seed:");
+    if (!text.isNull())
+    {
+        long seed = strtol(text.toLatin1(), 0, 16);
+        printf("seed %016lx\n", seed);
+        srand48(seed);
+    }
 }
 
 
 // Log controls
 void MainWindow::on_logHistoryLocation_sliderMoved(int value)
 {
-	//	update current frame
-	int minFrame = _processor->logger().firstFrameNumber();
-	int maxFrame = _processor->logger().lastFrameNumber();
-	_doubleFrameNumber = value + minFrame;
-	_doubleFrameNumber = min<double>(maxFrame, _doubleFrameNumber);
+    //  update current frame
+    int minFrame = _processor->logger().firstFrameNumber();
+    int maxFrame = _processor->logger().lastFrameNumber();
+    _doubleFrameNumber = value + minFrame;
+    _doubleFrameNumber = min<double>(maxFrame, _doubleFrameNumber);
 
-	emit historyLocationChanged(_doubleFrameNumber - minFrame);
+    emit historyLocationChanged(_doubleFrameNumber - minFrame);
 
-	//	pause playback
-	live(false);
-	_playbackRate = 0;
+    //  pause playback
+    live(false);
+    _playbackRate = 0;
 }
 
 void MainWindow::on_logPlaybackRewind_clicked()
@@ -978,15 +979,15 @@ void MainWindow::on_logPlaybackRewind_clicked()
 
 void MainWindow::on_logPlaybackPrevFrame_clicked()
 {
-	live(false);
-	_playbackRate = 0;
+    live(false);
+    _playbackRate = 0;
     _doubleFrameNumber -= 1;
 }
 
 void MainWindow::on_logPlaybackPause_clicked()
 {
-	live(false);
-	_playbackRate = 0;
+    live(false);
+    _playbackRate = 0;
 }
 
 void MainWindow::on_logPlaybackNextFrame_clicked()
@@ -998,47 +999,47 @@ void MainWindow::on_logPlaybackNextFrame_clicked()
 
 void MainWindow::on_logPlaybackPlay_clicked()
 {
-	live(false);
-	_playbackRate = 1;
+    live(false);
+    _playbackRate = 1;
 }
 
 void MainWindow::on_logPlaybackLive_clicked()
 {
-	live(true);
+    live(true);
 }
 
 void MainWindow::on_actionTeamBlue_triggered()
 {
-	_ui.team->setText("BLUE");
-	_ui.team->setStyleSheet("background-color: #4040ff; color: #ffffff");
-	_processor->blueTeam(true);
+    _ui.team->setText("BLUE");
+    _ui.team->setStyleSheet("background-color: #4040ff; color: #ffffff");
+    _processor->blueTeam(true);
 }
 
 void MainWindow::on_actionTeamYellow_triggered()
 {
-	_ui.team->setText("YELLOW");
-	_ui.team->setStyleSheet("background-color: #ffff00");
-	_processor->blueTeam(false);
+    _ui.team->setText("YELLOW");
+    _ui.team->setStyleSheet("background-color: #ffff00");
+    _processor->blueTeam(false);
 }
 
 void MainWindow::on_manualID_currentIndexChanged(int value)
 {
-	_processor->manualID(value - 1);
-	if (_quaternion_demo)
-	{
-		if (value == 0)
-		{
-			_quaternion_demo->hide();
-		} else {
-			_quaternion_demo->show();
-			_quaternion_demo->initialized = false;
-		}
-	}
+    _processor->manualID(value - 1);
+    if (_quaternion_demo)
+    {
+        if (value == 0)
+        {
+            _quaternion_demo->hide();
+        } else {
+            _quaternion_demo->show();
+            _quaternion_demo->initialized = false;
+        }
+    }
 }
 
 void MainWindow::on_goalieID_currentIndexChanged(int value)
 {
-	_processor->goalieID(value - 1);
+    _processor->goalieID(value - 1);
 }
 
 ////////
@@ -1046,60 +1047,60 @@ void MainWindow::on_goalieID_currentIndexChanged(int value)
 
 void MainWindow::allDebugOn()
 {
-	for (int i = 0; i < _ui.debugLayers->count(); ++i)
-	{
-		_ui.debugLayers->item(i)->setCheckState(Qt::Checked);
-	}
+    for (int i = 0; i < _ui.debugLayers->count(); ++i)
+    {
+        _ui.debugLayers->item(i)->setCheckState(Qt::Checked);
+    }
 }
 
 void MainWindow::allDebugOff()
 {
-	for (int i = 0; i < _ui.debugLayers->count(); ++i)
-	{
-		_ui.debugLayers->item(i)->setCheckState(Qt::Unchecked);
-	}
+    for (int i = 0; i < _ui.debugLayers->count(); ++i)
+    {
+        _ui.debugLayers->item(i)->setCheckState(Qt::Unchecked);
+    }
 }
 
 void MainWindow::on_debugLayers_customContextMenuRequested(const QPoint& pos)
 {
-	QListWidgetItem *item = _ui.debugLayers->itemAt(pos);
+    QListWidgetItem *item = _ui.debugLayers->itemAt(pos);
 
-	QMenu menu;
-	QAction *all = menu.addAction("All");
-	QAction *none = menu.addAction("None");
-	QAction *single = 0, *notSingle = 0;
-	if (item)
-	{
-		single = menu.addAction("Only this");
-		notSingle = menu.addAction("All except this");
-	}
+    QMenu menu;
+    QAction *all = menu.addAction("All");
+    QAction *none = menu.addAction("None");
+    QAction *single = 0, *notSingle = 0;
+    if (item)
+    {
+        single = menu.addAction("Only this");
+        notSingle = menu.addAction("All except this");
+    }
 
-	QAction *act = menu.exec(_ui.debugLayers->mapToGlobal(pos));
-	if (act == all)
-	{
-		allDebugOn();
-	} else if (act == none)
-	{
-		allDebugOff();
-	} else if (single && act == single)
-	{
-		allDebugOff();
-		item->setCheckState(Qt::Checked);
-	} else if (notSingle && act == notSingle)
-	{
-		allDebugOn();
-		item->setCheckState(Qt::Unchecked);
-	}
+    QAction *act = menu.exec(_ui.debugLayers->mapToGlobal(pos));
+    if (act == all)
+    {
+        allDebugOn();
+    } else if (act == none)
+    {
+        allDebugOff();
+    } else if (single && act == single)
+    {
+        allDebugOff();
+        item->setCheckState(Qt::Checked);
+    } else if (notSingle && act == notSingle)
+    {
+        allDebugOn();
+        item->setCheckState(Qt::Unchecked);
+    }
 }
 
 void MainWindow::on_debugLayers_itemChanged(QListWidgetItem* item)
 {
-	int layer = item->data(Qt::UserRole).toInt();
-	if (layer >= 0)
-	{
-		_ui.fieldView->layerVisible(layer, item->checkState() == Qt::Checked);
-	}
-	_ui.fieldView->update();
+    int layer = item->data(Qt::UserRole).toInt();
+    if (layer >= 0)
+    {
+        _ui.fieldView->layerVisible(layer, item->checkState() == Qt::Checked);
+    }
+    _ui.fieldView->update();
 }
 
 void MainWindow::on_configTree_itemChanged(QTreeWidgetItem* item, int column)
@@ -1109,125 +1110,128 @@ void MainWindow::on_configTree_itemChanged(QTreeWidgetItem* item, int column)
 
 void MainWindow::on_loadConfig_clicked()
 {
-	QString filename = QFileDialog::getOpenFileName(this, "Load Configuration");
-	if (!filename.isNull())
-	{
-		QString error;
-		if (!_config->load(filename, error))
-		{
-			QMessageBox::critical(this, "Load Configuration", error);
-		}
-	}
+    QString filename = QFileDialog::getOpenFileName(this, "Load Configuration");
+    if (!filename.isNull())
+    {
+        QString error;
+        if (!_config->load(filename, error))
+        {
+            QMessageBox::critical(this, "Load Configuration", error);
+        }
+    }
 }
 
 void MainWindow::on_saveConfig_clicked()
 {
-	QString filename = QFileDialog::getSaveFileName(this, "Save Configuration");
-	if (!filename.isNull())
-	{
-		QString error;
-		if (!_config->save(filename, error))
-		{
-			QMessageBox::critical(this, "Save Configuration", error);
-		}
-	}
+    QString filename = QFileDialog::getSaveFileName(this, "Save Configuration");
+    if (!filename.isNull())
+    {
+        QString error;
+        if (!_config->save(filename, error))
+        {
+            QMessageBox::critical(this, "Save Configuration", error);
+        }
+    }
 }
 
 void MainWindow::on_loadPlaybook_clicked()
 {
-	QString filename = QFileDialog::getOpenFileName(this, "Load Playbook", "../soccer/gameplay/playbooks/");
-	if (!filename.isNull())
-	{
-		try
-		{
-			_processor->gameplayModule()->loadPlaybook(filename.toStdString(), true);
-		}
-		catch(runtime_error* error) {
-			QMessageBox::critical(this, "File not found", QString("File not found: %1").arg(filename));
-		}
-	}
+    QString filename = QFileDialog::getOpenFileName(this, "Load Playbook", "../soccer/gameplay/playbooks/");
+    if (!filename.isNull())
+    {
+        try
+        {
+            _processor->gameplayModule()->loadPlaybook(filename.toStdString(), true);
+        }
+        catch(runtime_error* error) {
+            QMessageBox::critical(this, "File not found", QString("File not found: %1").arg(filename));
+        }
+    }
 }
 
 void MainWindow::on_savePlaybook_clicked()
 {
-	QString filename = QFileDialog::getSaveFileName(this, "Save Playbook", "../soccer/gameplay/playbooks/");
-	if (!filename.isNull())
-	{
-		try {
-			_processor->gameplayModule()->savePlaybook(filename.toStdString(), true);
-		}
-		catch(runtime_error* error) {
-			QMessageBox::critical(this, "File not found", QString("File not found: %1").arg(filename));
-		}
-	}
+    QString filename = QFileDialog::getSaveFileName(this, "Save Playbook", "../soccer/gameplay/playbooks/");
+    if (!filename.isNull())
+    {
+        try {
+            _processor->gameplayModule()->savePlaybook(filename.toStdString(), true);
+        }
+        catch(runtime_error* error) {
+            QMessageBox::critical(this, "File not found", QString("File not found: %1").arg(filename));
+        }
+    }
 }
 
 void MainWindow::setRadioChannel(RadioChannels channel)
 {
-	switch(channel)
-	{
-	case RadioChannels::MHz_904:
-		this->on_action904MHz_triggered();
-		break;
-	case RadioChannels::MHz_906:
-		this->on_action906MHz_triggered();
-		break;
-	}
+    switch(channel)
+    {
+    case RadioChannels::MHz_904:
+        this->on_action904MHz_triggered();
+        break;
+    case RadioChannels::MHz_906:
+        this->on_action906MHz_triggered();
+        break;
+    }
 }
 
 void MainWindow::on_fastHalt_clicked()
 {
-	_processor->refereeModule()->command = NewRefereeModuleEnums::HALT;
+    _processor->refereeModule()->command = NewRefereeModuleEnums::HALT;
 }
 
 void MainWindow::on_fastStop_clicked()
 {
-	_processor->refereeModule()->command = NewRefereeModuleEnums::STOP;
+    _processor->refereeModule()->command = NewRefereeModuleEnums::STOP;
 }
 
 void MainWindow::on_fastReady_clicked()
 {
-	_processor->refereeModule()->command = NewRefereeModuleEnums::NORMAL_START;
+    _processor->refereeModule()->command = NewRefereeModuleEnums::NORMAL_START;
 }
 
 void MainWindow::on_fastForceStart_clicked()
 {
-	_processor->refereeModule()->command = NewRefereeModuleEnums::FORCE_START;
+    _processor->refereeModule()->command = NewRefereeModuleEnums::FORCE_START;
 }
 
 void MainWindow::on_fastKickoffBlue_clicked()
 {
-	_processor->refereeModule()->command = NewRefereeModuleEnums::PREPARE_KICKOFF_BLUE;
+    _processor->refereeModule()->command = NewRefereeModuleEnums::PREPARE_KICKOFF_BLUE;
 }
 
 void MainWindow::on_fastKickoffYellow_clicked()
 {
-	_processor->refereeModule()->command = NewRefereeModuleEnums::PREPARE_KICKOFF_YELLOW;
+    _processor->refereeModule()->command = NewRefereeModuleEnums::PREPARE_KICKOFF_YELLOW;
 }
 
 void MainWindow::on_actionVisionPrimary_Half_triggered()
 {
-	_processor->changeVisionChannel(SharedVisionPortSinglePrimary);
-	_processor->setFieldDimensions(Field_Dimensions::Single_Field_Dimensions);
-	_ui.actionVisionPrimary_Half->setChecked(true);
-	_ui.actionVisionSecondary_Half->setChecked(false);
-	_ui.actionVisionFull_Field->setChecked(false);
+    _processor->changeVisionChannel(SharedVisionPortSinglePrimary);
+    _processor->setFieldDimensions(Field_Dimensions::Single_Field_Dimensions);
+    _ui.fieldView->setFieldDimensions(Field_Dimensions::Single_Field_Dimensions);
+    _ui.actionVisionPrimary_Half->setChecked(true);
+    _ui.actionVisionSecondary_Half->setChecked(false);
+    _ui.actionVisionFull_Field->setChecked(false);
 }
 
 void MainWindow::on_actionVisionSecondary_Half_triggered()
 {
-	_processor->changeVisionChannel(SharedVisionPortSingleSecondary);
-	_processor->setFieldDimensions(Field_Dimensions::Single_Field_Dimensions);
-	_ui.actionVisionPrimary_Half->setChecked(false);
-	_ui.actionVisionSecondary_Half->setChecked(true);
-	_ui.actionVisionFull_Field->setChecked(false);
+    _processor->changeVisionChannel(SharedVisionPortSingleSecondary);
+    _processor->setFieldDimensions(Field_Dimensions::Single_Field_Dimensions);
+    _ui.fieldView->setFieldDimensions(Field_Dimensions::Single_Field_Dimensions);
+    _ui.actionVisionPrimary_Half->setChecked(false);
+    _ui.actionVisionSecondary_Half->setChecked(true);
+    _ui.actionVisionFull_Field->setChecked(false);
 }
 
 void MainWindow::on_actionVisionFull_Field_triggered()
 {
-	_processor->changeVisionChannel(SharedVisionPortDoubleOld);
-	_processor->setFieldDimensions(Field_Dimensions::Double_Field_Dimensions);
-	_ui.actionVisionPrimary_Half->setChecked(false);
-	_ui.actionVisionSecondary_Half->setChecked(false);
-	_ui.actionVisionFull_Field->setChecked(true);
+    _processor->changeVisionChannel(SharedVisionPortDoubleOld);
+    _processor->setFieldDimensions(Field_Dimensions::Double_Field_Dimensions);
+    _ui.fieldView->setFieldDimensions(Field_Dimensions::Double_Field_Dimensions);
+    _ui.actionVisionPrimary_Half->setChecked(false);
+    _ui.actionVisionSecondary_Half->setChecked(false);
+    _ui.actionVisionFull_Field->setChecked(true);
 }

--- a/soccer/SimFieldView.cpp
+++ b/soccer/SimFieldView.cpp
@@ -21,8 +21,8 @@ SimFieldView::SimFieldView(QWidget* parent): FieldView(parent)
 
 void SimFieldView::mousePressEvent(QMouseEvent* me)
 {
-	Geometry2d::Point pos = _worldToTeam * _screenToWorld * me->pos();
-	
+	Geometry2d::Point pos = worldToTeam() * screenToWorld() * me->pos();
+
 	std::shared_ptr<LogFrame> frame = currentFrame();
 	if (me->button() == Qt::LeftButton && frame)
 	{
@@ -45,12 +45,12 @@ void SimFieldView::mousePressEvent(QMouseEvent* me)
 				break;
 			}
 		}
-		
+
 		if (_dragRobot < 0)
 		{
 			placeBall(me->pos());
 		}
-		
+
 		_dragMode = DRAG_PLACE;
 	} else if (me->button() == Qt::RightButton && frame)
 	{
@@ -70,7 +70,7 @@ void SimFieldView::mousePressEvent(QMouseEvent* me)
 					break;
 				}
 			}
-			
+
 			if (newID != frame->manual_id())
 			{
 				robotSelected(newID);
@@ -84,9 +84,9 @@ void SimFieldView::mouseMoveEvent(QMouseEvent* me)
 	switch (_dragMode)
 	{
 		case DRAG_SHOOT:
-			_dragTo = _worldToTeam * _screenToWorld * me->pos();
+			_dragTo = worldToTeam() * screenToWorld() * me->pos();
 			break;
-		
+
 		case DRAG_PLACE:
 			if (_dragRobot >= 0)
 			{
@@ -94,7 +94,7 @@ void SimFieldView::mouseMoveEvent(QMouseEvent* me)
 				SimCommand::Robot *r = cmd.add_robots();
 				r->set_shell(_dragRobot);
 				r->set_blue_team(_dragRobotBlue);
-				r->mutable_pos()->CopyFrom(_screenToWorld * me->pos());
+				r->mutable_pos()->CopyFrom(screenToWorld() * me->pos());
 				r->mutable_vel()->set_x(0);
 				r->mutable_vel()->set_y(0);
 				sendSimCommand(cmd);
@@ -102,7 +102,7 @@ void SimFieldView::mouseMoveEvent(QMouseEvent* me)
 				placeBall(me->pos());
 			}
 			break;
-		
+
 		default:
 			break;
 	}
@@ -114,19 +114,19 @@ void SimFieldView::mouseReleaseEvent(QMouseEvent* me)
 	if (_dragMode == DRAG_SHOOT)
 	{
 		SimCommand cmd;
-		*cmd.mutable_ball_vel() = _teamToWorld.transformDirection(_shot);
+		*cmd.mutable_ball_vel() = teamToWorld().transformDirection(_shot);
 		sendSimCommand(cmd);
-		
+
 		update();
 	}
-	
+
 	_dragMode = DRAG_NONE;
 }
 
 void SimFieldView::placeBall(QPointF pos)
 {
 	SimCommand cmd;
-	cmd.mutable_ball_pos()->CopyFrom(_screenToWorld * pos);
+	cmd.mutable_ball_pos()->CopyFrom(screenToWorld() * pos);
 	cmd.mutable_ball_vel()->set_x(0);
 	cmd.mutable_ball_vel()->set_y(0);
 	sendSimCommand(cmd);
@@ -150,19 +150,19 @@ void SimFieldView::drawTeamSpace(QPainter& p)
 		p.setPen(QPen(Qt::white, 0.1f));
 		Geometry2d::Point ball = frame->ball().pos();
 		p.drawLine(ball.toQPointF(), _dragTo.toQPointF());
-		
+
 		if (ball != _dragTo)
 		{
 			p.setPen(QPen(Qt::gray, 0.1f));
-			
+
 			_shot = (ball - _dragTo) * ShootScale;
 			float speed = _shot.mag();
 			Geometry2d::Point shotExtension = ball + _shot / speed * 8;
-			
+
 			p.drawLine(ball.toQPointF(), shotExtension.toQPointF());
 
 			p.setPen(Qt::black);
-			drawText(p, _dragTo.toQPointF(), QString("%1 m/s").arg(speed, 0, 'f', 1));
+			drawText(p, _dragTo.toQPointF(), QString("%1 m/s").arg(speed, 0, 'f', 1), true, false);
 		}
 	}
 }


### PR DESCRIPTION
FieldBackgroundView draws the field including lines, goals, etc,
and FieldView handles drawing the contents of LogFrames like robots,
debug shapes, etc.

I split it out into two classes so I can use the FieldBackgroundView in a path planner testing applet.  The previous FieldView setup only works with LogFrames.

In the process, I also fixed a couple things:
* Robot comet trails used to be drawn based on SSLDetection packets, now they're drawn from filtered robot  positions
* When switching from "Defend +X" to "Defend -X" the comet trails freaked out because of the coordinate change - we now cut off the part before the coordinate switch

@ashaw596, I remember you did some work on FieldView a while ago when we went from Qt 4 to Qt 5.  Can you look over this when you get a chance and see if there are any issues or if you have suggestions?  Thanks!