### PR TITLE
Add better failure checking for coordinated_pass

### DIFF
--- a/common/Geometry2d/Polygon.hpp
+++ b/common/Geometry2d/Polygon.hpp
@@ -13,14 +13,14 @@ namespace Geometry2d
     public:
         Polygon() {}
         Polygon(const Rect &rect);
-        
+
         /// Creates a rectangle of arbitrary orientation which encloses
         /// all points within a distance r of the given segment.
         Polygon(const Segment &seg, float r)
         {
             init(seg, r, seg.length());
         }
-        
+
         /// Same as above but with length given to avoid a square root.
         Polygon(const Segment &seg, float r, float length)
         {
@@ -30,7 +30,7 @@ namespace Geometry2d
         Polygon(const Polygon &other) : vertices(other.vertices) {}
 
         Shape *clone() const;
-        
+
         bool containsPoint(const Point &pt) const {
             return contains(pt);
         }
@@ -41,15 +41,15 @@ namespace Geometry2d
 
         bool hit(const Geometry2d::Point &pt) const;
         bool hit(const Geometry2d::Segment &seg) const;
-        
+
         /// Returns true if this polygon contains any vertex of other.
         bool containsVertex(const Polygon &other) const;
-        
+
         bool nearPoint(const Point &pt, float threshold) const;
         bool nearSegment(const Segment &seg, float threshold) const;
-        
+
         Rect bbox() const;
-        
+
         std::vector<Point> vertices;
 
         void addVertex(const Point &pt) {
@@ -64,7 +64,7 @@ namespace Geometry2d
             str << ">";
             return str.str();
         }
-    
+
     protected:
         /// Used by constructors
         void init(const Segment &seg, float r, float length);

--- a/soccer/SystemState.cpp
+++ b/soccer/SystemState.cpp
@@ -86,6 +86,18 @@ void SystemState::drawPolygon(const std::vector<Geometry2d::Point>& pts, const Q
 	dbg->set_color(color(qc));
 }
 
+void SystemState::drawPolygon(const Geometry2d::Polygon& points, const QColor &qc, const QString &layer)
+{
+    const std::vector<Geometry2d::Point>& pts = points.vertices;
+    DebugPath *dbg = logFrame->add_debug_polygons();
+    dbg->set_layer(findDebugLayer(layer));
+    for (size_t i = 0; i < pts.size(); ++i)
+    {
+        *dbg->add_points() = pts[i];
+    }
+    dbg->set_color(color(qc));
+}
+
 void SystemState::drawCircle(const Geometry2d::Point& center, float radius, const QColor& qc, const QString &layer)
 {
 	DebugCircle *dbg = logFrame->add_debug_circles();

--- a/soccer/SystemState.hpp
+++ b/soccer/SystemState.hpp
@@ -10,6 +10,7 @@
 #include <Geometry2d/CompositeShape.hpp>
 #include <Geometry2d/Segment.hpp>
 #include <Geometry2d/Point.hpp>
+#include <Geometry2d/Polygon.hpp>
 #include <protobuf/RadioTx.pb.h>
 #include <protobuf/RadioRx.pb.h>
 #include <GameState.hpp>
@@ -78,10 +79,12 @@ public:
 	/** @ingroup drawing_functions */
 	void drawCircle(const Geometry2d::Point &center, float radius, const QColor &color = Qt::black, const QString &layer = QString());
 	/** @ingroup drawing_functions */
+    void drawPolygon(const Geometry2d::Polygon &pts, const QColor &color = Qt::black, const QString &layer = QString());
+    /** @ingroup drawing_functions */
 	void drawPolygon(const Geometry2d::Point *pts, int n, const QColor &color = Qt::black, const QString &layer = QString());
 	/** @ingroup drawing_functions */
 	void drawPolygon(const std::vector<Geometry2d::Point>& pts, const QColor &color = Qt::black, const QString &layer = QString());
-	/** @ingroup drawing_functions */
+    /** @ingroup drawing_functions */
 	void drawText(const QString &text, const Geometry2d::Point &pos, const QColor &color = Qt::black, const QString &layer = QString());
 	/** @ingroup drawing_functions */
 	void drawShape(const std::shared_ptr<Geometry2d::Shape>& obs, const QColor &color = Qt::black, const QString &layer = QString());

--- a/soccer/gameplay/constants.py
+++ b/soccer/gameplay/constants.py
@@ -28,7 +28,7 @@ class Robot:
 class Ball:
     Radius = 0.0215
     Mass = 0.04593 # mass of golf ball (kg)
-    
+
 
 class Field:
     Length = 9.00
@@ -48,11 +48,11 @@ class Field:
     # Radius of the goal arcs
     ArcRadius = 1.0
 
-    # diameter of the center circle 
+    # diameter of the center circle
     CenterRadius = 0.5
     CenterDiameter = 1.0
 
-    # flat area for defense markings 
+    # flat area for defense markings
     GoalFlat = 0.5
 
     FloorLength = Length + 2.0 * Border;

--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -40,7 +40,7 @@ void translateException(NullArgumentException const& e)
 
 /**
  * NOTES FOR WRAPPER FUNCTIONS/METHODS
- * 
+ *
  * Keep in mind that pointer parameters will be be nullptr/NULL if the value
  * from python was None.  Check for this case so that we don't segfault.
  */
@@ -246,6 +246,10 @@ void State_draw_polygon(SystemState *self, boost::python::list points, boost::py
 	self->drawPolygon(ptVec, Color_from_tuple(rgb), QString::fromStdString(layer));
 }
 
+void State_draw_raw_polygon(SystemState *self, Geometry2d::Polygon points, boost::python::tuple rgb, const std::string &layer) {
+    self->drawPolygon(points, Color_from_tuple(rgb), QString::fromStdString(layer));
+}
+
 boost::python::list Circle_intersects_line(Geometry2d::Circle *self, const Geometry2d::Line *line) {
 	if(line == nullptr)
 		throw NullArgumentException("line");
@@ -414,7 +418,8 @@ BOOST_PYTHON_MODULE(robocup)
 	;
 
 	class_<Geometry2d::Polygon, bases<Geometry2d::Shape> >("Polygon", init<>())
-		.def("add_vertex", &Polygon_add_vertex);
+		.def("add_vertex", &Polygon_add_vertex)
+        .def("contains_point", &Geometry2d::Polygon::containsPoint)
 	;
 
 	class_<GameState>("GameState")
@@ -523,6 +528,7 @@ BOOST_PYTHON_MODULE(robocup)
 		.def("draw_shape", &SystemState::drawShape)
 		.def("draw_line", &State_draw_line)
 		.def("draw_polygon", &State_draw_polygon)
+        .def("draw_raw_polygon", &State_draw_raw_polygon)
 	;
 
 	class_<Field_Dimensions>("Field_Dimensions")

--- a/soccer/gameplay/skills/pass_receive.py
+++ b/soccer/gameplay/skills/pass_receive.py
@@ -4,6 +4,7 @@ import robocup
 import constants
 import main
 import enum
+import math
 import time
 
 
@@ -29,9 +30,7 @@ class PassReceive(single_robot_behavior.SingleRobotBehavior):
     SteadyMaxVel = 0.04
     SteadyMaxAngleVel = 3   # degrees / second
 
-    ## after this amount of time has elapsed after the kick and we haven't received the ball, we failed :(
-    ReceiveTimeout = 2
-
+    MarginAngle = 0.25
 
 
     class State(enum.Enum):
@@ -40,7 +39,7 @@ class PassReceive(single_robot_behavior.SingleRobotBehavior):
 
         ## being in this state signals that we're ready for the kicker to kick
         aligned = 2
-        
+
         ## the ball's been kicked and we're adjusting based on where the ball's moving
         receiving = 3
 
@@ -51,6 +50,8 @@ class PassReceive(single_robot_behavior.SingleRobotBehavior):
         self.ball_kicked = False
         self._target_pos = None
         self._ball_kick_time = 0
+        self.kicked_from = None
+        self.kicked_vel = None
 
 
         for state in PassReceive.State:
@@ -85,7 +86,8 @@ class PassReceive(single_robot_behavior.SingleRobotBehavior):
 
         self.add_transition(PassReceive.State.receiving,
             behavior.Behavior.State.failed,
-            lambda: time.time() - self._ball_kick_time > PassReceive.ReceiveTimeout,
+            # TODO look here
+            lambda: self.check_failure(),
             'ball missed :(')
 
 
@@ -100,7 +102,7 @@ class PassReceive(single_robot_behavior.SingleRobotBehavior):
         self._ball_kicked = value
         if value:
             self._ball_kick_time = time.time()
-    
+
 
     ## The point that the receiver should expect the ball to hit it's mouth
     # Default: None
@@ -194,6 +196,29 @@ class PassReceive(single_robot_behavior.SingleRobotBehavior):
         if self._target_pos != None:
             self.robot.move_to(self._target_pos)
 
+    def on_enter_receiving(self):
+        # Extrapolate center of robot location from kick velocity
+        self.kicked_from = main.ball().pos - (main.ball().vel / main.ball().vel.mag()) * constants.Robot.Radius * 4
+        self.kicked_vel = main.ball().vel
+
+    def check_failure(self):
+        pass_distance = self.kicked_from.dist_to(self.robot.pos)
+        offset = pass_distance * math.sin(PassReceive.MarginAngle)
+
+        good_area = robocup.Polygon()
+        good_area.add_vertex(robocup.Point(self.kicked_from.x + constants.Robot.Radius * math.cos(math.pi / 2 + self.kicked_vel.angle()),
+            self.kicked_from.y + constants.Robot.Radius * math.sin(math.pi / 2 + self.kicked_vel.angle())))
+        good_area.add_vertex(robocup.Point(self.kicked_from.x - constants.Robot.Radius * math.cos(math.pi / 2 + self.kicked_vel.angle()),
+            self.kicked_from.y - constants.Robot.Radius * math.sin(math.pi / 2 + self.kicked_vel.angle())))
+
+        good_area.add_vertex(robocup.Point(self.robot.pos.x - offset * math.cos(math.pi / 2 + self.kicked_vel.angle()),
+            self.robot.pos.y - offset * math.sin(math.pi / 2 + self.kicked_vel.angle())))
+        good_area.add_vertex(robocup.Point(self.robot.pos.x + offset * math.cos(math.pi / 2 + self.kicked_vel.angle()),
+            self.robot.pos.y + offset * math.sin(math.pi / 2 + self.kicked_vel.angle())))
+
+        main.system_state().draw_raw_polygon(good_area, constants.Colors.Green, "Good Pass Area")
+        return not good_area.contains_point(main.ball().pos)
+
 
     def execute_receiving(self):
         self.robot.set_dribble_speed(PassReceive.DribbleSpeed)
@@ -202,7 +227,6 @@ class PassReceive(single_robot_behavior.SingleRobotBehavior):
         pos_error = self._target_pos - self.robot.pos
         vel = pos_error * 3.5
         self.robot.set_world_vel(vel)
-
 
     ## prefer a robot that's already near the receive position
     def role_requirements(self):


### PR DESCRIPTION
Added better failure checking for the python coordinated_pass

It draws a triangle from the kick point to the receiver, and fails the pass if outside the area. I've set the angle for this triangle to 0.25 rads, which seems to err on keeping the play running when passes are bad. In the future, this angle should be set to what our robots are capable of reaching.

Either way, we should probably test this before merging.

TODO: These changes need to be applied to angle_receive in some way. It should be very similar to what is being done in pass_receive though.