### PR TITLE
Let coordinatedpass select the closest robot to the true receive point

### DIFF
--- a/soccer/gameplay/skills/pass_receive.py
+++ b/soccer/gameplay/skills/pass_receive.py
@@ -244,6 +244,9 @@ class PassReceive(single_robot_behavior.SingleRobotBehavior):
     ## prefer a robot that's already near the receive position
     def role_requirements(self):
         reqs = super().role_requirements()
+        if self._target_pos != None:
+            reqs.destination_shape = self._target_pos
+            return reqs
         if self.receive_point != None:
             reqs.destination_shape = self.receive_point
         return reqs


### PR DESCRIPTION
This is pretty tiny, but I want to save it until after comp, this is more of a reminder for myself. 

This tells coordinated pass to select the best robot to intercept the ball during a pass, rather than the closest robot to the agreed target position.