### PR TITLE
added `make modernize` to run the clang c++ modernizer

### DIFF
--- a/common/Geometry2d/Circle.hpp
+++ b/common/Geometry2d/Circle.hpp
@@ -77,15 +77,15 @@ namespace Geometry2d
         // Returns the number of points at which this circle intersects the given circle.
         // i must be null or point to two points.
         // Only the first n points in i are modified, where n is the return value.
-        int intersects(Circle &other, Point *i = 0) const;
+        int intersects(Circle &other, Point *i = nullptr) const;
         
         // Returns the number of points at which this circle intersects the given line.
         // i must be null or point to two points.
         // Only the first n points in i are modified, where n is the return value.
-        int intersects(const Line &line, Point *i = 0) const;
+        int intersects(const Line &line, Point *i = nullptr) const;
         
         bool tangentPoints(const Geometry2d::Point &src, 
-                Geometry2d::Point* p1 = 0, Geometry2d::Point* p2 = 0) const;
+                Geometry2d::Point* p1 = nullptr, Geometry2d::Point* p2 = nullptr) const;
         
         // finds the point on the circle closest to P
         Point nearestPoint(const Geometry2d::Point &P) const;

--- a/common/Geometry2d/Circle.hpp
+++ b/common/Geometry2d/Circle.hpp
@@ -27,7 +27,7 @@ namespace Geometry2d
             _r = other.radius();
         }
 
-        Shape *clone() const;
+        Shape *clone() const override;
         
 
         // Both radius and radius-squared are stored, since some operations are more
@@ -68,11 +68,11 @@ namespace Geometry2d
             _rsq = -1;
         }
         
-        bool containsPoint(const Point &pt) const;
+        bool containsPoint(const Point &pt) const override;
 
-        bool hit(const Point &pt) const;
+        bool hit(const Point &pt) const override;
 
-        bool hit(const Segment &pt) const;
+        bool hit(const Segment &pt) const override;
         
         // Returns the number of points at which this circle intersects the given circle.
         // i must be null or point to two points.
@@ -92,7 +92,7 @@ namespace Geometry2d
 
         Point center;
 
-        std::string toString() {
+        std::string toString() override {
             std::stringstream str;
             str << "Circle<" << center << ", " << radius() << ">";
             return str.str();

--- a/common/Geometry2d/CompositeShape.hpp
+++ b/common/Geometry2d/CompositeShape.hpp
@@ -32,9 +32,9 @@ namespace Geometry2d {
             }
         }
 
-        Shape *clone() const;
+        Shape *clone() const override;
 
-        virtual bool containsPoint(const Point &pt) const;
+        virtual bool containsPoint(const Point &pt) const override;
 
         void add(const std::shared_ptr<Shape> shape);
 
@@ -106,11 +106,11 @@ namespace Geometry2d {
             return false;
         }
 
-        bool hit(const Point &pt) const {
+        bool hit(const Point &pt) const override {
             return hit<Point>(pt);
         }
 
-        bool hit(const Segment &seg) const {
+        bool hit(const Segment &seg) const override {
             return hit<Segment>(seg);
         }
 
@@ -127,7 +127,7 @@ namespace Geometry2d {
         iterator begin() { return _subshapes.begin(); }
         iterator end() { return _subshapes.end(); }
 
-        std::string toString() {
+        std::string toString() override {
             std::stringstream str;
             str << "Composite<";
             for(int i = 0; i < _subshapes.size(); i++)

--- a/common/Geometry2d/Line.hpp
+++ b/common/Geometry2d/Line.hpp
@@ -54,10 +54,10 @@ namespace Geometry2d
 			@param intr set to the intersection point if the lines intersect
 			@return true if the lines intersect, false otherwise
 			*/
-			bool intersects(const Line &other, Point *intersection = 0) const;
+			bool intersects(const Line &other, Point *intersection = nullptr) const;
 			
 			/** returns the points of intersection b/t circle and line */
-			bool intersects(const Circle& circle, Point* p1 = 0, Point* p2 = 0) const;
+			bool intersects(const Circle& circle, Point* p1 = nullptr, Point* p2 = nullptr) const;
             
 			/**
 			 * tells you which side of the line you are on

--- a/common/Geometry2d/Polygon.hpp
+++ b/common/Geometry2d/Polygon.hpp
@@ -29,9 +29,9 @@ namespace Geometry2d
 
         Polygon(const Polygon &other) : vertices(other.vertices) {}
 
-        Shape *clone() const;
+        Shape *clone() const override;
         
-        bool containsPoint(const Point &pt) const {
+        bool containsPoint(const Point &pt) const override {
             return contains(pt);
         }
 
@@ -39,8 +39,8 @@ namespace Geometry2d
         bool intersects(const Rect &rect) const;
         bool intersects(const Polygon &other) const;
 
-        bool hit(const Geometry2d::Point &pt) const;
-        bool hit(const Geometry2d::Segment &seg) const;
+        bool hit(const Geometry2d::Point &pt) const override;
+        bool hit(const Geometry2d::Segment &seg) const override;
         
         /// Returns true if this polygon contains any vertex of other.
         bool containsVertex(const Polygon &other) const;
@@ -56,7 +56,7 @@ namespace Geometry2d
             vertices.push_back(pt);
         }
 
-        std::string toString() {
+        std::string toString() override {
             std::stringstream str;
             str << "Polygon<";
             for(int i = 0; i < vertices.size(); i++)

--- a/common/Geometry2d/Rect.hpp
+++ b/common/Geometry2d/Rect.hpp
@@ -31,7 +31,7 @@ namespace Geometry2d
 				pt[1] = other.pt[1];
 			}
 
-			Shape *clone() const;
+			Shape *clone() const override;
 
 			Rect &operator+=(const Point &offset)
 			{
@@ -70,16 +70,16 @@ namespace Geometry2d
 			bool contains(const Point &other) const;
 			bool contains(const Rect &other) const;
 
-			bool containsPoint(const Point &other) const {
+			bool containsPoint(const Point &other) const override {
 				return contains(other);
 			}
 
 
-	        bool hit(const Point &pt) const {
+	        bool hit(const Point &pt) const override {
 	        	return contains(pt);
 	        }
 
-	        bool hit(const Segment &seg) const;
+	        bool hit(const Segment &seg) const override;
 
 			Point center() const { return (pt[0] + pt[1]) / 2; }
 
@@ -98,7 +98,7 @@ namespace Geometry2d
 			
 			Point pt[2];
 
-			std::string toString() {
+			std::string toString() override {
 				std::stringstream str;
 				str << "Line<" << pt[0] << ", " << pt[1] << ">";
 				return str.str();

--- a/common/Geometry2d/Segment.hpp
+++ b/common/Geometry2d/Segment.hpp
@@ -47,7 +47,7 @@ namespace Geometry2d
 			/** find the nearest point on the segment given @a p */
 			Point nearestPoint(const Point& p) const;
 			
-			bool intersects(const Segment &other, Point *intr = 0) const;
+			bool intersects(const Segment &other, Point *intr = nullptr) const;
 			bool intersects(const Circle& circle) const;
 
 			//	Same as the segment intersection above, but returns the intersection

--- a/common/time.hpp
+++ b/common/time.hpp
@@ -11,7 +11,7 @@ typedef uint64_t Time;
 static inline Time timestamp()
 {
     struct timeval time;
-    gettimeofday(&time, 0);
+    gettimeofday(&time, nullptr);
 
     return (Time)time.tv_sec * 1000000 + (Time)time.tv_usec;
 }

--- a/makefile
+++ b/makefile
@@ -3,10 +3,6 @@ all:
 	mkdir -p build
 	cd build; cmake .. -Wno-dev && make $(MAKE_FLAGS)
 
-static-analysis:
-	mkdir -p build/static-analysis
-	cd build/static-analysis; scan-build cmake ../.. -Wno-dev -DSTATIC_ANALYSIS=ON && scan-build -o output make $(MAKE_FLAGS)
-
 run: all
 	cd run; ./soccer
 run-sim: all
@@ -71,3 +67,15 @@ base2011:
 	cd firmware; scons base2011
 base2011-prog:
 	cd firmware; scons base2011; sudo scons base2011-prog
+
+static-analysis:
+	mkdir -p build/static-analysis
+	cd build/static-analysis; scan-build cmake ../.. -Wno-dev -DSTATIC_ANALYSIS=ON && scan-build -o output make $(MAKE_FLAGS)
+modernize:
+	# Runs CMake with a sepcial flag telling it to output the compilation
+	# database, which lists the files to be compiled and the flags passed to
+	# the compiler for each one. Then runs clang-modernize, using the
+	# compilation database as input, on all c/c++ files in the repo.
+	mkdir -p build
+	cd build; cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -Wno-dev && make $(MAKE_FLAGS)
+	clang-modernize -p build -include=common,logging,simulator,soccer

--- a/makefile
+++ b/makefile
@@ -78,4 +78,7 @@ modernize:
 	# compilation database as input, on all c/c++ files in the repo.
 	mkdir -p build
 	cd build; cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -Wno-dev && make $(MAKE_FLAGS)
+	# You can pass specific flags to clang-modernize if you want it to only run some types of
+	# transformations, rather than all transformations that it's capable of.
+	# See `clang-modernize --help` for more info.
 	clang-modernize -p build -include=common,logging,simulator,soccer

--- a/simulator/RobotTableModel.hpp
+++ b/simulator/RobotTableModel.hpp
@@ -39,16 +39,16 @@ public:
 	const RobotID * robotForRow(int row) const;
 	RobotID * robotForRow(int row);
 
-	virtual int columnCount(const QModelIndex &parent) const;
-	virtual int rowCount(const QModelIndex &parent) const;
+	virtual int columnCount(const QModelIndex &parent) const override;
+	virtual int rowCount(const QModelIndex &parent) const override;
 
-	virtual Qt::ItemFlags flags(const QModelIndex &index) const;
+	virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
 
-	virtual QVariant data(const QModelIndex &index, int role) const;
+	virtual QVariant data(const QModelIndex &index, int role) const override;
 
-	virtual bool setData(const QModelIndex &index, const QVariant &value, int role);
+	virtual bool setData(const QModelIndex &index, const QVariant &value, int role) override;
 
-	virtual QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+	virtual QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
 private:
 	RobotIDMap _yellow, _blue;

--- a/simulator/SimulatorGLUTThread.cpp
+++ b/simulator/SimulatorGLUTThread.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 // Hooks for GLUT
 
-static SimulatorGLUTThread* gSimpleApplication = 0;
+static SimulatorGLUTThread* gSimpleApplication = nullptr;
 
 static void glutKeyboardCallback(unsigned char key, int x, int y) {
 	gSimpleApplication->keyboardCallback(key, x, y);
@@ -45,8 +45,8 @@ static void glutDisplayCallback(void) {
 // SimulatorGLUTThread implementation
 
 SimulatorGLUTThread::SimulatorGLUTThread(int argc, char* argv[], const QString& configFile, bool sendShared, bool showWindow)
-: _argv(argv), _argc(argc), _env(0), _vehicle(0), _blue(false),
-  _camera(0), _cameraHeight(4.f), _minCameraDistance(3.f), _maxCameraDistance(10.f), _showWindow(showWindow), _stopped(false)
+: _argv(argv), _argc(argc), _env(nullptr), _vehicle(nullptr), _blue(false),
+  _camera(nullptr), _cameraHeight(4.f), _minCameraDistance(3.f), _maxCameraDistance(10.f), _showWindow(showWindow), _stopped(false)
 {
 	initialize(configFile, sendShared);
 }

--- a/simulator/SimulatorGLUTThread.hpp
+++ b/simulator/SimulatorGLUTThread.hpp
@@ -58,7 +58,7 @@ public:
 
 private:
 	// Re-implement the run function to start the process
-	void run();
+	void run() override;
 	
 	QMutex _mutex;
 	bool _stopped;

--- a/simulator/SimulatorWindow.hpp
+++ b/simulator/SimulatorWindow.hpp
@@ -13,7 +13,7 @@ class SimulatorWindow: public QMainWindow
 	Q_OBJECT;
 
 public:
-	SimulatorWindow(Environment *value, QWidget *parent = 0);
+	SimulatorWindow(Environment *value, QWidget *parent = nullptr);
 
 private slots:
 	// slots from GUI components

--- a/simulator/bullet_opengl/DemoApplication.cpp
+++ b/simulator/bullet_opengl/DemoApplication.cpp
@@ -58,9 +58,9 @@ extern int gTotalBytesAlignedAllocs;
 DemoApplication::DemoApplication()
 //see btIDebugDraw.h for modes
 :
-m_dynamicsWorld(0),
-m_pickConstraint(0),
-m_shootBoxShape(0),
+m_dynamicsWorld(nullptr),
+m_pickConstraint(nullptr),
+m_shootBoxShape(nullptr),
 m_cameraDistance(15.0),
 m_debugMode(0),
 m_ele(20.f),
@@ -598,7 +598,7 @@ int gPickingConstraintId = 0;
 btVector3 gOldPickingPos;
 btVector3 gHitPos(-1,-1,-1);
 btScalar gOldPickingDist  = 0.f;
-btRigidBody* pickedBody = 0;//for deactivation state
+btRigidBody* pickedBody = nullptr;//for deactivation state
 
 
 btVector3	DemoApplication::getRayTo(int x,int y)
@@ -878,10 +878,10 @@ void DemoApplication::removePickingConstraint()
 		m_dynamicsWorld->removeConstraint(m_pickConstraint);
 		delete m_pickConstraint;
 		//printf("removed constraint %i",gPickingConstraintId);
-		m_pickConstraint = 0;
+		m_pickConstraint = nullptr;
 		pickedBody->forceActivationState(ACTIVE_TAG);
 		pickedBody->setDeactivationTime( 0.f );
-		pickedBody = 0;
+		pickedBody = nullptr;
 	}
 }
 

--- a/simulator/bullet_opengl/GLDebugDrawer.h
+++ b/simulator/bullet_opengl/GLDebugDrawer.h
@@ -14,23 +14,23 @@ public:
 	GLDebugDrawer();
 	virtual ~GLDebugDrawer(); 
 
-	virtual void	drawLine(const btVector3& from,const btVector3& to,const btVector3& fromColor, const btVector3& toColor);
+	virtual void	drawLine(const btVector3& from,const btVector3& to,const btVector3& fromColor, const btVector3& toColor) override;
 
-	virtual void	drawLine(const btVector3& from,const btVector3& to,const btVector3& color);
+	virtual void	drawLine(const btVector3& from,const btVector3& to,const btVector3& color) override;
 
-	virtual void	drawSphere (const btVector3& p, btScalar radius, const btVector3& color);
+	virtual void	drawSphere (const btVector3& p, btScalar radius, const btVector3& color) override;
 
-	virtual void	drawTriangle(const btVector3& a,const btVector3& b,const btVector3& c,const btVector3& color,btScalar alpha);
+	virtual void	drawTriangle(const btVector3& a,const btVector3& b,const btVector3& c,const btVector3& color,btScalar alpha) override;
 	
-	virtual void	drawContactPoint(const btVector3& PointOnB,const btVector3& normalOnB,btScalar distance,int lifeTime,const btVector3& color);
+	virtual void	drawContactPoint(const btVector3& PointOnB,const btVector3& normalOnB,btScalar distance,int lifeTime,const btVector3& color) override;
 
-	virtual void	reportErrorWarning(const char* warningString);
+	virtual void	reportErrorWarning(const char* warningString) override;
 
-	virtual void	draw3dText(const btVector3& location,const char* textString);
+	virtual void	draw3dText(const btVector3& location,const char* textString) override;
 
-	virtual void	setDebugMode(int debugMode);
+	virtual void	setDebugMode(int debugMode) override;
 
-	virtual int		getDebugMode() const { return m_debugMode;}
+	virtual int		getDebugMode() const override { return m_debugMode;}
 
 };
 

--- a/simulator/bullet_opengl/GL_DialogDynamicsWorld.cpp
+++ b/simulator/bullet_opengl/GL_DialogDynamicsWorld.cpp
@@ -25,10 +25,10 @@ subject to the following restrictions:
 
 GL_DialogDynamicsWorld::GL_DialogDynamicsWorld()
 {
-	m_upperBorder = 0;
-	m_lowerBorder =0;
+	m_upperBorder = nullptr;
+	m_lowerBorder =nullptr;
 
-	m_pickConstraint = 0;
+	m_pickConstraint = nullptr;
 	m_screenWidth = 0;
 	m_screenHeight = 0;
 
@@ -191,7 +191,7 @@ GL_DialogWindow*	GL_DialogDynamicsWorld::createDialog(int horPos,int vertPos,int
 	btScalar mass = 100.f;
 	btVector3 localInertia;
 	boxShape->calculateLocalInertia(mass,localInertia);
-	btRigidBody::btRigidBodyConstructionInfo rbInfo(mass,0,boxShape,localInertia);
+	btRigidBody::btRigidBodyConstructionInfo rbInfo(mass,nullptr,boxShape,localInertia);
 	btRigidBody* body = new btRigidBody(rbInfo);
 	btTransform trans;
 	trans.setIdentity();
@@ -222,7 +222,7 @@ GL_SliderControl* GL_DialogDynamicsWorld::createSlider(GL_DialogWindow* dialog, 
 	btScalar mass = .1f;
 	btVector3 localInertia;
 	boxShape->calculateLocalInertia(mass,localInertia);
-	btRigidBody::btRigidBodyConstructionInfo rbInfo(mass,0,boxShape,localInertia);
+	btRigidBody::btRigidBodyConstructionInfo rbInfo(mass,nullptr,boxShape,localInertia);
 	btRigidBody* body = new btRigidBody(rbInfo);
 	btTransform trans;
 	trans.setIdentity();
@@ -301,7 +301,7 @@ GL_ToggleControl* GL_DialogDynamicsWorld::createToggle(GL_DialogWindow* dialog, 
 	btScalar mass = 0.1f;
 	btVector3 localInertia;
 	boxShape->calculateLocalInertia(mass,localInertia);
-	btRigidBody::btRigidBodyConstructionInfo rbInfo(mass,0,boxShape,localInertia);
+	btRigidBody::btRigidBodyConstructionInfo rbInfo(mass,nullptr,boxShape,localInertia);
 	btRigidBody* body = new btRigidBody(rbInfo);
 	btTransform trans;
 	trans.setIdentity();
@@ -361,7 +361,7 @@ void	GL_DialogDynamicsWorld::draw(btScalar timeStep)
 	}
 }
 
-static btRigidBody* pickedBody = 0;//for deactivation state
+static btRigidBody* pickedBody = nullptr;//for deactivation state
 static btScalar mousePickClamping = 111130.f;
 
 //static int gPickingConstraintId = 0;
@@ -542,7 +542,7 @@ bool GL_DialogDynamicsWorld::mouseFunc(int button, int state, int x, int y)
 					m_dynamicsWorld->removeConstraint(m_pickConstraint);
 					delete m_pickConstraint;
 					//printf("removed constraint %i",gPickingConstraintId);
-					m_pickConstraint = 0;
+					m_pickConstraint = nullptr;
 					pickedBody->forceActivationState(ACTIVE_TAG);
 					pickedBody->setDeactivationTime( 0.f );
 					
@@ -555,7 +555,7 @@ bool GL_DialogDynamicsWorld::mouseFunc(int button, int state, int x, int y)
 						{
 							GL_SliderControl* sliderControl = (GL_SliderControl*) ctrl;
 							
-							btSliderConstraint* slider = 0;
+							btSliderConstraint* slider = nullptr;
 							btTypedConstraint* constraint = sliderControl->getConstraint();
 							if (constraint->getConstraintType() == SLIDER_CONSTRAINT_TYPE)
 							{
@@ -587,7 +587,7 @@ bool GL_DialogDynamicsWorld::mouseFunc(int button, int state, int x, int y)
 								
 					}
 					
-					pickedBody = 0;
+					pickedBody = nullptr;
 
 				}
 				

--- a/simulator/bullet_opengl/GL_DialogWindow.h
+++ b/simulator/bullet_opengl/GL_DialogWindow.h
@@ -89,7 +89,7 @@ public:
 	
 	virtual ~GL_TextControl() {}
 
-	virtual void draw(int& parentHorPos,int& parentVertPos,btScalar deltaTime);
+	virtual void draw(int& parentHorPos,int& parentVertPos,btScalar deltaTime) override;
 };
 
 
@@ -114,7 +114,7 @@ public:
 		m_type = GL_TOGGLE_CONTROL;
 	}
 
-	virtual void draw(int& parentHorPos,int& parentVertPos,btScalar deltaTime);
+	virtual void draw(int& parentHorPos,int& parentVertPos,btScalar deltaTime) override;
 };
 
 struct GL_SliderControl : public GL_DialogControl
@@ -140,7 +140,7 @@ public:
 		m_type = GL_SLIDER_CONTROL;
 	}
 
-	virtual void draw(int& parentHorPos,int& parentVertPos,btScalar deltaTime);
+	virtual void draw(int& parentHorPos,int& parentVertPos,btScalar deltaTime) override;
 
 	btScalar	btGetFraction() { return m_fraction; }
 

--- a/simulator/bullet_opengl/GL_ShapeDrawer.cpp
+++ b/simulator/bullet_opengl/GL_ShapeDrawer.cpp
@@ -361,7 +361,7 @@ GL_ShapeDrawer::ShapeCache*		GL_ShapeDrawer::cache(btConvexShape* shape)
 		const btVector3*	pv=sc->m_shapehull.getVertexPointer();
 		btAlignedObjectArray<ShapeCache::Edge*>	edges;
 		sc->m_edges.reserve(ni);
-		edges.resize(nv*nv,0);
+		edges.resize(nv*nv,nullptr);
 		for(int i=0;i<ni;i+=3)
 		{
 			const unsigned int* ti=pi+i;
@@ -726,7 +726,7 @@ void GL_ShapeDrawer::drawOpenGL(btScalar* m, const btCollisionShape* shape, cons
 				{
 					if (shape->isConvex())
 					{
-						const btConvexPolyhedron* poly = shape->isPolyhedral() ? ((btPolyhedralConvexShape*) shape)->getConvexPolyhedron() : 0;
+						const btConvexPolyhedron* poly = shape->isPolyhedral() ? ((btPolyhedralConvexShape*) shape)->getConvexPolyhedron() : nullptr;
 						if (poly)
 						{
 							int i;

--- a/simulator/bullet_opengl/GL_ShapeDrawer.cpp
+++ b/simulator/bullet_opengl/GL_ShapeDrawer.cpp
@@ -211,7 +211,7 @@ public:
 	{
 	}
 
-	virtual void processTriangle(btVector3* triangle,int partId, int triangleIndex)
+	virtual void processTriangle(btVector3* triangle,int partId, int triangleIndex) override
 	{
 
 		(void)triangleIndex;
@@ -252,7 +252,7 @@ public:
 class TriangleGlDrawcallback : public btInternalTriangleIndexCallback
 {
 public:
-	virtual void internalProcessTriangleIndex(btVector3* triangle,int partId,int  triangleIndex)
+	virtual void internalProcessTriangleIndex(btVector3* triangle,int partId,int  triangleIndex) override
 	{
 		(void)triangleIndex;
 		(void)partId;

--- a/simulator/bullet_opengl/GL_Simplex1to4.cpp
+++ b/simulator/bullet_opengl/GL_Simplex1to4.cpp
@@ -30,7 +30,7 @@ subject to the following restrictions:
 #include "LinearMath/btTransform.h"
 
 GL_Simplex1to4::GL_Simplex1to4()
-:m_simplexSolver(0)
+:m_simplexSolver(nullptr)
 {
 }
 

--- a/simulator/bullet_opengl/GlutDemoApplication.h
+++ b/simulator/bullet_opengl/GlutDemoApplication.h
@@ -25,11 +25,11 @@ public:
 
 	BT_DECLARE_ALIGNED_ALLOCATOR();
 
-	void specialKeyboard(int key, int x, int y);
+	void specialKeyboard(int key, int x, int y) override;
 
-	virtual void swapBuffers();
+	virtual void swapBuffers() override;
 
-	virtual	void	updateModifierKeys();
+	virtual	void	updateModifierKeys() override;
 
 };
 #endif //GLUT_DEMO_APPLICATION_H

--- a/simulator/bullet_opengl/GlutStuff.cpp
+++ b/simulator/bullet_opengl/GlutStuff.cpp
@@ -18,7 +18,7 @@ subject to the following restrictions:
 #include "DemoApplication.h"
 
 //glut is C code, this global gDemoApplication links glut to the C++ demo
-static DemoApplication* gDemoApplication = 0;
+static DemoApplication* gDemoApplication = nullptr;
 
 
 #include "GlutStuff.h"

--- a/simulator/physics/Ball.cpp
+++ b/simulator/physics/Ball.cpp
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 Ball::Ball(Environment* env) :
-		Entity(env), _ball(0), _ballShape(0), _simEngine(env->getSimEngine())
+		Entity(env), _ball(nullptr), _ballShape(nullptr), _simEngine(env->getSimEngine())
 {
 }
 

--- a/simulator/physics/Ball.hpp
+++ b/simulator/physics/Ball.hpp
@@ -18,10 +18,10 @@ public:
 	Ball(Environment* env);
 	virtual ~Ball();
 
-	virtual void position(float x, float y);
+	virtual void position(float x, float y) override;
 	virtual void velocity(float x, float y);
 
-	virtual Geometry2d::Point getPosition() const;
+	virtual Geometry2d::Point getPosition() const override;
 
 	void initPhysics();
 

--- a/simulator/physics/Environment.cpp
+++ b/simulator/physics/Environment.cpp
@@ -59,7 +59,7 @@ void Environment::connectSockets() {
 		throw std::runtime_error("Unable to bind sockets.  Is there another instance of simulator already running?");
 	}
 
-	gettimeofday(&_lastStepTime, 0);
+	gettimeofday(&_lastStepTime, nullptr);
 
 	connect(&_timer, SIGNAL(timeout()), SLOT(step()));
 	_timer.start(16 / Oversample);
@@ -109,7 +109,7 @@ void Environment::step()
 
 	// timing
 	struct timeval tv;
-	gettimeofday(&tv, 0);
+	gettimeofday(&tv, nullptr);
 	_lastStepTime = tv;
 
 	// execute simulation step
@@ -211,7 +211,7 @@ void Environment::sendVision()
 	det->set_camera_id(0);
 
 	struct timeval tv;
-	gettimeofday(&tv, 0);
+	gettimeofday(&tv, nullptr);
 	det->set_t_capture(tv.tv_sec + (double)tv.tv_usec * 1.0e-6);
 	det->set_t_sent(det->t_capture());
 
@@ -380,9 +380,9 @@ Robot *Environment::robot(bool blue, int board_id) const
 
 	if (robots.contains(board_id))
 	{
-		return robots.value(board_id,0);
+		return robots.value(board_id,nullptr);
 	} else {
-		return 0;
+		return nullptr;
 	}
 }
 

--- a/simulator/physics/FastTimer.cpp
+++ b/simulator/physics/FastTimer.cpp
@@ -9,8 +9,8 @@ FastTimer::FastTimer(QObject* parent):
     _us(0),
     _running(false)
 {
-    pthread_mutex_init(&_mutex, 0);
-    pthread_cond_init(&_cond, 0);
+    pthread_mutex_init(&_mutex, nullptr);
+    pthread_cond_init(&_cond, nullptr);
 }
 
 FastTimer::~FastTimer()
@@ -48,19 +48,19 @@ void FastTimer::stop()
 void FastTimer::run()
 {
     struct timeval start;
-    gettimeofday(&start, 0);
+    gettimeofday(&start, nullptr);
     pthread_mutex_lock(&_mutex);
     while (_running)
     {
         struct timeval t;
-        gettimeofday(&t, 0);
+        gettimeofday(&t, nullptr);
         useconds_t us = (t.tv_sec - start.tv_sec) * 1000000 + t.tv_usec - start.tv_usec;
         start = t;
 
         if (_us > us)
         {
             usleep(_us-us);
-            gettimeofday(&start, 0);
+            gettimeofday(&start, nullptr);
         }
 
         QApplication::instance()->postEvent(this, new QEvent(QEvent::User));

--- a/simulator/physics/FastTimer.hpp
+++ b/simulator/physics/FastTimer.hpp
@@ -14,7 +14,7 @@ class FastTimer: public QThread
     Q_OBJECT;
 
 public:
-    FastTimer(QObject *parent = 0);
+    FastTimer(QObject *parent = nullptr);
     virtual ~FastTimer();
 
     void start(int ms);

--- a/simulator/physics/FastTimer.hpp
+++ b/simulator/physics/FastTimer.hpp
@@ -24,8 +24,8 @@ signals:
     void timeout();
 
 protected:
-    virtual void run();
-    virtual bool event(QEvent *e);
+    virtual void run() override;
+    virtual bool event(QEvent *e) override;
 
     useconds_t _us;
     volatile bool _running;

--- a/simulator/physics/Field.cpp
+++ b/simulator/physics/Field.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 
 Field::Field(Environment* env) :
-	Entity(env),_indexVertexArrays(0),_vertices(0),_simEngine(env->getSimEngine()),_x(0),_y(0)
+	Entity(env),_indexVertexArrays(nullptr),_vertices(nullptr),_simEngine(env->getSimEngine()),_x(0),_y(0)
 {
 }
 

--- a/simulator/physics/Field.hpp
+++ b/simulator/physics/Field.hpp
@@ -23,7 +23,7 @@ public:
 	virtual ~Field();
 
 	// Translates the origin of the field
-	void position(float x, float y) { _x = x; _y = y; }
+	void position(float x, float y) override { _x = x; _y = y; }
 
 	void initPhysics();
 

--- a/simulator/physics/GlutCamera.cpp
+++ b/simulator/physics/GlutCamera.cpp
@@ -6,7 +6,7 @@
 using namespace std;
 
 GlutCamera::GlutCamera(SimEngine* engine) :
-		_mode(0),_vehicle(0),
+		_mode(0),_vehicle(nullptr),
 		_cameraDistance(1.0*scaling), _ele(20.f), _azi(0.f), _cameraPosition(0.f, 0.f, 0.f),
 		_cameraTargetPosition(0.f, 0.f, 0.f), _scaleBottom(0.5f), _scaleFactor(2.f),
 		_cameraUp(0, 1, 0), _forwardAxis(2), _glutScreenWidth(0), _glutScreenHeight(0),

--- a/simulator/physics/GlutCamera.hpp
+++ b/simulator/physics/GlutCamera.hpp
@@ -56,7 +56,7 @@ protected:
 	SimEngine *_simEngine;
 
 public:
-	GlutCamera(SimEngine* engine = 0);
+	GlutCamera(SimEngine* engine = nullptr);
 	virtual ~GlutCamera();
 
 	bool setTexturing(bool enable) { return (_shapeDrawer->enableTexture(enable)); }

--- a/simulator/physics/RaycastVehicle.cpp
+++ b/simulator/physics/RaycastVehicle.cpp
@@ -174,7 +174,7 @@ btScalar RaycastVehicle::rayCast(btWheelInfo& wheel)
 
 	void* object = m_vehicleRaycaster->castRay(source,target,rayResults);
 
-	wheel.m_raycastInfo.m_groundObject = 0;
+	wheel.m_raycastInfo.m_groundObject = nullptr;
 
 	if (object)
 	{
@@ -737,5 +737,5 @@ void* DefaultVehicleRaycaster::castRay(const btVector3& from,const btVector3& to
 			return body;
 		}
 	}
-	return 0;
+	return nullptr;
 }

--- a/simulator/physics/RaycastVehicle.hpp
+++ b/simulator/physics/RaycastVehicle.hpp
@@ -57,7 +57,7 @@ public:
 
 
 	///btActionInterface interface
-	virtual void updateAction( btCollisionWorld* collisionWorld, btScalar step)
+	virtual void updateAction( btCollisionWorld* collisionWorld, btScalar step) override
 	{
         (void) collisionWorld;
 		updateVehicle(step);
@@ -65,7 +65,7 @@ public:
 	
 
 	///btActionInterface interface
-	void debugDraw(btIDebugDraw* debugDrawer);
+	void debugDraw(btIDebugDraw* debugDrawer) override;
 			
 	const btTransform& getChassisWorldTransform() const;
 	
@@ -223,7 +223,7 @@ public:
 	{
 	}
 
-	virtual void* castRay(const btVector3& from,const btVector3& to, btVehicleRaycasterResult& result);
+	virtual void* castRay(const btVector3& from,const btVector3& to, btVehicleRaycasterResult& result) override;
 };
 
 

--- a/simulator/physics/Robot.cpp
+++ b/simulator/physics/Robot.cpp
@@ -29,7 +29,7 @@ static const float robotWeight = 8*scaling;
 
 Robot::Robot(Environment* env, unsigned int id,  Robot::RobotRevision rev, const Geometry2d::Point& startPos) :
 	Entity(env),shell(id), _rev(rev),
-	_robotChassis(0), _robotVehicle(0), _wheelShape(0),_controller(0),
+	_robotChassis(nullptr), _robotVehicle(nullptr), _wheelShape(nullptr),_controller(nullptr),
 	_brakingForce(0),_targetVel(0,0,0),_targetRot(0),
 	_simEngine(env->getSimEngine())
 {

--- a/simulator/physics/Robot.hpp
+++ b/simulator/physics/Robot.hpp
@@ -81,11 +81,11 @@ public:
 	//the following are in field space, aka soccer's coordinate system
 
 	// Entity interface
-	virtual void position(float x, float y); // world coords
+	virtual void position(float x, float y) override; // world coords
 
 	virtual void velocity(float x, float y, float w); // body coords
 
-	virtual Geometry2d::Point getPosition() const;
+	virtual Geometry2d::Point getPosition() const override;
 
 	virtual float getAngle() const;
 

--- a/simulator/physics/RobotBallController.cpp
+++ b/simulator/physics/RobotBallController.cpp
@@ -16,7 +16,7 @@ static const float MaxChipVelocity = 3*scaling;
 static const float ChipAngle = 0.34906585;//20 degree
 
 RobotBallController::RobotBallController(Robot* robot) :
-	_ghostObject(0),_localMouthPos(0,0,0),_parent(robot),_ball(0),
+	_ghostObject(nullptr),_localMouthPos(0,0,0),_parent(robot),_ball(nullptr),
 	_simEngine(robot->getSimEngine())
 {
 	ballSensorWorks = true;
@@ -64,7 +64,7 @@ void RobotBallController::initPhysics()
 
 bool RobotBallController::detectBall ( btCollisionWorld* collisionWorld)
 {
-	_ball = 0;
+	_ball = nullptr;
 
 	btManifoldArray   manifoldArray;
 	btBroadphasePairArray& pairArray = _ghostObject->getOverlappingPairCache()->getOverlappingPairArray();
@@ -245,7 +245,7 @@ void RobotBallController::prepareDribbler(uint64_t dribble){
 }
 
 bool RobotBallController::hasBall(){
-	return _ball != 0;
+	return _ball != nullptr;
 }
 
 bool RobotBallController::getKickerStatus(){

--- a/simulator/physics/RobotBallController.hpp
+++ b/simulator/physics/RobotBallController.hpp
@@ -45,14 +45,14 @@ public:
 	void initPhysics();
 
 	///btActionInterface interface
-	virtual void updateAction( btCollisionWorld* collisionWorld,btScalar deltaTime){
+	virtual void updateAction( btCollisionWorld* collisionWorld,btScalar deltaTime) override{
 		detectBall(collisionWorld);
 		dribblerStep();
 		kickerStep();
 	}
 
 	///btActionInterface interface
-	void debugDraw(btIDebugDraw* debugDrawer) {};
+	void debugDraw(btIDebugDraw* debugDrawer) override {};
 
 	bool detectBall(btCollisionWorld* collisionWorld);
 	void dribblerStep();

--- a/simulator/physics/RobotMotionState.hpp
+++ b/simulator/physics/RobotMotionState.hpp
@@ -15,14 +15,14 @@ struct RobotMotionState : public btDefaultMotionState
 	}
 
 	///synchronizes world transform from user to physics
-	virtual void	getWorldTransform(btTransform& centerOfMassWorldTrans ) const
+	virtual void	getWorldTransform(btTransform& centerOfMassWorldTrans ) const override
 	{
 			centerOfMassWorldTrans = 	m_centerOfMassOffset.inverse() * m_graphicsWorldTrans ;
 	}
 
 	///synchronizes world transform from physics to user
 	///Bullet only calls the update of worldtransform for active objects
-	virtual void	setWorldTransform(const btTransform& centerOfMassWorldTrans)
+	virtual void	setWorldTransform(const btTransform& centerOfMassWorldTrans) override
 	{
 			m_graphicsWorldTrans = centerOfMassWorldTrans * m_centerOfMassOffset ;
 			m_controller->syncMotionState(centerOfMassWorldTrans);

--- a/simulator/physics/SimEngine.cpp
+++ b/simulator/physics/SimEngine.cpp
@@ -23,7 +23,7 @@ using namespace std;
 
 
 SimEngine::SimEngine() :
-		_dynamicsWorld(0), _stepping(true), _singleStep(false),
+		_dynamicsWorld(nullptr), _stepping(true), _singleStep(false),
 		_debugMode(0),	_defaultContactProcessingThreshold(BT_LARGE_FLOAT) {}
 
 void SimEngine::initPhysics() {

--- a/simulator/simulator.cpp
+++ b/simulator/simulator.cpp
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
 	struct sigaction act;
 	memset(&act, 0, sizeof(act));
 	act.sa_handler = quit;
-	sigaction(SIGINT, &act, 0);
+	sigaction(SIGINT, &act, nullptr);
 
 	// Create and initialize GUI with environment information
 	SimulatorWindow win(sim_thread.env());

--- a/soccer/BatteryWidget.hpp
+++ b/soccer/BatteryWidget.hpp
@@ -8,7 +8,7 @@
  */
 class BatteryWidget : public QWidget {
 public:
-	BatteryWidget (QWidget *parent = 0, Qt::WindowFlags f = 0);
+	BatteryWidget (QWidget *parent = nullptr, Qt::WindowFlags f = nullptr);
 
 	/**
 	 * @brief Battery level represented by a number between 0 and 1

--- a/soccer/BatteryWidget.hpp
+++ b/soccer/BatteryWidget.hpp
@@ -17,7 +17,7 @@ public:
 	void setBatteryLevel(float batteryLevel);
 
 
-	void paintEvent(QPaintEvent *event);
+	void paintEvent(QPaintEvent *event) override;
 
 
 private:

--- a/soccer/Configuration.cpp
+++ b/soccer/Configuration.cpp
@@ -16,7 +16,7 @@ Q_DECLARE_METATYPE(ConfigItem *) // FIXME: verify this
 ConfigItem::ConfigItem(Configuration *config, const QString& name)
 {
 	_config = config;
-	_treeItem = 0;
+	_treeItem = nullptr;
 	_path = name.split('/');
 }
 
@@ -26,7 +26,7 @@ ConfigItem::~ConfigItem()
 	{
 		//FIXME - Things are getting deleted in a non-GUI thread
 // 		delete _treeItem;
-		_treeItem = 0;
+		_treeItem = nullptr;
 	}
 }
 
@@ -131,7 +131,7 @@ void ConfigDouble::setValue(const QString& str)
 
 Configuration::Configuration()
 {
-	_tree = 0;
+	_tree = nullptr;
 	
 	// Create the XML root element
 	_doc.appendChild(_doc.createElement("config"));
@@ -156,7 +156,7 @@ void Configuration::addToTree(ConfigItem *item)
 	--last;
 	for (QStringList::const_iterator i = path.begin(); i != last; ++i)
 	{
-		QTreeWidgetItem *next = 0;
+		QTreeWidgetItem *next = nullptr;
 		for (int j = 0; j < parent->childCount(); ++j)
 		{
 			QTreeWidgetItem *child = parent->child(j);
@@ -226,7 +226,7 @@ ConfigItem *Configuration::nameLookup(const QString& name) const
 			return item;
 		}
 	}
-	return 0;
+	return nullptr;
 }
 
 bool Configuration::load(const QString &filename, QString &error)

--- a/soccer/Configuration.hpp
+++ b/soccer/Configuration.hpp
@@ -115,12 +115,12 @@ class ConfigBool: public ConfigItem
 			return x;
 		}
 		
-		virtual QString toString();
-		virtual void setValue(const QString &str);
+		virtual QString toString() override;
+		virtual void setValue(const QString &str) override;
 	
 	protected:
 		friend class Configuration;
-		virtual void setupItem();
+		virtual void setupItem() override;
 		
 		bool _value;
 };
@@ -130,8 +130,8 @@ class ConfigInt: public ConfigItem
 	public:
 	ConfigInt(Configuration *tree, QString name, int value = 0);
 
-		virtual QString toString();
-		virtual void setValue(const QString &str);
+		virtual QString toString() override;
+		virtual void setValue(const QString &str) override;
 		
 		operator int() const
 		{
@@ -165,8 +165,8 @@ class ConfigDouble: public ConfigItem
 	public:
 		ConfigDouble(Configuration *tree, QString name, double value = 0);
 		
-		virtual QString toString();
-		virtual void setValue(const QString &str);
+		virtual QString toString() override;
+		virtual void setValue(const QString &str) override;
 		
 		operator double() const
 		{
@@ -220,7 +220,7 @@ template<class T>
 class ConfigurableImpl: public Configurable
 {
 public:
-	virtual void createConfiguration(Configuration *cfg) const
+	virtual void createConfiguration(Configuration *cfg) const override
 	{
 		T::createConfiguration(cfg);
 	}

--- a/soccer/FieldView.cpp
+++ b/soccer/FieldView.cpp
@@ -45,7 +45,7 @@ FieldView::FieldView(QWidget* parent) :
     showDotPatterns = false;
     showTeamNames = false;
 	_rotate = 1;
-	_history = 0;
+	_history = nullptr;
 
 	// Green background
 	QPalette p = palette();

--- a/soccer/FieldView.hpp
+++ b/soccer/FieldView.hpp
@@ -59,8 +59,8 @@ class FieldView : public QWidget
 		bool showTeamNames;
 		
 	protected:
-		virtual void paintEvent(QPaintEvent* e);
-		virtual void resizeEvent(QResizeEvent *e);
+		virtual void paintEvent(QPaintEvent* e) override;
+		virtual void resizeEvent(QResizeEvent *e) override;
 		
 		virtual void drawWorldSpace(QPainter &p);
 		virtual void drawTeamSpace(QPainter &p);

--- a/soccer/FieldView.hpp
+++ b/soccer/FieldView.hpp
@@ -16,7 +16,7 @@ class Logger;
 class FieldView : public QWidget
 {
 	public:
-		FieldView(QWidget* parent = 0);
+		FieldView(QWidget* parent = nullptr);
 		
 		void layerVisible(int i, bool value)
 		{

--- a/soccer/LogViewer.hpp
+++ b/soccer/LogViewer.hpp
@@ -12,7 +12,7 @@ class LogViewer: public QMainWindow
 	Q_OBJECT;
 	
 	public:
-		LogViewer(QWidget *parent = 0);
+		LogViewer(QWidget *parent = nullptr);
 		
 		int frameNumber() const
 		{

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -44,10 +44,10 @@ MainWindow::MainWindow(QWidget *parent):
 {
 	qRegisterMetaType<QVector<int> >("QVector<int>");
 
-	_quaternion_demo = 0;
+	_quaternion_demo = nullptr;
 
 	_updateCount = 0;
-	_processor = 0;
+	_processor = nullptr;
 	_autoExternalReferee = true;
 	_doubleFrameNumber = -1;
 
@@ -321,7 +321,7 @@ void MainWindow::updateViews()
 		// Update the orientation demo view
 		if (_quaternion_demo && manual >= 0 && currentFrame->radio_rx().size() && currentFrame->radio_rx(0).has_quaternion())
 		{
-			const RadioRx *manualRx = 0;
+			const RadioRx *manualRx = nullptr;
 			for (const RadioRx &rx :  currentFrame->radio_rx())
 			{
 				if ((int)rx.robot_id() == manual)
@@ -360,7 +360,7 @@ void MainWindow::updateViews()
 		_ui.behaviorTree->setPlainText(QString::fromStdString(currentFrame->behavior_tree()));
 	}
 
-	if(std::time(0) - (_processor->refereeModule()->received_time/1000000) > 1)
+	if(std::time(nullptr) - (_processor->refereeModule()->received_time/1000000) > 1)
 	{
 		_ui.fastHalt->setEnabled(true);
 		_ui.fastStop->setEnabled(true);
@@ -947,7 +947,7 @@ void MainWindow::on_actionSeed_triggered()
 	QString text = QInputDialog::getText(this, "Set Random Seed", "Hexadecimal seed:");
 	if (!text.isNull())
 	{
-		long seed = strtol(text.toLatin1(), 0, 16);
+		long seed = strtol(text.toLatin1(), nullptr, 16);
 		printf("seed %016lx\n", seed);
 		srand48(seed);
 	}
@@ -1067,7 +1067,7 @@ void MainWindow::on_debugLayers_customContextMenuRequested(const QPoint& pos)
 	QMenu menu;
 	QAction *all = menu.addAction("All");
 	QAction *none = menu.addAction("None");
-	QAction *single = 0, *notSingle = 0;
+	QAction *single = nullptr, *notSingle = nullptr;
 	if (item)
 	{
 		single = menu.addAction("Only this");

--- a/soccer/MainWindow.hpp
+++ b/soccer/MainWindow.hpp
@@ -30,7 +30,7 @@ class MainWindow : public QMainWindow
 
 	public:
 
-		MainWindow(QWidget *parent = 0);
+		MainWindow(QWidget *parent = nullptr);
 
 		void configuration(Configuration *config);
 

--- a/soccer/NewRefereeModule.hpp
+++ b/soccer/NewRefereeModule.hpp
@@ -176,7 +176,7 @@ public:
 	void spinKickWatcher();
 
 protected:
-	virtual void run();
+	virtual void run() override;
 
 	volatile bool _running;
 

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -77,7 +77,7 @@ Processor::Processor(bool sim) : _loopMutex(QMutex::Recursive)
 	_useOpponentHalf = true;
 
 	_simulation = sim;
-	_radio = 0;
+	_radio = nullptr;
 
 	//	joysticks
 	_joysticks.push_back(new GamepadJoystick());

--- a/soccer/Processor.hpp
+++ b/soccer/Processor.hpp
@@ -218,7 +218,7 @@ class Processor: public QThread
 		Time firstLogTime;
 
 	protected:
-		void run();
+		void run() override;
 
 		void applyJoystickControls(const JoystickControlValues &controlVals, Packet::RadioTx::Robot *txRobot, OurRobot *robot);
 

--- a/soccer/ProtobufTree.cpp
+++ b/soccer/ProtobufTree.cpp
@@ -29,9 +29,9 @@ ProtobufTree::ProtobufTree(QWidget *parent):
 	QTreeWidget(parent)
 {
 	_first = true;
-	_history = 0;
-	mainWindow = 0;
-	updateTimer = 0;
+	_history = nullptr;
+	mainWindow = nullptr;
+	updateTimer = nullptr;
 }
 
 bool ProtobufTree::message(const google::protobuf::Message& msg)
@@ -388,7 +388,7 @@ void ProtobufTree::contextMenuEvent(QContextMenuEvent* e)
 {
 	QMenu menu;
 	
-	QAction *expandItemAction = 0, *collapseItemAction = 0;
+	QAction *expandItemAction = nullptr, *collapseItemAction = nullptr;
 	QTreeWidgetItem *item = itemAt(e->pos());
 	if (item)
 	{
@@ -410,11 +410,11 @@ void ProtobufTree::contextMenuEvent(QContextMenuEvent* e)
 	
 	menu.addSeparator();
 
-	QAction *chartAction = 0;
+	QAction *chartAction = nullptr;
 	QList<QAction*> chartMenuActions;
 
 	QList<QDockWidget *> dockWidgets;
-	const FieldDescriptor *field = 0;
+	const FieldDescriptor *field = nullptr;
 	if (mainWindow && item)
 	{
 		field = item->data(Column_Tag, FieldDescriptorRole).value<const FieldDescriptor *>();

--- a/soccer/ProtobufTree.hpp
+++ b/soccer/ProtobufTree.hpp
@@ -59,7 +59,7 @@ class ProtobufTree: public QTreeWidget
 		
 		void addBytes(QTreeWidgetItem *parent, const std::string &bytes);
 		
-		virtual void contextMenuEvent(QContextMenuEvent *e);
+		virtual void contextMenuEvent(QContextMenuEvent *e) override;
 		
 		bool _first;
 		const std::vector<std::shared_ptr<Packet::LogFrame> > *_history;

--- a/soccer/ProtobufTree.hpp
+++ b/soccer/ProtobufTree.hpp
@@ -18,7 +18,7 @@ class ProtobufTree: public QTreeWidget
 	Q_OBJECT;
 	
 	public:
-		ProtobufTree(QWidget *parent = 0);
+		ProtobufTree(QWidget *parent = nullptr);
 		
 		// Column numbers
 		enum
@@ -35,7 +35,7 @@ class ProtobufTree: public QTreeWidget
 		// in a repeated field is reduced.  Fields are never removed.
 		bool message(const google::protobuf::Message &msg);
 		
-		void expandMessages(QTreeWidgetItem *item = 0);
+		void expandMessages(QTreeWidgetItem *item = nullptr);
 		
 		// Expands an item recursively
 		void expandSubtree(QTreeWidgetItem *item);

--- a/soccer/QuaternionDemo.hpp
+++ b/soccer/QuaternionDemo.hpp
@@ -7,7 +7,7 @@
 class QuaternionDemo: public QGLWidget
 {
 public:
-	QuaternionDemo(QWidget *parent = 0);
+	QuaternionDemo(QWidget *parent = nullptr);
 
 	bool initialized;
 	Eigen::Quaternionf ref;

--- a/soccer/QuaternionDemo.hpp
+++ b/soccer/QuaternionDemo.hpp
@@ -14,7 +14,7 @@ public:
 	Eigen::Quaternionf q;
 
 protected:
-	void paintGL();
+	void paintGL() override;
 };
 
 QuaternionDemo::QuaternionDemo(QWidget* parent)

--- a/soccer/RefereeTab.hpp
+++ b/soccer/RefereeTab.hpp
@@ -8,7 +8,7 @@ class RefereeTab: public QWidget
 	Q_OBJECT;
 
 	public:
-		RefereeTab(QWidget *parent = 0);
+		RefereeTab(QWidget *parent = nullptr);
 
 	protected Q_SLOTS:
 		void on_externalReferee_toggled(bool value);

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -205,7 +205,7 @@ void OurRobot::worldVelocity(const Geometry2d::Point& v)
 {
 	_motionConstraints.targetPos = boost::none;
 	_motionConstraints.targetWorldVel = v;
-	setPath(NULL);
+	setPath(nullptr);
 	*_cmdText << "worldVel(" << v.x << ", " << v.y << ")\n";
 }
 
@@ -228,7 +228,7 @@ void OurRobot::pivot(const Geometry2d::Point &pivotTarget) {
 
 	//	reset other conflicting motion commands
 
-	setPath(NULL);
+	setPath(nullptr);
 	_motionConstraints.targetPos = boost::none;
 	_motionConstraints.targetWorldVel = boost::none;
 	_motionConstraints.faceTarget = boost::none;

--- a/soccer/RobotStatusWidget.hpp
+++ b/soccer/RobotStatusWidget.hpp
@@ -12,7 +12,7 @@
 class RobotStatusWidget : public QWidget {
 public:
 
-	RobotStatusWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+	RobotStatusWidget(QWidget *parent = nullptr, Qt::WindowFlags f = nullptr);
 
 	int shellID() const;
 	void setShellID(int shellID);

--- a/soccer/RobotWidget.hpp
+++ b/soccer/RobotWidget.hpp
@@ -18,7 +18,7 @@ public:
     void setBallSenseFault(bool faulty = true);
     void setHasBall(bool hasBall = true);
     
-    void paintEvent(QPaintEvent *event);
+    void paintEvent(QPaintEvent *event) override;
 
 
 private:

--- a/soccer/RobotWidget.hpp
+++ b/soccer/RobotWidget.hpp
@@ -8,7 +8,7 @@
  */
 class RobotWidget : public QWidget {
 public:
-    RobotWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+    RobotWidget(QWidget *parent = nullptr, Qt::WindowFlags f = nullptr);
 
     void setBlueTeam(bool blueTeam);
     bool blueTeam() const;

--- a/soccer/SimFieldView.hpp
+++ b/soccer/SimFieldView.hpp
@@ -23,11 +23,11 @@ class SimFieldView: public FieldView
 		void robotSelected(int shell);
 	
 	protected:
-		virtual void mouseReleaseEvent(QMouseEvent*);
-		virtual void mousePressEvent(QMouseEvent*);
-		virtual void mouseMoveEvent(QMouseEvent*);
+		virtual void mouseReleaseEvent(QMouseEvent*) override;
+		virtual void mousePressEvent(QMouseEvent*) override;
+		virtual void mouseMoveEvent(QMouseEvent*) override;
 		
-		virtual void drawTeamSpace(QPainter &p);
+		virtual void drawTeamSpace(QPainter &p) override;
 		
 	private:
 		// Places the ball at a position on the screen

--- a/soccer/SimFieldView.hpp
+++ b/soccer/SimFieldView.hpp
@@ -12,7 +12,7 @@ class SimFieldView: public FieldView
 	Q_OBJECT;
 	
 	public:
-		SimFieldView(QWidget *parent = 0);
+		SimFieldView(QWidget *parent = nullptr);
 		
 		void sendSimCommand(const Packet::SimCommand &cmd);
 		

--- a/soccer/StripChart.cpp
+++ b/soccer/StripChart.cpp
@@ -18,7 +18,7 @@ using namespace google::protobuf;
 
 StripChart::StripChart(QWidget* parent)
 {
-	_history = 0;
+	_history = nullptr;
 	_minValue = 0;
 	_maxValue = 1;
 	//_function = 0;

--- a/soccer/StripChart.hpp
+++ b/soccer/StripChart.hpp
@@ -26,7 +26,7 @@ namespace Chart
 	
 	struct PointMagnitude: public Function
 	{
-		virtual bool value(const Packet::LogFrame &frame, float &v) const;
+		virtual bool value(const Packet::LogFrame &frame, float &v) const override;
 		
 		// Vector of tags from LogFrame to the Point to be used.
 		// Each tag except must identify a Message.
@@ -36,7 +36,7 @@ namespace Chart
 	
 	struct NumericField: public Function
 	{
-		virtual bool value(const Packet::LogFrame &frame, float &v) const;
+		virtual bool value(const Packet::LogFrame &frame, float &v) const override;
 		
 		// Vector of tags from LogFrame to the float or double field to be used.
 		// Each tag except the last one must identify a Message.
@@ -81,7 +81,7 @@ class StripChart: public QWidget
 		bool autoRange;
 		
 	protected:
-		void paintEvent(QPaintEvent *e);
+		void paintEvent(QPaintEvent *e) override;
 		
 		// Returns the position for the data at a given frame.
 		// i is an index in _history, so 0 is the most recent frame

--- a/soccer/StripChart.hpp
+++ b/soccer/StripChart.hpp
@@ -48,7 +48,7 @@ namespace Chart
 class StripChart: public QWidget
 {
 	public:
-		StripChart(QWidget *parent = 0);
+		StripChart(QWidget *parent = nullptr);
 		~StripChart();
 
 		void history(const std::vector<std::shared_ptr<Packet::LogFrame> > *value)

--- a/soccer/VisionReceiver.hpp
+++ b/soccer/VisionReceiver.hpp
@@ -52,7 +52,7 @@ public:
 	int port;
 	
 protected:
-	virtual void run();
+	virtual void run() override;
 	
 	volatile bool _running;
 	

--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -29,7 +29,7 @@ struct NullArgumentException : public std::exception {
 	std::string argument_name;
 	NullArgumentException() : argument_name("") {}
 	NullArgumentException(std::string name) : argument_name(name) {}
-	virtual const char* what() const throw(){ return ("'" + argument_name + "'' was 'None'.").c_str(); }
+	virtual const char* what() const throw() override{ return ("'" + argument_name + "'' was 'None'.").c_str(); }
 };
 
 void translateException(NullArgumentException const& e)

--- a/soccer/joystick/GamepadJoystick.cpp
+++ b/soccer/joystick/GamepadJoystick.cpp
@@ -15,7 +15,7 @@ static const char *devices[] =
     "/dev/input/by-id/usb-Logitech_Logitech_Dual_Action-joystick",
     
     // End of list
-    0
+    nullptr
 };
 
 GamepadJoystick::GamepadJoystick()

--- a/soccer/joystick/SpaceNavJoystick.hpp
+++ b/soccer/joystick/SpaceNavJoystick.hpp
@@ -26,12 +26,12 @@ public:
      * This is less than ideal, but it's what we've got.
      * @return A boolean indicating if the joystick is valid
      */
-    bool valid() const;
+    bool valid() const override;
 
-    void reset();
-    void update();
+    void reset() override;
+    void update() override;
 
-    JoystickControlValues getJoystickControlValues();
+    JoystickControlValues getJoystickControlValues() override;
 
 
 protected:

--- a/soccer/main.cpp
+++ b/soccer/main.cpp
@@ -131,7 +131,7 @@ int main (int argc, char* argv[])
 			}
 
 			i++;
-			seed = strtol(argv[i], 0, 16);
+			seed = strtol(argv[i], nullptr, 16);
 		}
 		else if(strcmp(var, "-pbk") == 0)
 		{
@@ -175,7 +175,7 @@ int main (int argc, char* argv[])
 	QString error;
 	if (!config.load(cfgFile, error))
 	{
-		QMessageBox::critical(0, "Soccer",
+		QMessageBox::critical(nullptr, "Soccer",
 			QString("Can't read initial configuration %1:\n%2").arg(cfgFile, error));
 	}
 

--- a/soccer/modeling/BallTracker.cpp
+++ b/soccer/modeling/BallTracker.cpp
@@ -137,7 +137,7 @@ void BallTracker::run(const vector< BallObservation >& obs, SystemState *state)
 			_lastTrackTime = goodObs[best]->time;
 			
 			// Update the real track
-			_ballFilter->predict(state->logFrame->command_time(), &state->ball, 0);
+			_ballFilter->predict(state->logFrame->command_time(), &state->ball, nullptr);
 			
 			// Don't use this observation for a possible track since it's the real track
 			fastRemove(goodObs, best);
@@ -212,7 +212,7 @@ void BallTracker::run(const vector< BallObservation >& obs, SystemState *state)
 				// First update and prediction
 				_ballFilter->update(&_possibleTracks[i].obs);
 				_lastTrackTime = _possibleTracks[i].obs.time;
-				_ballFilter->predict(state->logFrame->command_time(), &state->ball, 0);
+				_ballFilter->predict(state->logFrame->command_time(), &state->ball, nullptr);
 				
 				fastRemove(_possibleTracks, i);
 				break;

--- a/soccer/planning/Tree.cpp
+++ b/soccer/planning/Tree.cpp
@@ -36,7 +36,7 @@ void Tree::Point::addEdges(std::list<Geometry2d::Segment>& edges)
 Tree::Tree()
 {
 	step = .1;
-	_obstacles = 0;
+	_obstacles = nullptr;
 }
 
 Tree::~Tree()
@@ -46,7 +46,7 @@ Tree::~Tree()
 
 void Tree::clear()
 {
-	 _obstacles = 0;
+	 _obstacles = nullptr;
 
     // Delete all points
     for (Point *pt :  points)
@@ -62,7 +62,7 @@ void Tree::init(const Geometry2d::Point& start, const Geometry2d::CompositeShape
 
 	_obstacles = obstacles;
 
-	Point* p = new Point(start, 0);
+	Point* p = new Point(start, nullptr);
 	_obstacles->hit(p->pos, p->hit);
 	points.push_back(p);
 }
@@ -96,7 +96,7 @@ void Tree::addPath(Planning::InterpolatedPath &path, Point* dest, const bool rev
 Tree::Point* Tree::nearest(Geometry2d::Point pt)
 {
 	float bestDistance = -1;
-    Point *best = 0;
+    Point *best = nullptr;
 
     for (Point* other :  points)
     {
@@ -115,7 +115,7 @@ Tree::Point* Tree::start() const
 {
 	if (points.empty())
 	{
-		return 0;
+		return nullptr;
 	}
 
 	return points.front();
@@ -125,7 +125,7 @@ Tree::Point* Tree::last() const
 {
 	if (points.empty())
 	{
-		return 0;
+		return nullptr;
 	}
 
 	return points.back();
@@ -140,7 +140,7 @@ Tree::Point* FixedStepTree::extend(Geometry2d::Point pt, Tree::Point* base)
 		base = nearest(pt);
 		if (!base)
 		{
-			return 0;
+			return nullptr;
 		}
 	}
 
@@ -174,7 +174,7 @@ Tree::Point* FixedStepTree::extend(Geometry2d::Point pt, Tree::Point* base)
 		} catch (exception& e)
 		{
 			// We hit a new obstacle
-			return 0;
+			return nullptr;
 		}
 	}
 
@@ -191,7 +191,7 @@ bool FixedStepTree::connect(Geometry2d::Point pt)
 	//try to reach the goal pt
 	const unsigned int maxAttemps = 50;
 
-	Point* from = 0;
+	Point* from = nullptr;
 
 	for (unsigned int i=0 ; i<maxAttemps ; ++i)
 	{

--- a/soccer/planning/Tree.hpp
+++ b/soccer/planning/Tree.hpp
@@ -83,7 +83,7 @@ namespace Planning
 		public:
 			FixedStepTree() {}
 
-			Tree::Point* extend(Geometry2d::Point pt, Tree::Point* base = nullptr);
-			bool connect(Geometry2d::Point pt);
+			Tree::Point* extend(Geometry2d::Point pt, Tree::Point* base = nullptr) override;
+			bool connect(Geometry2d::Point pt) override;
 	};
 }

--- a/soccer/planning/Tree.hpp
+++ b/soccer/planning/Tree.hpp
@@ -53,7 +53,7 @@ namespace Planning
 			/** grow the tree in the direction of pt
 			 *  returns the new tree point.
 			 *  If base == 0, then the closest tree point is used */
-			virtual Point* extend(Geometry2d::Point pt, Point* base = 0) = 0;
+			virtual Point* extend(Geometry2d::Point pt, Point* base = nullptr) = 0;
 
 			/** attempt to connect the tree to the point */
 			virtual bool connect(const Geometry2d::Point pt) = 0;
@@ -83,7 +83,7 @@ namespace Planning
 		public:
 			FixedStepTree() {}
 
-			Tree::Point* extend(Geometry2d::Point pt, Tree::Point* base = 0);
+			Tree::Point* extend(Geometry2d::Point pt, Tree::Point* base = nullptr);
 			bool connect(Geometry2d::Point pt);
 	};
 }

--- a/soccer/radio/SimRadio.hpp
+++ b/soccer/radio/SimRadio.hpp
@@ -12,10 +12,10 @@ class SimRadio: public Radio
 public:
     SimRadio(bool blueTeam = false);
 
-	virtual bool isOpen() const;
-	virtual void send(Packet::RadioTx &packet);
-    virtual void receive();
-    virtual void switchTeam(bool blueTeam);
+	virtual bool isOpen() const override;
+	virtual void send(Packet::RadioTx &packet) override;
+    virtual void receive() override;
+    virtual void switchTeam(bool blueTeam) override;
 	
 private:
 	QUdpSocket _socket;

--- a/soccer/radio/USBRadio.cpp
+++ b/soccer/radio/USBRadio.cpp
@@ -22,8 +22,8 @@ USBRadio::USBRadio()
 {
 	_sequence = 0;
 	_printedError = false;
-	_device = 0;
-	_usb_context = 0;
+	_device = nullptr;
+	_usb_context = nullptr;
 	libusb_init(&_usb_context);
 	
 	for (int i = 0; i < NumRXTransfers; ++i)
@@ -49,7 +49,7 @@ USBRadio::~USBRadio()
 
 bool USBRadio::open()
 {
-	libusb_device **devices = 0;
+	libusb_device **devices = nullptr;
 	ssize_t numDevices = libusb_get_device_list(_usb_context, &devices);
 	
 	if (numDevices < 0)
@@ -154,7 +154,7 @@ void USBRadio::rxCompleted(libusb_transfer* transfer)
 
 void USBRadio::command(uint8_t cmd)
 {
-	if (libusb_control_transfer(_device, LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR, 2, 0, cmd, 0, 0, Control_Timeout))
+	if (libusb_control_transfer(_device, LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR, 2, 0, cmd, nullptr, 0, Control_Timeout))
 	{
 		throw runtime_error("USBRadio::command control write failed");
 	}
@@ -162,7 +162,7 @@ void USBRadio::command(uint8_t cmd)
 
 void USBRadio::write(uint8_t reg, uint8_t value)
 {
-	if (libusb_control_transfer(_device, LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR, 1, value, reg, 0, 0, Control_Timeout))
+	if (libusb_control_transfer(_device, LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR, 1, value, reg, nullptr, 0, Control_Timeout))
 	{
 		throw runtime_error("USBRadio::write control write failed");
 	}
@@ -202,7 +202,7 @@ void USBRadio::configure()
 void USBRadio::auto_calibrate(bool enable)
 {
 	int flag = enable ? 1 : 0;
-	assert(libusb_control_transfer(_device, LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR, 4, flag, 0, 0, 0, Control_Timeout) == 0);
+	assert(libusb_control_transfer(_device, LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR, 4, flag, 0, nullptr, 0, Control_Timeout) == 0);
 }
 
 bool USBRadio::isOpen() const
@@ -285,7 +285,7 @@ void USBRadio::send(Packet::RadioTx& packet)
 	{
 		fprintf(stderr, "USBRadio: Bulk write failed\n");
 		libusb_close(_device);
-		_device = 0;
+		_device = nullptr;
 	}
 	
 	_sequence = (_sequence + 1) & 7;

--- a/soccer/radio/USBRadio.hpp
+++ b/soccer/radio/USBRadio.hpp
@@ -27,12 +27,12 @@ public:
     USBRadio();
     ~USBRadio();
 
-	virtual bool isOpen() const;
-	virtual void send(Packet::RadioTx &packet);
-	virtual void receive();
+	virtual bool isOpen() const override;
+	virtual void send(Packet::RadioTx &packet) override;
+	virtual void receive() override;
 	
-	virtual void channel(int n);
-    void switchTeam(bool) { }
+	virtual void channel(int n) override;
+    void switchTeam(bool) override { }
 	
 protected:
 	libusb_context *_usb_context;


### PR DESCRIPTION
The clang modernizer analyzes c++ code and applies transformations to bring it up to date with modern features.  For example:
* convert NULL and 0 to nullptr
* change for loops to use new range-based syntax
* use the auto keyword where appropriate
* add the override keyword where appropriate