### PR TITLE
using homebrew for libspnav

### DIFF
--- a/util/osx-packages.txt
+++ b/util/osx-packages.txt
@@ -6,6 +6,7 @@ qt5
 pyqt5
 python3
 sdl
+libspnav
 boost
 boost-build
 boost-python --with-python3

--- a/util/osx-setup
+++ b/util/osx-setup
@@ -22,18 +22,5 @@ sudo pip3 install -r $BASE/util/requirements3.txt
 echo "-- Disabling AppNap for simulator"
 defaults write org.robojackets.robocup.simulator NSAppSleepDisabled -bool YES
 
-echo "-- Checking for libspnav for 3d mouse support"
-SPNAV_LOC="/usr/local/include/spnav.h"
-if [ ! -f "$SPNAV_LOC" ]; then
-    echo "-- Downloading libspnav"
-    TMP_DIR=$(mktemp -d /tmp/spacenav.XXXX)
-    curl -L "http://downloads.sourceforge.net/project/spacenav/spacenav%20library%20%28SDK%29/libspnav%200.2.3/libspnav-0.2.3.tar.gz?r=&ts=1425162527&use_mirror=hivelocity" -o "$TMP_DIR/libspnav-0.2.3.tar.gz"
-    pushd "$TMP_DIR"; tar -xvzf libspnav-0.2.3.tar.gz
-    echo "-- Building and installing libspnav"
-    pushd "$TMP_DIR/libspnav-0.2.3"; ./configure --disable-x11; make; sudo make install
-    popd
-    popd
-fi
-
 echo "-- Updating submodules"
 git submodule update --init


### PR DESCRIPTION
Once the [PR](https://github.com/Homebrew/homebrew/pull/42906) goes through, we'll use homebrew for libspnav on OS X rather than having a script in our repo to install it.