### PR TITLE
Fixed python unit tests. Closes #56

### DIFF
--- a/soccer/Configuration.cpp
+++ b/soccer/Configuration.cpp
@@ -104,6 +104,14 @@ Configuration::Configuration() {
     _doc.appendChild(_doc.createElement("config"));
 }
 
+std::shared_ptr<Configuration> Configuration::FromRegisteredConfigurables() {
+    std::shared_ptr<Configuration> config = std::make_shared<Configuration>();
+    for (Configurable* obj : Configurable::configurables()) {
+        obj->createConfiguration(config.get());
+    }
+    return config;
+}
+
 void Configuration::addItem(ConfigItem* item) {
     _allItems.push_back(item);
 

--- a/soccer/Configuration.hpp
+++ b/soccer/Configuration.hpp
@@ -9,6 +9,7 @@ class QTreeWidget;
 class QTreeWidgetItem;
 class Configuration;
 class ConfigItem;
+
 /**
  * static variable for the program, extremely general
  */
@@ -17,6 +18,9 @@ class Configuration : public QObject {
 
 public:
     Configuration();
+
+    /// Initializes a config object and adds all registered configurables to it.
+    static std::shared_ptr<Configuration> FromRegisteredConfigurables();
 
     void tree(QTreeWidget* tree);
 
@@ -162,6 +166,7 @@ protected:
 };
 
 #define REGISTER_CONFIGURABLE(x) static ConfigurableImpl<x> x##__configurable;
+
 /**
  *
  */
@@ -175,8 +180,10 @@ public:
     static const std::list<Configurable*>& configurables();
 
 private:
+    /// Global list of all registered configurables
     static std::list<Configurable*>* _configurables;
 };
+
 /**
  * a template for making configurables
  * the implementing object is responsible for handling configuration

--- a/soccer/Configuration.hpp
+++ b/soccer/Configuration.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <memory>
+#include <QDomDocument>
 #include <QFile>
 #include <QStringList>
 #include <vector>
-#include <QDomDocument>
 
 class QTreeWidget;
 class QTreeWidgetItem;

--- a/soccer/TestMain.cpp
+++ b/soccer/TestMain.cpp
@@ -6,7 +6,8 @@ int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
 
     // setup config system because some tests rely on it
-    std::shared_ptr<Configuration> config = Configuration::FromRegisteredConfigurables();
+    std::shared_ptr<Configuration> config =
+        Configuration::FromRegisteredConfigurables();
 
     return RUN_ALL_TESTS();
 }

--- a/soccer/TestMain.cpp
+++ b/soccer/TestMain.cpp
@@ -6,10 +6,7 @@ int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
 
     // setup config system because some tests rely on it
-    Configuration config;
-    for (Configurable* obj : Configurable::configurables()) {
-        obj->createConfiguration(&config);
-    }
+    std::shared_ptr<Configuration> config = Configuration::FromRegisteredConfigurables();
 
     return RUN_ALL_TESTS();
 }

--- a/soccer/WindowEvaluatorTest.cpp
+++ b/soccer/WindowEvaluatorTest.cpp
@@ -11,11 +11,6 @@ Configuration config;
 // evaluator, but is not actuallly in the way.  Should return one segment as
 // the result.
 TEST(WindowEvaluator, eval_pt_to_seg) {
-    // setup config system because window evaulator relies on it
-    for (Configurable* obj : Configurable::configurables()) {
-        obj->createConfiguration(&config);
-    }
-
     SystemState state;
     OurRobot* obstacleBot = state.self[0];
     obstacleBot->visible = true;

--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -77,6 +77,12 @@ std::string Robot_repr(Robot* self) { return self->toString(); }
 
 Geometry2d::Point Robot_pos(Robot* self) { return self->pos; }
 
+// Sets a robot's position - this should never be used in gameplay code, but
+// is useful for testing.
+void Robot_set_pos_for_testing(Robot* self, Geometry2d::Point pos) {
+    self->pos = pos;
+}
+
 Geometry2d::Point Robot_vel(Robot* self) { return self->vel; }
 
 float Robot_angle(Robot* self) { return self->angle; }
@@ -554,6 +560,7 @@ BOOST_PYTHON_MODULE(robocup) {
              "whether or not this robot is on our team")
         .add_property("pos", &Robot_pos,
                       "position vector of the robot in meters")
+        .def("set_pos_for_testing", &Robot_set_pos_for_testing)
         .add_property("vel", &Robot_vel, "velocity vector of the robot in m/s")
         .add_property("angle", &Robot_angle, "angle of the robot in degrees")
         .add_property("angle_vel", &Robot_angle_vel,
@@ -678,4 +685,8 @@ BOOST_PYTHON_MODULE(robocup) {
         .def("eval_pt_to_opp_goal", &WinEval_eval_pt_to_opp_goal)
         .def("eval_pt_to_our_goal", &WinEval_eval_pt_to_our_goal)
         .def("eval_pt_to_seg", &WinEval_eval_pt_to_seg);
+
+    class_<std::shared_ptr<Configuration>>("Configuration")
+        .def("FromRegisteredConfigurables", &Configuration::FromRegisteredConfigurables)
+        .staticmethod("FromRegisteredConfigurables");
 }

--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -687,6 +687,7 @@ BOOST_PYTHON_MODULE(robocup) {
         .def("eval_pt_to_seg", &WinEval_eval_pt_to_seg);
 
     class_<std::shared_ptr<Configuration>>("Configuration")
-        .def("FromRegisteredConfigurables", &Configuration::FromRegisteredConfigurables)
+        .def("FromRegisteredConfigurables",
+             &Configuration::FromRegisteredConfigurables)
         .staticmethod("FromRegisteredConfigurables");
 }

--- a/soccer/gameplay/role_assignment.py
+++ b/soccer/gameplay/role_assignment.py
@@ -140,7 +140,6 @@ class ImpossibleAssignmentError(RuntimeError): pass
 # the munkres library doesn't like infinity, so we use this instead
 MaxWeight = 10000000
 
-
 # multiply this by the distance between two points to get the cost
 PositionCostMultiplier = 1.0
 

--- a/soccer/gameplay/tests/test_play_registry.py
+++ b/soccer/gameplay/tests/test_play_registry.py
@@ -1,30 +1,30 @@
 import unittest
 import play_registry
-import plays.line_up
+import plays.testing.line_up
 
 
 class TestPlayRegistry(unittest.TestCase):
     def test_insert(self):
         pr = play_registry.PlayRegistry()
-        pr.insert(['line_up'], plays.line_up.LineUp)
-        self.assertTrue(plays.line_up.LineUp in pr)
+        pr.insert(['line_up'], plays.testing.line_up.LineUp)
+        self.assertTrue(plays.testing.line_up.LineUp in pr)
 
     def test_delete(self):
         pr = play_registry.PlayRegistry()
-        pr.insert(['line_up'], plays.line_up.LineUp)
+        pr.insert(['line_up'], plays.testing.line_up.LineUp)
         pr.delete(['line_up'])
-        self.assertFalse(plays.line_up.LineUp in pr)
+        self.assertFalse(plays.testing.line_up.LineUp in pr)
 
     def test_nested_insert(self):
         pr = play_registry.PlayRegistry()
-        pr.insert(['demo', 'line_up'], plays.line_up.LineUp)
-        self.assertTrue(plays.line_up.LineUp in pr)
+        pr.insert(['demo', 'line_up'], plays.testing.line_up.LineUp)
+        self.assertTrue(plays.testing.line_up.LineUp in pr)
 
     def test_delete_last_item_in_category(self):
         """When the last play in a category is deleted, the category should be removed"""
 
         pr = play_registry.PlayRegistry()
-        pr.insert(['demo', 'line_up'], plays.line_up.LineUp)
+        pr.insert(['demo', 'line_up'], plays.testing.line_up.LineUp)
         self.assertEqual(len(pr.root.children), 1)
         pr.delete(['demo', 'line_up'])
         self.assertEqual(len(pr.root.children), 0)

--- a/soccer/gameplay/tests/test_role_assignment.py
+++ b/soccer/gameplay/tests/test_role_assignment.py
@@ -4,22 +4,27 @@ import robocup
 
 
 class TestRoleAssignment(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestRoleAssignment, self).__init__(*args, **kwargs)
+        # Some objects initialized below depend on the config system being setup
+        self.config = robocup.Configuration.FromRegisteredConfigurables()
+        self.system_state = robocup.SystemState()
 
     def test_pos_cost(self):
         """Ensure that when requirements specify a target position, it is taken
         into account in assignment"""
 
-        bot1 = robocup.OurRobot(1, None)
-        bot1.pos = robocup.Point(1, 6)
+        bot1 = robocup.OurRobot(1, self.system_state)
+        bot1.set_pos_for_testing(robocup.Point(1, 6))
 
-        bot2 = robocup.OurRobot(2, None)
-        bot2.pos = robocup.Point(2, 3)
+        bot2 = robocup.OurRobot(2, self.system_state)
+        bot2.set_pos_for_testing(robocup.Point(2, 3))
 
         req1 = role_assignment.RoleRequirements()
-        req1.pos = robocup.Point(1, 7)
+        req1.destination_shape = robocup.Point(1, 7)
 
         req2 = role_assignment.RoleRequirements()
-        req2.pos = robocup.Point(3, 4)
+        req2.destination_shape = robocup.Point(3, 4)
 
         req_tree = {'role1': req1, 'role2': req2}
         assignments = role_assignment.assign_roles([bot1, bot2], req_tree)
@@ -31,8 +36,8 @@ class TestRoleAssignment(unittest.TestCase):
     def test_not_enough_bots(self):
         """If there's not enough robots to do an assignment, it should raise an error"""
 
-        bot1 = robocup.OurRobot(1, None)
-        bot1.pos = robocup.Point(1, 6)
+        bot1 = robocup.OurRobot(1, self.system_state)
+        bot1.set_pos_for_testing(robocup.Point(1, 6))
 
         req1 = role_assignment.RoleRequirements()
         req1.pos = robocup.Point(1, 7)

--- a/soccer/main.cpp
+++ b/soccer/main.cpp
@@ -132,10 +132,7 @@ int main(int argc, char* argv[]) {
                                                          : "soccer-real.cfg");
     }
 
-    Configuration config;
-    for (Configurable* obj : Configurable::configurables()) {
-        obj->createConfiguration(&config);
-    }
+    std::shared_ptr<Configuration> config = Configuration::FromRegisteredConfigurables();
 
     Processor* processor = new Processor(sim);
     processor->blueTeam(blueTeam);
@@ -143,7 +140,7 @@ int main(int argc, char* argv[]) {
 
     // Load config file
     QString error;
-    if (!config.load(cfgFile, error)) {
+    if (!config->load(cfgFile, error)) {
         QMessageBox::critical(
             nullptr, "Soccer",
             QString("Can't read initial configuration %1:\n%2")
@@ -151,7 +148,7 @@ int main(int argc, char* argv[]) {
     }
 
     MainWindow* win = new MainWindow;
-    win->configuration(&config);
+    win->configuration(config.get());
     win->processor(processor);
 
     win->setUseRefChecked(!noref);

--- a/soccer/main.cpp
+++ b/soccer/main.cpp
@@ -132,7 +132,8 @@ int main(int argc, char* argv[]) {
                                                          : "soccer-real.cfg");
     }
 
-    std::shared_ptr<Configuration> config = Configuration::FromRegisteredConfigurables();
+    std::shared_ptr<Configuration> config =
+        Configuration::FromRegisteredConfigurables();
 
     Processor* processor = new Processor(sim);
     processor->blueTeam(blueTeam);

--- a/util/docker/maketest.sh
+++ b/util/docker/maketest.sh
@@ -73,6 +73,7 @@ ci_task 'make test-soccer' 'test-soccer' 'A check to see if soccer tests pass'
 ci_task 'make robot2015' 'firmware' 'A check to see if firmware compiles'
 ci_task 'make test-firmware' 'test-firmware' 'A check to see if firmware tests pass'
 ci_task 'make checkstyle' 'style' 'A check to see if style passes'
+ci_task 'make test-python' 'test-python' 'A check to see if python unit tests pass'
 
 # This script needs to be run prior with the --pending flag if you want to see pending flags
 if [ "$PENDING" = "true" ]; then


### PR DESCRIPTION
The tests were failing before because the config system wasn't initialized before running tests, leading to null pointer dereferences.  I exposed a config initialization method to the python code and made a call to it in the relevant tests, so everything works now.

I also added the python test suite to the circleci setup as a separate check.