### PR TITLE
Refactored InterpolatedPath to use MotionInstant and made Path.evaluate() return an optional instant

### DIFF
--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -547,11 +547,13 @@ void OurRobot::replanIfNeeded(
                 ((float)(timestamp() - _pathStartTime)) * TimestampToSecs +
                 1.0f / 60.0f;
 
-            boost::optional<MotionInstant> optTarget = _path->evaluate(timeIntoPath);
+            boost::optional<MotionInstant> optTarget =
+                _path->evaluate(timeIntoPath);
             if (optTarget) {
                 target = *optTarget;
             } else {
-                // We went off the end of the path, so use the end for calculations.
+                // We went off the end of the path, so use the end for
+                // calculations.
                 target = *_path->destination();
             }
 

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -443,7 +443,7 @@ protected:
     Planning::MotionCommand::CommandType _lastCommandType;
     MotionConstraints _motionConstraints;
 
-    std::shared_ptr<Planning::PathPlanner>
+    std::shared_ptr<Planning::SingleRobotPathPlanner>
         _planner;  /// single-robot RRT planner
 
     void setPath(std::unique_ptr<Planning::Path> path);

--- a/soccer/motion/TrapezoidalMotion.hpp
+++ b/soccer/motion/TrapezoidalMotion.hpp
@@ -36,4 +36,5 @@ namespace Trapezoidal {
  */
 float getTime(float distance, float pathLength, float maxSpeed, float maxAcc,
               float startSpeed, float finalSpeed);
-}
+
+}  // namespace Trapezoidal

--- a/soccer/planning/CompositePath.hpp
+++ b/soccer/planning/CompositePath.hpp
@@ -6,6 +6,7 @@
 #include <Configuration.hpp>
 
 namespace Planning {
+
 /**
  * @brief Represents a motion path made up of a series of Paths.
  *
@@ -33,8 +34,7 @@ public:
      */
     void append(std::unique_ptr<Path> path);
 
-    virtual bool evaluate(float t,
-                          MotionInstant& targetMotionInstant) const override;
+    virtual boost::optional<MotionInstant> evaluate(float t) const override;
     virtual bool hit(const Geometry2d::CompositeShape& shape, float& hitTime,
                      float startTime = 0) const override;
     virtual void draw(SystemState* const state, const QColor& color = Qt::black,
@@ -46,4 +46,5 @@ public:
     virtual boost::optional<MotionInstant> destination() const override;
     virtual std::unique_ptr<Path> clone() const override;
 };
-}
+
+}  // namespace Planning

--- a/soccer/planning/InterpolatedPath.cpp
+++ b/soccer/planning/InterpolatedPath.cpp
@@ -146,43 +146,6 @@ Segment InterpolatedPath::nearestSegment(Point pt) const {
     return best;
 }
 
-// void InterpolatedPath::startFrom(Point pt, InterpolatedPath& result) const {
-//     // path will start at the current robot pose
-//     result.clear();
-//     result.points.push_back(pt);
-
-//     if (points.empty()) return;
-
-//     // handle simple paths
-//     if (points.size() == 1) {
-//         result.points.push_back(points.front());
-//         return;
-//     }
-
-//     // find where to start the path
-//     Segment close_segment;
-//     float dist = -1;
-//     unsigned int i = (points.front().nearPoint(pt, 0.02)) ? 1 : 0;
-//     vector<Point>::const_iterator path_start = ++points.begin();
-//     for (; i < (points.size() - 1); ++i) {
-//         Segment s(points[i], points[i + 1]);
-//         const float d = s.distTo(pt);
-//         if (dist < 0 || d < dist) {
-//             close_segment = s;
-//             dist = d;
-//         }
-//     }
-
-//     // slice path
-//     // new path will be pt, [closest point on nearest segment], [i+1 to end]
-//     if (dist > 0.0 && dist < 0.02) {
-//         Point intersection_pt = close_segment.nearestPoint(pt);
-//         result.points.push_back(intersection_pt);
-//     }
-
-//     result.points.insert(result.points.end(), path_start, points.end());
-// }
-
 float InterpolatedPath::length(Point pt) const {
     float dist = -1;
     float length = 0;
@@ -214,31 +177,6 @@ float InterpolatedPath::length(Point pt) const {
 
     return length;
 }
-
-// boos::optional<MotionInstant> InterpolatedPath::getPoint(float distance)
-// const {
-//     if (distance <= 0) {
-//         return boost::none;
-//     }
-//     if (points.empty()) {
-//         return boost::none;
-//     }
-//     for (unsigned int i = 0; i < (points.size() - 1); ++i) {
-//         Point vector(points[i + 1] - points[i]);
-
-//         float vectorLength = vector.mag();
-//         distance -= vectorLength;
-
-//         if (distance <= 0) {
-//             distance += vectorLength;
-//             position = points[i] + (vector * (distance / vectorLength));
-//             direction = vector.normalized();
-//             return true;
-//         }
-//     }
-
-//     return boost::none;
-// }
 
 void InterpolatedPath::draw(SystemState* const state,
                             const QColor& col = Qt::black,

--- a/soccer/planning/InterpolatedPath.cpp
+++ b/soccer/planning/InterpolatedPath.cpp
@@ -1,73 +1,65 @@
-#include <protobuf/LogFrame.pb.h>
 #include "InterpolatedPath.hpp"
-#include "Utils.hpp"
 #include "LogUtils.hpp"
-#include <stdexcept>
+#include "Utils.hpp"
+#include <protobuf/LogFrame.pb.h>
 
-#pragma mark InterpolatedPath
+#include <stdexcept>
 
 using namespace std;
 using namespace Geometry2d;
 
 namespace Planning {
-InterpolatedPath::InterpolatedPath(Geometry2d::Point p0) {
-    points.push_back(p0);
+
+InterpolatedPath::InterpolatedPath(Point p0) {
+    waypoints.emplace_back(p0, Point());
 }
 
-InterpolatedPath::InterpolatedPath(Geometry2d::Point p0, Geometry2d::Point p1) {
-    points.push_back(p0);
-    points.push_back(p1);
+InterpolatedPath::InterpolatedPath(Point p0, Point p1) {
+    waypoints.emplace_back(p0, Point());
+    waypoints.emplace_back(p1, Point());
 }
 
 float InterpolatedPath::length(unsigned int start) const {
-    if (points.empty() || start >= (points.size() - 1)) {
-        return 0;
-    }
-
-    float length = 0;
-    for (unsigned int i = start; i < (points.size() - 1); ++i) {
-        length += (points[i + 1] - points[i]).mag();
-    }
-    return length;
+    return length(start, waypoints.size() - 1);
 }
 
 float InterpolatedPath::length(unsigned int start, unsigned int end) const {
-    if (points.empty() || start >= (points.size() - 1)) {
+    if (waypoints.empty() || start >= (waypoints.size() - 1)) {
         return 0;
     }
 
     float length = 0;
     for (unsigned int i = start; i < end; ++i) {
-        length += (points[i + 1] - points[i]).mag();
+        length += (waypoints[i + 1].pos - waypoints[i].pos).mag();
     }
     return length;
 }
 
-boost::optional<Geometry2d::Point> InterpolatedPath::start() const {
-    if (points.empty())
+boost::optional<MotionInstant> InterpolatedPath::start() const {
+    if (waypoints.empty())
         return boost::none;
     else
-        return points.front();
+        return waypoints.front();
 }
 
 boost::optional<MotionInstant> InterpolatedPath::destination() const {
-    if (points.empty())
+    if (waypoints.empty())
         return boost::none;
     else
-        return MotionInstant(points.back(), vels.back());
+        return waypoints.back();
 }
 
 // Returns the index of the point in this path nearest to pt.
-int InterpolatedPath::nearestIndex(Geometry2d::Point pt) const {
-    if (points.size() == 0) {
+int InterpolatedPath::nearestIndex(Point pt) const {
+    if (waypoints.size() == 0) {
         return -1;
     }
 
     int index = 0;
-    float dist = pt.distTo(points[0]);
+    float dist = pt.distTo(waypoints[0].pos);
 
-    for (unsigned int i = 1; i < points.size(); ++i) {
-        float d = pt.distTo(points[i]);
+    for (unsigned int i = 1; i < waypoints.size(); ++i) {
+        float d = pt.distTo(waypoints[i].pos);
         if (d < dist) {
             dist = d;
             index = i;
@@ -77,8 +69,8 @@ int InterpolatedPath::nearestIndex(Geometry2d::Point pt) const {
     return index;
 }
 
-bool InterpolatedPath::hit(const Geometry2d::CompositeShape& obstacles,
-                           float& hitTime, float startTime) const {
+bool InterpolatedPath::hit(const CompositeShape& obstacles, float& hitTime,
+                           float startTime) const {
     size_t start = 0;
     for (float t : times) {
         start++;
@@ -88,21 +80,21 @@ bool InterpolatedPath::hit(const Geometry2d::CompositeShape& obstacles,
         }
     }
 
-    if (start >= points.size()) {
+    if (start >= waypoints.size()) {
         // Empty path or starting beyond end of path
         return false;
     }
 
     // This code disregards obstacles which the robot starts in. This allows the
     // robot to move out a obstacle if it is already in one.
-    std::set<std::shared_ptr<Geometry2d::Shape>> startHitSet;
-    obstacles.hit(points[start], startHitSet);
+    std::set<std::shared_ptr<Shape>> startHitSet;
+    obstacles.hit(waypoints[start].pos, startHitSet);
 
-    for (size_t i = start; i < points.size() - 1; i++) {
-        std::set<std::shared_ptr<Geometry2d::Shape>> newHitSet;
-        if (obstacles.hit(Geometry2d::Segment(points[i], points[i + 1]),
+    for (size_t i = start; i < waypoints.size() - 1; i++) {
+        std::set<std::shared_ptr<Shape>> newHitSet;
+        if (obstacles.hit(Segment(waypoints[i].pos, waypoints[i + 1].pos),
                           newHitSet)) {
-            for (std::shared_ptr<Geometry2d::Shape> hit : newHitSet) {
+            for (std::shared_ptr<Shape> hit : newHitSet) {
                 // If it hits something, check if the hit was in the origional
                 // hitSet
                 if (startHitSet.find(hit) == startHitSet.end()) {
@@ -115,15 +107,15 @@ bool InterpolatedPath::hit(const Geometry2d::CompositeShape& obstacles,
     return false;
 }
 
-float InterpolatedPath::distanceTo(Geometry2d::Point pt) const {
+float InterpolatedPath::distanceTo(Point pt) const {
     int i = nearestIndex(pt);
     if (i < 0) {
         return 0;
     }
 
     float dist = -1;
-    for (unsigned int i = 0; i < (points.size() - 1); ++i) {
-        Geometry2d::Segment s(points[i], points[i + 1]);
+    for (unsigned int i = 0; i < (waypoints.size() - 1); ++i) {
+        Segment s(waypoints[i].pos, waypoints[i + 1].pos);
         const float d = s.distTo(pt);
 
         if (dist < 0 || d < dist) {
@@ -134,16 +126,15 @@ float InterpolatedPath::distanceTo(Geometry2d::Point pt) const {
     return dist;
 }
 
-Geometry2d::Segment InterpolatedPath::nearestSegment(
-    Geometry2d::Point pt) const {
-    Geometry2d::Segment best;
+Segment InterpolatedPath::nearestSegment(Point pt) const {
+    Segment best;
     float dist = -1;
-    if (points.empty()) {
+    if (waypoints.empty()) {
         return best;
     }
 
-    for (unsigned int i = 0; i < (points.size() - 1); ++i) {
-        Geometry2d::Segment s(points[i], points[i + 1]);
+    for (unsigned int i = 0; i < (waypoints.size() - 1); ++i) {
+        Segment s(waypoints[i].pos, waypoints[i + 1].pos);
         const float d = s.distTo(pt);
 
         if (dist < 0 || d < dist) {
@@ -155,53 +146,52 @@ Geometry2d::Segment InterpolatedPath::nearestSegment(
     return best;
 }
 
-void InterpolatedPath::startFrom(Geometry2d::Point pt,
-                                 InterpolatedPath& result) const {
-    // path will start at the current robot pose
-    result.clear();
-    result.points.push_back(pt);
+// void InterpolatedPath::startFrom(Point pt, InterpolatedPath& result) const {
+//     // path will start at the current robot pose
+//     result.clear();
+//     result.points.push_back(pt);
 
-    if (points.empty()) return;
+//     if (points.empty()) return;
 
-    // handle simple paths
-    if (points.size() == 1) {
-        result.points.push_back(points.front());
-        return;
-    }
+//     // handle simple paths
+//     if (points.size() == 1) {
+//         result.points.push_back(points.front());
+//         return;
+//     }
 
-    // find where to start the path
-    Geometry2d::Segment close_segment;
-    float dist = -1;
-    unsigned int i = (points.front().nearPoint(pt, 0.02)) ? 1 : 0;
-    vector<Geometry2d::Point>::const_iterator path_start = ++points.begin();
-    for (; i < (points.size() - 1); ++i) {
-        Geometry2d::Segment s(points[i], points[i + 1]);
-        const float d = s.distTo(pt);
-        if (dist < 0 || d < dist) {
-            close_segment = s;
-            dist = d;
-        }
-    }
+//     // find where to start the path
+//     Segment close_segment;
+//     float dist = -1;
+//     unsigned int i = (points.front().nearPoint(pt, 0.02)) ? 1 : 0;
+//     vector<Point>::const_iterator path_start = ++points.begin();
+//     for (; i < (points.size() - 1); ++i) {
+//         Segment s(points[i], points[i + 1]);
+//         const float d = s.distTo(pt);
+//         if (dist < 0 || d < dist) {
+//             close_segment = s;
+//             dist = d;
+//         }
+//     }
 
-    // slice path
-    // new path will be pt, [closest point on nearest segment], [i+1 to end]
-    if (dist > 0.0 && dist < 0.02) {
-        Geometry2d::Point intersection_pt = close_segment.nearestPoint(pt);
-        result.points.push_back(intersection_pt);
-    }
+//     // slice path
+//     // new path will be pt, [closest point on nearest segment], [i+1 to end]
+//     if (dist > 0.0 && dist < 0.02) {
+//         Point intersection_pt = close_segment.nearestPoint(pt);
+//         result.points.push_back(intersection_pt);
+//     }
 
-    result.points.insert(result.points.end(), path_start, points.end());
-}
+//     result.points.insert(result.points.end(), path_start, points.end());
+// }
 
-float InterpolatedPath::length(Geometry2d::Point pt) const {
+float InterpolatedPath::length(Point pt) const {
     float dist = -1;
     float length = 0;
-    if (points.empty()) {
+    if (waypoints.empty()) {
         return 0;
     }
 
-    for (unsigned int i = 0; i < (points.size() - 1); ++i) {
-        Geometry2d::Segment s(points[i], points[i + 1]);
+    for (unsigned int i = 0; i < (waypoints.size() - 1); ++i) {
+        Segment s(waypoints[i].pos, waypoints[i + 1].pos);
 
         // add the segment length
         length += s.length();
@@ -211,7 +201,7 @@ float InterpolatedPath::length(Geometry2d::Point pt) const {
         // if point closer to this segment
         if (dist < 0 || d < dist) {
             // closest point on segment
-            Geometry2d::Point p = s.nearestPoint(pt);
+            Point p = s.nearestPoint(pt);
 
             // new best distance
             dist = d;
@@ -225,46 +215,44 @@ float InterpolatedPath::length(Geometry2d::Point pt) const {
     return length;
 }
 
-bool InterpolatedPath::getPoint(float distance, Geometry2d::Point& position,
-                                Geometry2d::Point& direction) const {
-    if (distance <= 0) {
-        position = points.front();
-        return false;
-    }
-    if (points.empty()) {
-        return false;
-    }
-    for (unsigned int i = 0; i < (points.size() - 1); ++i) {
-        Geometry2d::Point vector(points[i + 1] - points[i]);
+// boos::optional<MotionInstant> InterpolatedPath::getPoint(float distance)
+// const {
+//     if (distance <= 0) {
+//         return boost::none;
+//     }
+//     if (points.empty()) {
+//         return boost::none;
+//     }
+//     for (unsigned int i = 0; i < (points.size() - 1); ++i) {
+//         Point vector(points[i + 1] - points[i]);
 
-        float vectorLength = vector.mag();
-        distance -= vectorLength;
+//         float vectorLength = vector.mag();
+//         distance -= vectorLength;
 
-        if (distance <= 0) {
-            distance += vectorLength;
-            position = points[i] + (vector * (distance / vectorLength));
-            direction = vector.normalized();
-            return true;
-        }
-    }
-    position = points.back();
-    return false;
-}
+//         if (distance <= 0) {
+//             distance += vectorLength;
+//             position = points[i] + (vector * (distance / vectorLength));
+//             direction = vector.normalized();
+//             return true;
+//         }
+//     }
+
+//     return boost::none;
+// }
 
 void InterpolatedPath::draw(SystemState* const state,
                             const QColor& col = Qt::black,
                             const QString& layer = "Motion") const {
     Packet::DebugPath* dbg = state->logFrame->add_debug_paths();
     dbg->set_layer(state->findDebugLayer(layer));
-    for (Geometry2d::Point pt : points) {
-        *dbg->add_points() = pt;
+    for (const MotionInstant& waypoint : waypoints) {
+        *dbg->add_points() = waypoint.pos;
     }
     dbg->set_color(color(col));
     return;
 }
 
-bool InterpolatedPath::evaluate(float t,
-                                MotionInstant& targetMotionInstant) const {
+boost::optional<MotionInstant> InterpolatedPath::evaluate(float t) const {
     if (t < 0) {
         debugThrow(
             invalid_argument("A time less than 0 was entered for time t."));
@@ -283,7 +271,7 @@ bool InterpolatedPath::evaluate(float t,
     multiple values
         linearSpeed);   //
 
-    Geometry2d::Point direction;
+    Point direction;
     if(!getPoint(linearPos, targetPosOut, direction)) {
         return false;
     }
@@ -291,11 +279,9 @@ bool InterpolatedPath::evaluate(float t,
     targetVelOut = direction * linearSpeed;
     */
     if (times.size() == 0) {
-        targetMotionInstant = MotionInstant();
-        return false;
+        return boost::none;
     } else if (times.size() == 1) {
-        targetMotionInstant = MotionInstant(points[0], vels[0]);
-        return false;
+        return boost::none;
     }
     if (t < times[0]) {
         debugThrow(
@@ -305,31 +291,27 @@ bool InterpolatedPath::evaluate(float t,
     int i = 0;
     while (times[i] <= t) {
         if (times[i] == t) {
-            targetMotionInstant = MotionInstant(points[i], vels[i]);
-            return true;
+            return waypoints[i];
         }
         i++;
         if (i == size()) {
-            targetMotionInstant = MotionInstant(points[i - 1], vels[i - 1]);
-            return false;
+            return boost::none;
         }
     }
     float deltaT = (times[i] - times[i - 1]);
     if (deltaT == 0) {
-        targetMotionInstant = MotionInstant(points[i], vels[i]);
-        return true;
+        return waypoints[i];
     }
     float constant = (t - times[i - 1]) / deltaT;
 
-    targetMotionInstant =
-        MotionInstant(points[i - 1] * (1 - constant) + points[i] * (constant),
-                      vels[i - 1] * (1 - constant) + vels[i] * (constant));
-    return true;
+    return MotionInstant(
+        waypoints[i - 1].pos * (1 - constant) + waypoints[i].pos * (constant),
+        waypoints[i - 1].vel * (1 - constant) + waypoints[i].vel * (constant));
 }
 
-size_t InterpolatedPath::size() const { return points.size(); }
+size_t InterpolatedPath::size() const { return waypoints.size(); }
 
-bool InterpolatedPath::valid() const { return !points.empty(); }
+bool InterpolatedPath::valid() const { return !waypoints.empty(); }
 
 float InterpolatedPath::getTime(int index) const { return times[index]; }
 
@@ -390,16 +372,16 @@ unique_ptr<Path> InterpolatedPath::subPath(float startTime,
     // Add the first points to the InterpolatedPath
     path->times.push_back(0);
     if (times[start] == startTime) {
-        path->points.push_back(points[start]);
-        path->vels.push_back(vels[start]);
+        path->waypoints.push_back(waypoints[start]);
     } else {
         float deltaT = (times[start + 1] - times[start]);
         float constant = (times[start + 1] - startTime) / deltaT;
-        Point startPos =
-            points[start + 1] * (1 - constant) + points[start] * (constant);
-        Point vi = vels[start + 1] * (1 - constant) + vels[start] * (constant);
-        path->points.push_back(startPos);
-        path->vels.push_back(vi);
+        Point startPos = waypoints[start + 1].pos * (1 - constant) +
+                         waypoints[start].pos * (constant);
+        Point vi = waypoints[start + 1].vel * (1 - constant) +
+                   waypoints[start].vel * (constant);
+
+        path->waypoints.emplace_back(startPos, vi);
     }
 
     // Find the last point in the InterpolatedPath
@@ -408,8 +390,8 @@ unique_ptr<Path> InterpolatedPath::subPath(float startTime,
     size_t end;
     if (endTime >= getDuration()) {
         end = size() - 1;
-        vf = vels[end];
-        endPos = points[end];
+        vf = waypoints[end].vel;
+        endPos = waypoints[end].pos;
     } else {
         end = start + 1;
         while (times[end] < endTime) {
@@ -417,23 +399,22 @@ unique_ptr<Path> InterpolatedPath::subPath(float startTime,
         }
         float deltaT = (times[end] - times[end - 1]);
         float constant = (times[end] - endTime) / deltaT;
-        // endTime = times[end];
-        vf = vels[end] * (1 - constant) + vels[end - 1] * (constant);
-        endPos = points[end] * (1 - constant) + points[end - 1] * (constant);
+        vf = waypoints[end].vel * (1 - constant) +
+             waypoints[end - 1].vel * (constant);
+        endPos = waypoints[end].pos * (1 - constant) +
+                 waypoints[end - 1].pos * constant;
     }
 
     // Add all the points in the middle
     size_t i = start + 1;
     while (i < end) {
-        path->points.push_back(points[i]);
-        path->vels.push_back(vels[i]);
+        path->waypoints.push_back(waypoints[i]);
         path->times.push_back(times[i] - startTime);
         i++;
     }
 
     // Add the last point
-    path->points.push_back(endPos);
-    path->vels.push_back(vf);
+    path->waypoints.emplace_back(endPos, vf);
     path->times.push_back(endTime - startTime);
 
     return unique_ptr<Path>(path);
@@ -442,4 +423,5 @@ unique_ptr<Path> InterpolatedPath::subPath(float startTime,
 unique_ptr<Path> InterpolatedPath::clone() const {
     return unique_ptr<Path>(new InterpolatedPath(*this));
 }
-}
+
+}  // namespace Planning

--- a/soccer/planning/InterpolatedPath.hpp
+++ b/soccer/planning/InterpolatedPath.hpp
@@ -42,7 +42,7 @@ public:
         waypoints.push_back(instant);
     }
 
-    // Overriden Path Methods
+    // Overridden Path Methods
     virtual boost::optional<MotionInstant> destination() const override;
     virtual bool hit(const Geometry2d::CompositeShape& shape, float& hitTime,
                      float startTime) const override;
@@ -57,7 +57,11 @@ public:
 
     bool empty() const { return waypoints.empty(); }
 
-    void clear() { waypoints.clear(); }
+    /// Erase all path contents
+    void clear() {
+        waypoints.clear();
+        times.clear();
+    }
 
     /**
      * Calulates the length of the path
@@ -98,21 +102,6 @@ public:
 
     /// Returns the start of the path or boost::none if the path is empty.
     boost::optional<MotionInstant> start() const;
-
-    // Returns a new path starting from a given point
-    // void startFrom(Geometry2d::Point pt,
-    //                Planning::InterpolatedPath& result) const;
-
-    /**
-     * Evaluates the point and velocity of the robot at a given distance in the
-     * path.  Similar to evaluate(), but gets the MotionInstant at a given
-     * distance rather than time into the path.
-     *
-     * @param[in] distance A given distance from the start of the path
-     * @return The MotionInstant at the given distance into the path.  Returns
-     *     boost::none if the given distance is not in the range of the path.
-     */
-    // boost::optional<MotionInstant> getPoint(float distance) const;
 
     /**
      * Estimates how long it would take for the robot to get to a certain point

--- a/soccer/planning/MotionInstant.hpp
+++ b/soccer/planning/MotionInstant.hpp
@@ -16,6 +16,10 @@ struct MotionInstant {
     Geometry2d::Point pos;
     Geometry2d::Point vel;
 
+    friend bool operator==(const MotionInstant& a, const MotionInstant& b) {
+        return a.pos == b.pos && a.vel == b.vel;
+    }
+
     friend std::ostream& operator<<(std::ostream& stream,
                                     const MotionInstant& instant) {
         return stream << "MotionInstant(pos=" << instant.pos

--- a/soccer/planning/MotionInstant.hpp
+++ b/soccer/planning/MotionInstant.hpp
@@ -3,6 +3,7 @@
 #include <Geometry2d/Point.hpp>
 
 namespace Planning {
+
 /**
  * This class represents a robot's motion "state" at a given time, including
  * position and velocity.
@@ -14,5 +15,12 @@ struct MotionInstant {
 
     Geometry2d::Point pos;
     Geometry2d::Point vel;
+
+    friend std::ostream& operator<<(std::ostream& stream,
+                                    const MotionInstant& instant) {
+        return stream << "MotionInstant(pos=" << instant.pos
+                      << ", vel=" << instant.vel << ")";
+    }
 };
-}
+
+}  // namespace Planning

--- a/soccer/planning/Path.hpp
+++ b/soccer/planning/Path.hpp
@@ -1,10 +1,13 @@
 #pragma once
+
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/CompositeShape.hpp>
 #include <SystemState.hpp>
+#include "MotionInstant.hpp"
+
+#include <boost/optional.hpp>
 #include <QColor>
 #include <QString>
-#include "MotionInstant.hpp"
 
 namespace Planning {
 /**
@@ -15,21 +18,16 @@ public:
     virtual ~Path() {}
 
     /**
-     * A path describes the position and velocity a robot should be at for a
-     * particular time interval.  This method evalates the path at a given time
-     * and
-     * returns the target position and velocity of the robot.
+     * This method evalates the path at a given time and returns the target
+     * position and velocity of the robot.
      *
-     * @param[in] 	t Time (in seconds) since the robot started the path. Throws
-     * an exception if t<0
-     * @param[out] 	targetMotionInstant The position and velocity the robot
-     * would ideally be at at the given time
-     * @return 		true if the path is valid at time @t, false if you've gone
-     * past
-     * the end
+     * @param t Time (in seconds) since the robot started the path. Throws an
+     *     exception if t<0
+     * @return A MotionInstant containing the position and velocity at the given
+     *     time if @t is within the range of the path.  If @t is not within the
+     *     time range of this path, this method returns boost::none.
      */
-    virtual bool evaluate(float t,
-                          MotionInstant& targetMotionInstant) const = 0;
+    virtual boost::optional<MotionInstant> evaluate(float t) const = 0;
 
     /**
      * Returns true if the path hits an obstacle

--- a/soccer/planning/PathTest.cpp
+++ b/soccer/planning/PathTest.cpp
@@ -2,20 +2,21 @@
 #include <gtest/gtest.h>
 #include <planning/InterpolatedPath.hpp>
 #include <planning/CompositePath.hpp>
+#include <boost/optional/optional_io.hpp>
 
 using namespace std;
 using namespace Geometry2d;
-using namespace Planning;
 
-/* ************************************************************************* */
+namespace Planning {
+
 TEST(Path, nearestSegment) {
-    Geometry2d::Point p0, p1(1.0, 0.0), p2(2.0, 0.0), p3(3.0, 0.0);
+    Point p0, p1(1.0, 0.0), p2(2.0, 0.0), p3(3.0, 0.0);
 
-    Planning::InterpolatedPath path;
-    path.points.push_back(p0);
-    path.points.push_back(p1);
-    path.points.push_back(p2);
-    path.points.push_back(p3);
+    InterpolatedPath path;
+    path.waypoints.emplace_back(p0, Point());
+    path.waypoints.emplace_back(p1, Point());
+    path.waypoints.emplace_back(p2, Point());
+    path.waypoints.emplace_back(p3, Point());
 
     Segment actSeg = path.nearestSegment(Point(0.5, -0.5));
     EXPECT_FLOAT_EQ(p0.x, actSeg.pt[0].x);
@@ -24,103 +25,30 @@ TEST(Path, nearestSegment) {
     EXPECT_FLOAT_EQ(p1.y, actSeg.pt[1].y);
 }
 
-/* ************************************************************************* */
-TEST(Path, startFrom1) {
-    Geometry2d::Point p0, p1(1.0, 0.0), p2(2.0, 0.0), p3(3.0, 0.0);
-
-    Planning::InterpolatedPath path;
-    path.points.push_back(p0);
-    path.points.push_back(p1);
-    path.points.push_back(p2);
-    path.points.push_back(p3);
-
-    // simple case - on same axis as path
-    Planning::InterpolatedPath act;
-    path.startFrom(Point(-1.0, 0.0), act);
-
-    // verify
-    ASSERT_EQ(4, act.size());
-    EXPECT_FLOAT_EQ(-1.0, act.points[0].x);
-    EXPECT_FLOAT_EQ(0.0, act.points[0].y);
-    EXPECT_TRUE(act.points[1] == p1);
-}
-
-/* ************************************************************************* */
-TEST(Path, startFrom2) {
-    Geometry2d::Point p0, p1(1.0, 0.0), p2(2.0, 0.0), p3(3.0, 0.0);
-
-    Planning::InterpolatedPath path;
-    path.points.push_back(p0);
-    path.points.push_back(p1);
-    path.points.push_back(p2);
-    path.points.push_back(p3);
-
-    Point pt(0.5, -1.0);
-    Planning::InterpolatedPath act;
-    path.startFrom(pt, act);
-
-    // verify
-    ASSERT_EQ(4, act.size());
-    EXPECT_TRUE(pt == act.points[0]);
-    // EXPECT_FLOAT_EQ( 0.5, act.points[1].x); // fails
-    EXPECT_FLOAT_EQ(0.0, act.points[1].y);
-}
-
-/* ************************************************************************* */
-TEST(Path, startFrom3) {
-    Geometry2d::Point p0, p1(1.0, 0.0), p2(2.0, 0.0), p3(3.0, 0.0);
-
-    Planning::InterpolatedPath path;
-    path.points.push_back(p0);
-    path.points.push_back(p1);
-    path.points.push_back(p2);
-    path.points.push_back(p3);
-
-    Point pt(0.5, -0.01);
-    Planning::InterpolatedPath act;
-    path.startFrom(pt, act);
-
-    // verify
-    ASSERT_EQ(5, act.size());
-    EXPECT_TRUE(pt == act.points[0]);
-    // EXPECT_TRUE(p1 == act.points[1]); // fails
-}
-
 TEST(InterpolatedPath, evaluate) {
     Point p0(1, 1), p1(1, 2), p2(2, 2);
 
     InterpolatedPath path;
-    path.points.push_back(p0);
-    path.points.push_back(p1);
-    path.points.push_back(p2);
+    path.waypoints.emplace_back(p0, Point());
+    path.waypoints.emplace_back(p1, p1);
+    path.waypoints.emplace_back(p2, Point());
     path.times.push_back(0);
     path.times.push_back(3);
     path.times.push_back(6);
-    path.vels.push_back(Point(0, 0));
-    path.vels.push_back(p1);
-    path.vels.push_back(Point(0, 0));
-
-    MotionInstant out;
-    bool pathValid;
 
     // path should be invalid and at end state when t > duration
-    pathValid = path.evaluate(1000, out);
-    EXPECT_FLOAT_EQ(0, (out.pos - p2).mag());
-    EXPECT_FLOAT_EQ(0, out.vel.mag());
-    EXPECT_FALSE(pathValid);
+    auto out = path.evaluate(1000);
+    ASSERT_EQ(boost::none, out);
 }
 
 TEST(InterpolatedPath, subPath1) {
     InterpolatedPath path;
-    path.points.push_back(Point(1, 1));
-    path.points.push_back(Point(1, 2));
-    path.points.push_back(Point(1, 3));
+    path.waypoints.emplace_back(Point(1, 1), Point(0, 0));
+    path.waypoints.emplace_back(Point(1, 2), Point(1, 1));
+    path.waypoints.emplace_back(Point(1, 3), Point(0, 0));
     path.times.push_back(0);
     path.times.push_back(3);
     path.times.push_back(6);
-    path.vels.push_back(Point(0, 0));
-    path.vels.push_back(Point(1, 1));
-    path.vels.push_back(Point(0, 0));
 
     //  test invalid parameters to subPath()
     EXPECT_THROW(path.subPath(-1, 5), invalid_argument);
@@ -131,49 +59,43 @@ TEST(InterpolatedPath, subPath1) {
     //  make a subpath that cuts off one second from the start and end of the
     //  original
     unique_ptr<Path> subPath = path.subPath(1, 5);
-    MotionInstant mid;
     float midTime = (5 - 1) / 2.0;
-    bool valid = subPath->evaluate(midTime, mid);
-    EXPECT_TRUE(valid);
-    EXPECT_FLOAT_EQ(Point(1, 1).x, mid.vel.x);
+    auto mid = subPath->evaluate(midTime);
+    ASSERT_NE(boost::none, mid);
+    EXPECT_FLOAT_EQ(Point(1, 1).x, mid->vel.x);
 
     //  mid velocity of subpath should be the same as velocity of original path
-    EXPECT_FLOAT_EQ(Point(1, 1).y, mid.vel.y);
+    EXPECT_FLOAT_EQ(Point(1, 1).y, mid->vel.y);
 
-    EXPECT_FLOAT_EQ(1, mid.pos.x);
-    EXPECT_FLOAT_EQ(2, mid.pos.y);
+    EXPECT_FLOAT_EQ(1, mid->pos.x);
+    EXPECT_FLOAT_EQ(2, mid->pos.y);
 
     //  test the subpath at t = 0
-    MotionInstant start;
-    valid = subPath->evaluate(0, start);
-    EXPECT_TRUE(valid);
+    auto start = subPath->evaluate(0);
+    ASSERT_NE(boost::none, start);
 
     //  the starting velocity of the subpath should be somewhere between the 0
     //  and the velocity at the middle
-    EXPECT_GT(start.vel.mag(), 0);
-    EXPECT_LT(start.vel.mag(), Point(1, 1).mag());
+    EXPECT_GT(start->vel.mag(), 0);
+    EXPECT_LT(start->vel.mag(), Point(1, 1).mag());
 
     //  the starting position of the subpath should be somewhere between the
     //  start pos of the original path and the middle point
-    EXPECT_GT(start.pos.y, 1);
-    EXPECT_LT(start.pos.x, 2);
+    EXPECT_GT(start->pos.y, 1);
+    EXPECT_LT(start->pos.x, 2);
 }
 
 TEST(InterpolatedPath, subpath2) {
     // Create a test path
     InterpolatedPath path;
-    path.points.push_back(Point(1, 0));
-    path.points.push_back(Point(1, 2));
-    path.points.push_back(Point(-2, 19));
-    path.points.push_back(Point(1, 6));
+    path.waypoints.emplace_back(Point(1, 0), Point(0, 0));
+    path.waypoints.emplace_back(Point(1, 2), Point(-1, -1));
+    path.waypoints.emplace_back(Point(-2, 19), Point(1, 1));
+    path.waypoints.emplace_back(Point(1, 6), Point(0, 0));
     path.times.push_back(0);
     path.times.push_back(1);
     path.times.push_back(3);
     path.times.push_back(9);
-    path.vels.push_back(Point(0, 0));
-    path.vels.push_back(Point(-1, -1));
-    path.vels.push_back(Point(1, 1));
-    path.vels.push_back(Point(0, 0));
 
     // Create 6 subPaths of length 1.5
     vector<unique_ptr<Path>> subPaths;
@@ -184,16 +106,17 @@ TEST(InterpolatedPath, subpath2) {
 
     // Compare the subPaths to the origional path and check that the results of
     // evaluating the paths are close enough
-    MotionInstant org, sub;
     for (int i = 0; i < 6; i++) {
         for (float j = 0; j < 1.5; j += 0.001) {
-            bool validOrg = path.evaluate(i * 1.5 + j, org);
-            bool validSub = subPaths[i]->evaluate(j, sub);
-            EXPECT_NEAR(org.vel.x, sub.vel.x, 0.000001) << "i+j=" << i + j;
-            EXPECT_NEAR(org.vel.y, sub.vel.y, 0.000001) << "i+j=" << i + j;
-            EXPECT_NEAR(org.pos.x, sub.pos.x, 0.000001) << "i+j=" << i + j;
-            EXPECT_NEAR(org.pos.y, sub.pos.y, 0.00001) << "i+j=" << i + j;
-            EXPECT_EQ(validOrg, validSub) << "i+j=" << i + j;
+            auto org = path.evaluate(i * 1.5 + j);
+            auto sub = subPaths[i]->evaluate(j);
+
+            ASSERT_NE(boost::none, org);
+            ASSERT_NE(boost::none, sub);
+            EXPECT_NEAR(org->vel.x, sub->vel.x, 0.000001) << "i+j=" << i + j;
+            EXPECT_NEAR(org->vel.y, sub->vel.y, 0.000001) << "i+j=" << i + j;
+            EXPECT_NEAR(org->pos.x, sub->pos.x, 0.000001) << "i+j=" << i + j;
+            EXPECT_NEAR(org->pos.y, sub->pos.y, 0.00001) << "i+j=" << i + j;
         }
     }
 }
@@ -201,18 +124,14 @@ TEST(InterpolatedPath, subpath2) {
 TEST(CompositePath, CompositeSubPath) {
     // Create a test path
     InterpolatedPath path;
-    path.points.push_back(Point(1, 0));
-    path.points.push_back(Point(1, 2));
-    path.points.push_back(Point(-2, 19));
-    path.points.push_back(Point(1, 6));
+    path.waypoints.emplace_back(Point(1, 0), Point(0, 0));
+    path.waypoints.emplace_back(Point(1, 2), Point(-1, -1));
+    path.waypoints.emplace_back(Point(-2, 19), Point(1, 1));
+    path.waypoints.emplace_back(Point(1, 6), Point(0, 0));
     path.times.push_back(0);
     path.times.push_back(1);
     path.times.push_back(3);
     path.times.push_back(9);
-    path.vels.push_back(Point(0, 0));
-    path.vels.push_back(Point(-1, -1));
-    path.vels.push_back(Point(1, 1));
-    path.vels.push_back(Point(0, 0));
 
     // Create 6 subPaths and rejoin them together into one compositePath
     CompositePath compositePath;
@@ -222,16 +141,18 @@ TEST(CompositePath, CompositeSubPath) {
     }
     compositePath.append(path.subPath(7.5));
 
-    // Compare that the compositePath and origional path are mostly equal
+    // Compare that the compositePath and origonal path are mostly equal
     for (float i = 0; i <= 10; i += 0.001) {
-        MotionInstant org, sub;
-        bool validOrg = path.evaluate(i, org);
-        bool validSub = compositePath.evaluate(i, sub);
-        EXPECT_NEAR(org.vel.x, sub.vel.x, 0.000001) << "i=" << i;
-        EXPECT_NEAR(org.vel.y, sub.vel.y, 0.000001) << "i=" << i;
-        EXPECT_NEAR(org.pos.x, sub.pos.x, 0.000001) << "i=" << i;
-        EXPECT_NEAR(org.pos.y, sub.pos.y, 0.00001) << "i=" << i;
-        EXPECT_EQ(validOrg, validSub) << "i=" << i;
+        auto org = path.evaluate(i);
+        auto sub = compositePath.evaluate(i);
+        if (!org && !sub) break;
+
+        ASSERT_NE(boost::none, org);
+        ASSERT_NE(boost::none, sub);
+        EXPECT_NEAR(org->vel.x, sub->vel.x, 0.000001) << "i=" << i;
+        EXPECT_NEAR(org->vel.y, sub->vel.y, 0.000001) << "i=" << i;
+        EXPECT_NEAR(org->pos.x, sub->pos.x, 0.000001) << "i=" << i;
+        EXPECT_NEAR(org->pos.y, sub->pos.y, 0.00001) << "i=" << i;
     }
 
     // Create 9 subPaths from the compositePaths
@@ -246,14 +167,16 @@ TEST(CompositePath, CompositeSubPath) {
     // check that the results of evaluating the paths are close enough
     for (int i = 0; i < 9; i++) {
         for (float j = 0; j < 1; j += 0.1) {
-            MotionInstant org, sub;
-            bool validOrg = path.evaluate(i * 1 + j, org);
-            bool validSub = subPaths[i]->evaluate(j, sub);
-            EXPECT_NEAR(org.vel.x, sub.vel.x, 0.000001) << "i+j=" << i + j;
-            EXPECT_NEAR(org.vel.y, sub.vel.y, 0.000001) << "i+j=" << i + j;
-            EXPECT_NEAR(org.pos.x, sub.pos.x, 0.000001) << "i+j=" << i + j;
-            EXPECT_NEAR(org.pos.y, sub.pos.y, 0.00001) << "i+j=" << i + j;
-            EXPECT_EQ(validOrg, validSub) << "i+j=" << i + j;
+            auto org = path.evaluate(i * 1 + j);
+            auto sub = subPaths[i]->evaluate(j);
+            ASSERT_NE(boost::none, org);
+            ASSERT_NE(boost::none, sub);
+            EXPECT_NEAR(org->vel.x, sub->vel.x, 0.000001) << "i+j=" << i + j;
+            EXPECT_NEAR(org->vel.y, sub->vel.y, 0.000001) << "i+j=" << i + j;
+            EXPECT_NEAR(org->pos.x, sub->pos.x, 0.000001) << "i+j=" << i + j;
+            EXPECT_NEAR(org->pos.y, sub->pos.y, 0.00001) << "i+j=" << i + j;
         }
     }
 }
+
+}  // namespace Planning

--- a/soccer/planning/RRTPlanner.cpp
+++ b/soccer/planning/RRTPlanner.cpp
@@ -14,7 +14,6 @@
 using namespace std;
 using namespace Planning;
 
-
 Geometry2d::Point Planning::randomPoint() {
     float x =
         Field_Dimensions::Current_Dimensions.FloorWidth() * (drand48() - 0.5f);
@@ -185,8 +184,9 @@ Planning::InterpolatedPath* RRTPlanner::optimize(
         for (int i = 0; i + span < pts.size(); i++) {
             bool transitionValid = true;
             std::set<std::shared_ptr<Geometry2d::Shape>> newHitSet;
-            if (obstacles->hit(Geometry2d::Segment(pts[i].pos, pts[i + span].pos),
-                               newHitSet)) {
+            if (obstacles->hit(
+                    Geometry2d::Segment(pts[i].pos, pts[i + span].pos),
+                    newHitSet)) {
                 for (std::shared_ptr<Geometry2d::Shape> hit : newHitSet) {
                     if (startHitSet.find(hit) == startHitSet.end()) {
                         transitionValid = false;
@@ -295,9 +295,10 @@ Planning::InterpolatedPath* RRTPlanner::cubicBezier(
             t = ((float)j / (float)(interpolations)) / k;
             // 3 k (-(A (-1 + k t)^2) + k t (2 C - 3 C k t + D k t) + B (1 - 4 k
             // t + 3 k^2 t^2))
-            Geometry2d::Point vel = 3 * k * (-(p0 * pow(-1 + k * t, 2)) +
-                            k * t * (2 * p2 - 3 * p2 * k * t + p3 * k * t) +
-                            p1 * (1 - 4 * k * t + 3 * pow(k, 2) * pow(t, 2)));
+            Geometry2d::Point vel =
+                3 * k * (-(p0 * pow(-1 + k * t, 2)) +
+                         k * t * (2 * p2 - 3 * p2 * k * t + p3 * k * t) +
+                         p1 * (1 - 4 * k * t + 3 * pow(k, 2) * pow(t, 2)));
             pts.emplace_back(pos, vel);
             times.push_back(time + t);
         }

--- a/soccer/planning/RRTPlanner.cpp
+++ b/soccer/planning/RRTPlanner.cpp
@@ -14,6 +14,7 @@
 using namespace std;
 using namespace Planning;
 
+
 Geometry2d::Point Planning::randomPoint() {
     float x =
         Field_Dimensions::Current_Dimensions.FloorWidth() * (drand48() - 0.5f);
@@ -39,10 +40,8 @@ std::unique_ptr<Path> RRTPlanner::run(
 
     // Simple case: no path
     if (startInstant.pos == goal) {
-        path->points.push_back(startInstant.pos);
-
         path->times.push_back(0);
-        path->vels.push_back(Geometry2d::Point(0, 0));
+        path->waypoints.emplace_back(startInstant.pos, Geometry2d::Point());
         return unique_ptr<Path>(path);
     }
 
@@ -120,12 +119,11 @@ std::unique_ptr<Path> RRTPlanner::run(
     // see if we found a better global path
     path = makePath();
 
-    if (path && path->points.empty()) {
+    if (path && path->waypoints.empty()) {
         // FIXME: without these two lines, an empty path is returned which
         // causes errors down the line.
-        path->points.push_back(startInstant.pos);
         path->times.push_back(0);
-        path->vels.push_back(Geometry2d::Point(0, 0));
+        path->waypoints.emplace_back(startInstant.pos, Geometry2d::Point());
     }
     return unique_ptr<Path>(path);
 }
@@ -175,19 +173,19 @@ Planning::InterpolatedPath* RRTPlanner::optimize(
         return nullptr;
     }
 
-    vector<Geometry2d::Point> pts = path.points;
+    vector<MotionInstant>& pts = path.waypoints;
 
     // The set of obstacles the starting point was inside of
     std::set<std::shared_ptr<Geometry2d::Shape>> startHitSet;
 
-    obstacles->hit(pts[start], startHitSet);
+    obstacles->hit(pts[start].pos, startHitSet);
     int span = 2;
     while (span < pts.size()) {
         bool changed = false;
         for (int i = 0; i + span < pts.size(); i++) {
             bool transitionValid = true;
             std::set<std::shared_ptr<Geometry2d::Shape>> newHitSet;
-            if (obstacles->hit(Geometry2d::Segment(pts[i], pts[i + span]),
+            if (obstacles->hit(Geometry2d::Segment(pts[i].pos, pts[i + span].pos),
                                newHitSet)) {
                 for (std::shared_ptr<Geometry2d::Shape> hit : newHitSet) {
                     if (startHitSet.find(hit) == startHitSet.end()) {
@@ -208,8 +206,6 @@ Planning::InterpolatedPath* RRTPlanner::optimize(
         if (!changed) span++;
     }
     // Done with the path
-    // pts.push_back(path.points.back());
-    path.points = pts;
     return cubicBezier(path, obstacles, motionConstraints, vi);
 }
 
@@ -232,7 +228,7 @@ Planning::InterpolatedPath* RRTPlanner::cubicBezier(
     Planning::InterpolatedPath& path,
     const Geometry2d::CompositeShape* obstacles,
     const MotionConstraints& motionConstraints, Geometry2d::Point vi) {
-    int length = path.points.size();
+    int length = path.waypoints.size();
     int curvesNum = length - 1;
     if (curvesNum <= 0) {
         delete &path;
@@ -246,14 +242,14 @@ Planning::InterpolatedPath* RRTPlanner::cubicBezier(
     vector<double> ks2(length - 1);
 
     for (int i = 0; i < length; i++) {
-        pointsX[i] = path.points[i].x;
-        pointsY[i] = path.points[i].y;
+        pointsX[i] = path.waypoints[i].pos.x;
+        pointsY[i] = path.waypoints[i].pos.y;
     }
     float startSpeed = vi.mag();
 
     // This is pretty hacky;
     Geometry2d::Point startDirection =
-        (path.points[1] - path.points[0]).normalized();
+        (path.waypoints[1].pos - path.waypoints[0].pos).normalized();
     if (startSpeed < 0.3) {
         startSpeed = 0.3;
         vi = startDirection * startSpeed;
@@ -278,42 +274,38 @@ Planning::InterpolatedPath* RRTPlanner::cubicBezier(
     VectorXd solutionY = cubicBezierCalc(vi.y, vf.y, pointsY, ks, ks2);
 
     Geometry2d::Point p0, p1, p2, p3;
-    vector<Geometry2d::Point> pts;
-    vector<Geometry2d::Point> vels;
+    vector<MotionInstant> pts;
     vector<float> times;
     const int interpolations = 10;
     double time = 0;
 
     for (int i = 0; i < curvesNum; i++)  // access by reference to avoid copying
     {
-        p0 = path.points[i];
-        p3 = path.points[i + 1];
+        p0 = path.waypoints[i].pos;
+        p3 = path.waypoints[i + 1].pos;
         p1 = Geometry2d::Point(solutionX(i * 2), solutionY(i * 2));
         p2 = Geometry2d::Point(solutionX(i * 2 + 1), solutionY(i * 2 + 1));
 
         for (int j = 0; j < interpolations; j++) {
             double k = ks[i];
             float t = (((float)j / (float)(interpolations)));
-            Geometry2d::Point temp =
+            Geometry2d::Point pos =
                 pow(1.0 - t, 3) * p0 + 3.0 * pow(1.0 - t, 2) * t * p1 +
                 3 * (1.0 - t) * pow(t, 2) * p2 + pow(t, 3) * p3;
-            pts.push_back(temp);
             t = ((float)j / (float)(interpolations)) / k;
             // 3 k (-(A (-1 + k t)^2) + k t (2 C - 3 C k t + D k t) + B (1 - 4 k
             // t + 3 k^2 t^2))
-            temp = 3 * k * (-(p0 * pow(-1 + k * t, 2)) +
+            Geometry2d::Point vel = 3 * k * (-(p0 * pow(-1 + k * t, 2)) +
                             k * t * (2 * p2 - 3 * p2 * k * t + p3 * k * t) +
                             p1 * (1 - 4 * k * t + 3 * pow(k, 2) * pow(t, 2)));
-            vels.push_back(temp);
+            pts.emplace_back(pos, vel);
             times.push_back(time + t);
         }
         time += 1.0 / ks[i];
     }
-    pts.push_back(path.points[length - 1]);
-    vels.push_back(vf);
+    pts.emplace_back(path.waypoints[length - 1].pos, vf);
     times.push_back(time);
-    path.points = pts;
-    path.vels = vels;
+    path.waypoints = pts;
     path.times = times;
     return &path;
 }

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -97,4 +97,4 @@ protected:
                                     std::vector<double>& ks2);
 };
 
-} // namespace Planning
+}  // namespace Planning

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "PathPlanner.hpp"
+#include "SingleRobotPathPlanner.hpp"
 #include "Tree.hpp"
 #include <Geometry2d/CompositeShape.hpp>
 #include <Geometry2d/Point.hpp>
@@ -13,6 +13,7 @@
 #include <list>
 
 namespace Planning {
+
 /** generate a random point on the floor */
 Geometry2d::Point randomPoint();
 
@@ -25,7 +26,7 @@ Geometry2d::Point randomPoint();
  * You can check out our interactive RRT applet on GitHub here:
  * https://github.com/RoboJackets/rrt.
  */
-class RRTPlanner : public PathPlanner {
+class RRTPlanner : public SingleRobotPathPlanner {
 public:
     RRTPlanner(int maxIterations);
     /**
@@ -95,4 +96,5 @@ protected:
                                     std::vector<double>& ks,
                                     std::vector<double>& ks2);
 };
-}
+
+} // namespace Planning

--- a/soccer/planning/SingleRobotPathPlanner.hpp
+++ b/soccer/planning/SingleRobotPathPlanner.hpp
@@ -5,10 +5,11 @@
 #include <planning/Path.hpp>
 
 namespace Planning {
+
 /**
  * @brief Interface for Path Planners
  */
-class PathPlanner {
+class SingleRobotPathPlanner {
 public:
     /**
      * Returns an obstacle-free Path subject to the specified MotionContraints.
@@ -18,4 +19,5 @@ public:
         const MotionConstraints& motionConstraints,
         const Geometry2d::CompositeShape* obstacles) = 0;
 };
-}
+
+} // namespace Planning

--- a/soccer/planning/SingleRobotPathPlanner.hpp
+++ b/soccer/planning/SingleRobotPathPlanner.hpp
@@ -20,4 +20,4 @@ public:
         const Geometry2d::CompositeShape* obstacles) = 0;
 };
 
-} // namespace Planning
+}  // namespace Planning

--- a/soccer/planning/TrapezoidalPath.hpp
+++ b/soccer/planning/TrapezoidalPath.hpp
@@ -11,6 +11,7 @@
 #include <planning/Path.hpp>
 
 namespace Planning {
+
 /**
  * @brief Represents a straight-line path with a trapezoidal velocity profile
  *
@@ -53,8 +54,7 @@ public:
                                         maxSpeed, maxAcc, startSpeed, endSpeed);
     }
 
-    virtual bool evaluate(float time,
-                          MotionInstant& targetMotionInstant) const override {
+    virtual boost::optional<MotionInstant> evaluate(float time) const override {
         float distance;
         float speedOut;
         bool valid = TrapezoidalMotion(pathLength,  // PathLength
@@ -65,9 +65,10 @@ public:
                                        endSpeed,    // endSpeed
                                        distance,    // posOut
                                        speedOut);   // speedOut
-        targetMotionInstant.pos = pathDirection * distance + startPos;
-        targetMotionInstant.vel = pathDirection * speedOut;
-        return valid;
+        if (!valid) return boost::none;
+
+        return MotionInstant(pathDirection * distance + startPos,
+                             pathDirection * speedOut);
     }
 
     virtual bool hit(const Geometry2d::CompositeShape& shape, float& hitTime,
@@ -100,4 +101,5 @@ public:
         return nullptr;
     }
 };
-}
+
+}  // namespace Planning

--- a/soccer/planning/Tree.cpp
+++ b/soccer/planning/Tree.cpp
@@ -71,9 +71,9 @@ void Tree::addPath(Planning::InterpolatedPath& path, Point* dest,
         ++n;
     }
 
-    path.points.reserve(path.points.size() + n);
+    path.waypoints.reserve(path.waypoints.size() + n);
     for (Point* pt : points) {
-        path.points.push_back(pt->pos);
+        path.waypoints.emplace_back(pt->pos, Geometry2d::Point());
     }
 }
 


### PR DESCRIPTION
* renamed PathPlanner -> SingleRobotPathPlanner
* InterpolatedPath now has a vector of MotionInstant objects rather than separate vectors of position and velocity
* Path.evaluate() returns a boost::optional<MotionInstant> rather than having an output variable
* Removed unused methods: InterpolatedPath.{getPoint(), startFrom()}