### PR TITLE
Added a ShapeSet class

### DIFF
--- a/common/Geometry2d/CompositeShape.hpp
+++ b/common/Geometry2d/CompositeShape.hpp
@@ -37,7 +37,7 @@ public:
     /// adds @compShape's subshapes to the receiver
     void add(const CompositeShape& compShape);
 
-    const std::vector<std::shared_ptr<Shape> >& subshapes() const {
+    const std::vector<std::shared_ptr<Shape>>& subshapes() const {
         return _subshapes;
     }
 
@@ -47,33 +47,6 @@ public:
     bool empty() { return _subshapes.empty(); }
 
     unsigned int size() const { return _subshapes.size(); }
-
-    /**
-     * Checks if a given object hits obstacles in the group
-     *
-     * @param obj The object to collision test
-     * @param hitSet A set to add the colliding obstacles to
-     * @return A bool telling whether or not there were any collisions
-     */
-    template <typename T>
-    bool hit(const T& obj, std::set<std::shared_ptr<Shape> >& hitSet) const {
-        for (const_iterator it = begin(); it != end(); ++it) {
-            if ((*it)->hit(obj)) {
-                hitSet.insert(*it);
-            }
-        }
-
-        return !hitSet.empty();
-    }
-
-    bool hit(Point pt, std::set<std::shared_ptr<Shape> >& hitSet) const {
-        return hit<Point>(pt, hitSet);
-    }
-
-    bool hit(const Segment& seg,
-             std::set<std::shared_ptr<Shape> >& hitSet) const {
-        return hit<Segment>(seg, hitSet);
-    }
 
     /**
      * Checks if a given shape is in it
@@ -97,8 +70,8 @@ public:
     bool hit(const Segment& seg) const override { return hit<Segment>(seg); }
 
     // STL typedefs
-    typedef std::vector<std::shared_ptr<Shape> >::const_iterator const_iterator;
-    typedef std::vector<std::shared_ptr<Shape> >::iterator iterator;
+    typedef std::vector<std::shared_ptr<Shape>>::const_iterator const_iterator;
+    typedef std::vector<std::shared_ptr<Shape>>::iterator iterator;
     typedef std::shared_ptr<Shape> value_type;
 
     // STL Interface
@@ -110,10 +83,11 @@ public:
 
     std::string toString() override {
         std::stringstream str;
-        str << "Composite<";
+        str << "CompositeShape<";
         for (int i = 0; i < _subshapes.size(); i++) {
             str << _subshapes[i]->toString() << ", ";
         }
+        str << ">";
 
         return str.str();
     }
@@ -122,11 +96,12 @@ public:
         return _subshapes[index];
     }
 
-    std::shared_ptr<Shape> operator[](unsigned int index) const {
+    std::shared_ptr<const Shape> operator[](unsigned int index) const {
         return _subshapes[index];
     }
 
 private:
-    std::vector<std::shared_ptr<Shape> > _subshapes;
+    std::vector<std::shared_ptr<Shape>> _subshapes;
 };
-}
+
+}  // namespace Geometry2d

--- a/common/Geometry2d/Rect.cpp
+++ b/common/Geometry2d/Rect.cpp
@@ -1,6 +1,7 @@
 #include "Rect.hpp"
 #include "Point.hpp"
 #include "Segment.hpp"
+#include <Constants.hpp>
 
 using namespace std;
 
@@ -56,6 +57,8 @@ bool Rect::hit(const Segment& seg) const {
            seg.intersects(
                Segment(Point(maxx(), maxy()), Point(maxx(), miny())));
 }
+
+bool Rect::hit(Point pt) const { return nearPoint(pt, Robot_Radius); }
 
 void Rect::expand(Point p) {
     pt[0].x = min(pt[0].x, p.x);

--- a/common/Geometry2d/Rect.hpp
+++ b/common/Geometry2d/Rect.hpp
@@ -57,7 +57,7 @@ public:
 
     bool containsPoint(Point other) const override;
 
-    bool hit(Point pt) const override { return containsPoint(pt); }
+    bool hit(Point pt) const override;
 
     bool hit(const Segment& seg) const override;
 

--- a/common/Geometry2d/Shape.hpp
+++ b/common/Geometry2d/Shape.hpp
@@ -31,6 +31,7 @@ public:
         return false;
     }
 
+    /// Returns true if the given point is within one robot radius of the shape
     virtual bool hit(Point pt) const {
         throw std::runtime_error("Unimplemented method");
         return false;
@@ -41,15 +42,12 @@ public:
         return false;
     }
 
-    virtual std::string toString() {
-        std::stringstream str;
-        str << "Shape";
-        return str.str();
-    }
+    virtual std::string toString() { return "Shape"; }
 
     friend std::ostream& operator<<(std::ostream& stream, Shape& shape) {
         stream << shape.toString();
         return stream;
     }
 };
-}
+
+}  // namespace Geometry2d

--- a/common/Geometry2d/ShapeSet.hpp
+++ b/common/Geometry2d/ShapeSet.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "Shape.hpp"
+
+#include <vector>
+#include <memory>
+
+namespace Geometry2d {
+
+/// This class maintains a collection of Shape objects.
+class ShapeSet {
+public:
+    ShapeSet() {}
+
+    /// Initializes the set by iterating from @first to @last, which are
+    /// iterators into a collection of std::shared_ptr<Shape>.
+    template <class InputIt>
+    ShapeSet(InputIt first, InputIt last) {
+        while (first != last) {
+            add(*first++);
+        }
+    }
+
+    std::vector<std::shared_ptr<Shape>> shapes() { return _shapes; }
+    const std::vector<std::shared_ptr<Shape>> shapes() const { return _shapes; }
+
+    void add(std::shared_ptr<Shape> shape) { _shapes.push_back(shape); }
+
+    void add(const ShapeSet& other) {
+        for (auto shape : other.shapes()) {
+            add(shape);
+        }
+    }
+
+    /// Remove all shapes
+    void clear() { _shapes.clear(); }
+
+    /**
+     * Get a set of which shapes "hit" the given object.
+     *
+     * @param obj The object to collision test
+     * @return A set of all shapes that collide with the given object
+     */
+    template <typename T>
+    std::set<std::shared_ptr<Shape>> hitSet(const T& obj) const {
+        std::set<std::shared_ptr<Shape>> hits;
+        for (const auto& shape : _shapes) {
+            if (shape->hit(obj)) {
+                hits.insert(shape);
+            }
+        }
+        return hits;
+    }
+
+    /**
+     * Check if any of the shapes in this set "hit" the given object.
+     *
+     * @param obj The object to collision test
+     * @return True if one of the contained shapes hits the object.
+     */
+    template <typename T>
+    bool hit(const T& obj) const {
+        return !hitSet<T>(obj).empty();
+    }
+
+private:
+    std::vector<std::shared_ptr<Shape>> _shapes;
+};
+
+}  // namespace Geometry2d

--- a/common/Geometry2d/ShapeSet.hpp
+++ b/common/Geometry2d/ShapeSet.hpp
@@ -2,8 +2,9 @@
 
 #include "Shape.hpp"
 
-#include <vector>
 #include <memory>
+#include <set>
+#include <vector>
 
 namespace Geometry2d {
 

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -486,8 +486,7 @@ int OurRobot::consecutivePathChangeCount() const {
     return count > 0 ? count - 1 : 0;
 }
 
-void OurRobot::replanIfNeeded(
-    const Geometry2d::CompositeShape& global_obstacles) {
+void OurRobot::replanIfNeeded(const Geometry2d::ShapeSet& global_obstacles) {
     Planning::MotionCommand::CommandType lastCommandType = _lastCommandType;
     _lastCommandType = _motionCommand.getCommandType();
 
@@ -505,14 +504,14 @@ void OurRobot::replanIfNeeded(
     }
 
     // create and visualize obstacles
-    Geometry2d::CompositeShape full_obstacles(_local_obstacles);
+    Geometry2d::ShapeSet full_obstacles(_local_obstacles);
     // Adds our robots as obstacles only if they're within a certain distance
     // from this robot. This distance increases with velocity.
-    Geometry2d::CompositeShape self_obs = createRobotObstacles(
-                                   _state->self, _self_avoid_mask, this->pos,
-                                   0.6 + this->vel.mag()),
-                               opp_obs = createRobotObstacles(_state->opp,
-                                                              _opp_avoid_mask);
+    Geometry2d::ShapeSet self_obs = createRobotObstacles(
+                             _state->self, _self_avoid_mask, this->pos,
+                             0.6 + this->vel.mag()),
+                         opp_obs =
+                             createRobotObstacles(_state->opp, _opp_avoid_mask);
 
     if (_state->ball.valid) {
         std::shared_ptr<Geometry2d::Shape> ball_obs = createBallObstacle();
@@ -524,10 +523,10 @@ void OurRobot::replanIfNeeded(
     full_obstacles.add(opp_obs);
     full_obstacles.add(global_obstacles);
 
-    _state->drawCompositeShape(self_obs, Qt::gray,
-                               QString("self_obstacles_%1").arg(shell()));
-    _state->drawCompositeShape(opp_obs, Qt::gray,
-                               QString("opp_obstacles_%1").arg(shell()));
+    _state->drawShapeSet(self_obs, Qt::gray,
+                         QString("self_obstacles_%1").arg(shell()));
+    _state->drawShapeSet(opp_obs, Qt::gray,
+                         QString("opp_obstacles_%1").arg(shell()));
     if (_path && lastCommandType == _motionCommand.getCommandType()) {
         if (_motionCommand.getCommandType() ==
             Planning::MotionCommand::PathTarget) {

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -318,7 +318,7 @@ public:
     void localObstacles(const std::shared_ptr<Geometry2d::Shape>& obs) {
         _local_obstacles.add(obs);
     }
-    const Geometry2d::CompositeShape& localObstacles() const {
+    const Geometry2d::ShapeSet& localObstacles() const {
         return _local_obstacles;
     }
     void clearLocalObstacles() { _local_obstacles.clear(); }
@@ -371,7 +371,7 @@ public:
      * Replans the path if needed.
      * Sets some parameters on the path.
      */
-    void replanIfNeeded(const Geometry2d::CompositeShape& global_obstacles);
+    void replanIfNeeded(const Geometry2d::ShapeSet& global_obstacles);
 
     /**
      * status evaluations for choosing robots in behaviors - combines multiple
@@ -433,7 +433,7 @@ protected:
     SystemState* _state;
 
     /// set of obstacles added by plays
-    Geometry2d::CompositeShape _local_obstacles;
+    Geometry2d::ShapeSet _local_obstacles;
 
     /// masks for obstacle avoidance
     RobotMask _self_avoid_mask, _opp_avoid_mask;
@@ -467,9 +467,9 @@ protected:
      * or opp from _state
      */
     template <class ROBOT>
-    Geometry2d::CompositeShape createRobotObstacles(
-        const std::vector<ROBOT*>& robots, const RobotMask& mask) const {
-        Geometry2d::CompositeShape result;
+    Geometry2d::ShapeSet createRobotObstacles(const std::vector<ROBOT*>& robots,
+                                              const RobotMask& mask) const {
+        Geometry2d::ShapeSet result;
         for (size_t i = 0; i < mask.size(); ++i)
             if (mask[i] > 0 && robots[i] && robots[i]->visible)
                 result.add(std::shared_ptr<Geometry2d::Shape>(
@@ -489,10 +489,11 @@ protected:
      * or opp from _state
      */
     template <class ROBOT>
-    Geometry2d::CompositeShape createRobotObstacles(
-        const std::vector<ROBOT*>& robots, const RobotMask& mask,
-        Geometry2d::Point currentPosition, float checkRadius) const {
-        Geometry2d::CompositeShape result;
+    Geometry2d::ShapeSet createRobotObstacles(const std::vector<ROBOT*>& robots,
+                                              const RobotMask& mask,
+                                              Geometry2d::Point currentPosition,
+                                              float checkRadius) const {
+        Geometry2d::ShapeSet result;
         for (size_t i = 0; i < mask.size(); ++i)
             if (mask[i] > 0 && robots[i] && robots[i]->visible) {
                 if (currentPosition.distTo(robots[i]->pos) <= checkRadius) {

--- a/soccer/SystemState.cpp
+++ b/soccer/SystemState.cpp
@@ -91,17 +91,24 @@ void SystemState::drawShape(const std::shared_ptr<Geometry2d::Shape>& obs,
         std::dynamic_pointer_cast<Geometry2d::Circle>(obs);
     std::shared_ptr<Geometry2d::Polygon> polyObs =
         std::dynamic_pointer_cast<Geometry2d::Polygon>(obs);
+    std::shared_ptr<Geometry2d::CompositeShape> compObs =
+        std::dynamic_pointer_cast<Geometry2d::CompositeShape>(obs);
     if (circObs)
         drawCircle(circObs->center, circObs->radius(), color, layer);
     else if (polyObs)
         drawPolygon(polyObs->vertices, color, layer);
+    else if (compObs) {
+        for (const std::shared_ptr<Geometry2d::Shape>& obs :
+             compObs->subshapes())
+            drawShape(obs, color, layer);
+    }
 }
 
-void SystemState::drawCompositeShape(const Geometry2d::CompositeShape& group,
-                                     const QColor& color,
-                                     const QString& layer) {
-    for (const std::shared_ptr<Geometry2d::Shape>& obs : group)
-        drawShape(obs, color, layer);
+void SystemState::drawShapeSet(const Geometry2d::ShapeSet& shapes,
+                               const QColor& color, const QString& layer) {
+    for (auto& shape : shapes.shapes()) {
+        drawShape(shape, color, layer);
+    }
 }
 
 void SystemState::drawLine(const Geometry2d::Line& line, const QColor& qc,

--- a/soccer/SystemState.hpp
+++ b/soccer/SystemState.hpp
@@ -8,6 +8,7 @@
 #include <QColor>
 
 #include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 #include <Geometry2d/Segment.hpp>
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/Polygon.hpp>
@@ -103,23 +104,27 @@ public:
                    const QColor& color = Qt::black,
                    const QString& layer = QString());
     /** @ingroup drawing_functions */
-    void drawCompositeShape(const Geometry2d::CompositeShape& group,
-                            const QColor& color = Qt::black,
-                            const QString& layer = QString());
-
+    void drawShapeSet(const Geometry2d::ShapeSet& shapes,
+                      const QColor& color = Qt::black,
+                      const QString& layer = QString());
     Time timestamp;
     GameState gameState;
 
     /// All possible robots.
     ///
-    /// Robots that aren't on the field are present here because a robot may be
-    /// removed and replaced, and that particular robot may be important (e.g.
+    /// Robots that aren't on the field are present here because a robot may
+    /// be
+    /// removed and replaced, and that particular robot may be important
+    /// (e.g.
     /// goalie).
     ///
-    /// Plays need to keep Robot*'s around, so we can't just delete the robot
-    /// since the play needs to see that it is no longer visible.  We don't want
+    /// Plays need to keep Robot*'s around, so we can't just delete the
+    /// robot
+    /// since the play needs to see that it is no longer visible.  We don't
+    /// want
     /// multiple Robots for the same shell because that would give the
-    /// appearance that a new robot appeared when it was actually just pushed
+    /// appearance that a new robot appeared when it was actually just
+    /// pushed
     /// back on the field.
     std::vector<OurRobot*> self;
     std::vector<OpponentRobot*> opp;

--- a/soccer/gameplay/GameplayModule.cpp
+++ b/soccer/gameplay/GameplayModule.cpp
@@ -244,8 +244,8 @@ void Gameplay::GameplayModule::goalieID(int value) {
 /**
  * returns the group of obstacles for the field
  */
-Geometry2d::CompositeShape Gameplay::GameplayModule::globalObstacles() const {
-    Geometry2d::CompositeShape obstacles;
+Geometry2d::ShapeSet Gameplay::GameplayModule::globalObstacles() const {
+    Geometry2d::ShapeSet obstacles;
     if (_state->gameState.stayOnSide()) {
         obstacles.add(_sideObstacle);
     }
@@ -372,8 +372,8 @@ void Gameplay::GameplayModule::run() {
 
     /// determine global obstacles - field requirements
     /// Two versions - one set with goal area, another without for goalie
-    Geometry2d::CompositeShape global_obstacles = globalObstacles();
-    Geometry2d::CompositeShape obstacles_with_goals = global_obstacles;
+    Geometry2d::ShapeSet global_obstacles = globalObstacles();
+    Geometry2d::ShapeSet obstacles_with_goals = global_obstacles;
     obstacles_with_goals.add(_ourGoalArea);
     obstacles_with_goals.add(_theirGoalArea);
 

--- a/soccer/gameplay/GameplayModule.hpp
+++ b/soccer/gameplay/GameplayModule.hpp
@@ -9,6 +9,7 @@
 #include <Geometry2d/Polygon.hpp>
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 
 #include <set>
 #include <QMutex>
@@ -139,7 +140,7 @@ private:
     /**
      * Returns the current set of global obstacles, including the field
      */
-    Geometry2d::CompositeShape globalObstacles() const;
+    Geometry2d::ShapeSet globalObstacles() const;
 
     int _our_score_last_frame;
 

--- a/soccer/planning/CompositePath.cpp
+++ b/soccer/planning/CompositePath.cpp
@@ -43,7 +43,7 @@ boost::optional<MotionInstant> CompositePath::evaluate(float t) const {
     return boost::none;
 }
 
-bool CompositePath::hit(const CompositeShape& shape, float& hitTime,
+bool CompositePath::hit(const ShapeSet& obstacles, float& hitTime,
                         float startTime) const {
     if (paths.empty()) {
         return false;
@@ -54,7 +54,7 @@ bool CompositePath::hit(const CompositeShape& shape, float& hitTime,
         start++;
         float timeLength = path->getDuration();
         if (timeLength == std::numeric_limits<float>::infinity()) {
-            if (path->hit(shape, hitTime, startTime)) {
+            if (path->hit(obstacles, hitTime, startTime)) {
                 hitTime += totalTime;
                 return true;
             } else {
@@ -64,7 +64,7 @@ bool CompositePath::hit(const CompositeShape& shape, float& hitTime,
         startTime -= timeLength;
         if (startTime <= 0) {
             startTime += timeLength;
-            if (path->hit(shape, hitTime, startTime)) {
+            if (path->hit(obstacles, hitTime, startTime)) {
                 hitTime += totalTime;
                 return true;
             }
@@ -75,7 +75,7 @@ bool CompositePath::hit(const CompositeShape& shape, float& hitTime,
     }
 
     for (; start < paths.size(); start++) {
-        if (paths[start]->hit(shape, hitTime, 0)) {
+        if (paths[start]->hit(obstacles, hitTime, 0)) {
             hitTime += totalTime;
             return true;
         }

--- a/soccer/planning/CompositePath.hpp
+++ b/soccer/planning/CompositePath.hpp
@@ -2,7 +2,7 @@
 #include <planning/Path.hpp>
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/Segment.hpp>
-#include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 #include <Configuration.hpp>
 
 namespace Planning {
@@ -35,7 +35,7 @@ public:
     void append(std::unique_ptr<Path> path);
 
     virtual boost::optional<MotionInstant> evaluate(float t) const override;
-    virtual bool hit(const Geometry2d::CompositeShape& shape, float& hitTime,
+    virtual bool hit(const Geometry2d::ShapeSet& shape, float& hitTime,
                      float startTime = 0) const override;
     virtual void draw(SystemState* const state, const QColor& color = Qt::black,
                       const QString& layer = "Motion") const override;

--- a/soccer/planning/InterpolatedPath.cpp
+++ b/soccer/planning/InterpolatedPath.cpp
@@ -69,7 +69,7 @@ int InterpolatedPath::nearestIndex(Point pt) const {
     return index;
 }
 
-bool InterpolatedPath::hit(const CompositeShape& obstacles, float& hitTime,
+bool InterpolatedPath::hit(const ShapeSet& obstacles, float& hitTime,
                            float startTime) const {
     size_t start = 0;
     for (float t : times) {
@@ -87,15 +87,15 @@ bool InterpolatedPath::hit(const CompositeShape& obstacles, float& hitTime,
 
     // This code disregards obstacles which the robot starts in. This allows the
     // robot to move out a obstacle if it is already in one.
-    std::set<std::shared_ptr<Shape>> startHitSet;
-    obstacles.hit(waypoints[start].pos, startHitSet);
+    std::set<std::shared_ptr<Shape>> startHitSet =
+        obstacles.hitSet(waypoints[start].pos);
 
     for (size_t i = start; i < waypoints.size() - 1; i++) {
-        std::set<std::shared_ptr<Shape>> newHitSet;
-        if (obstacles.hit(Segment(waypoints[i].pos, waypoints[i + 1].pos),
-                          newHitSet)) {
+        std::set<std::shared_ptr<Shape>> newHitSet =
+            obstacles.hitSet(Segment(waypoints[i].pos, waypoints[i + 1].pos));
+        if (!newHitSet.empty()) {
             for (std::shared_ptr<Shape> hit : newHitSet) {
-                // If it hits something, check if the hit was in the origional
+                // If it hits something, check if the hit was in the original
                 // hitSet
                 if (startHitSet.find(hit) == startHitSet.end()) {
                     hitTime = times[i];

--- a/soccer/planning/InterpolatedPath.hpp
+++ b/soccer/planning/InterpolatedPath.hpp
@@ -3,7 +3,7 @@
 #include <planning/Path.hpp>
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/Segment.hpp>
-#include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 #include <Configuration.hpp>
 
 namespace Planning {
@@ -44,7 +44,7 @@ public:
 
     // Overridden Path Methods
     virtual boost::optional<MotionInstant> destination() const override;
-    virtual bool hit(const Geometry2d::CompositeShape& shape, float& hitTime,
+    virtual bool hit(const Geometry2d::ShapeSet& obstacles, float& hitTime,
                      float startTime) const override;
     virtual std::unique_ptr<Path> subPath(
         float startTime = 0,

--- a/soccer/planning/Path.hpp
+++ b/soccer/planning/Path.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Geometry2d/Point.hpp>
-#include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 #include <SystemState.hpp>
 #include "MotionInstant.hpp"
 
@@ -38,7 +38,7 @@ public:
      * @param[in] 	startTime The time on the path to start checking from
      * @return 		true if it hits an obstacle, otherwise false
      */
-    virtual bool hit(const Geometry2d::CompositeShape& shape, float& hitTime,
+    virtual bool hit(const Geometry2d::ShapeSet& obstacles, float& hitTime,
                      float startTime) const = 0;
 
     /**

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -2,7 +2,7 @@
 
 #include "SingleRobotPathPlanner.hpp"
 #include "Tree.hpp"
-#include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 #include <Geometry2d/Point.hpp>
 #include <planning/InterpolatedPath.hpp>
 #include <planning/MotionCommand.hpp>
@@ -40,10 +40,10 @@ public:
 
     /// run the path RRTplanner
     /// this will always populate path to be the path we need to travel
-    std::unique_ptr<Path> run(
-        MotionInstant startInstant, MotionInstant motionCommand,
-        const MotionConstraints& motionConstraints,
-        const Geometry2d::CompositeShape* obstacles) override;
+    std::unique_ptr<Path> run(MotionInstant startInstant,
+                              MotionInstant motionCommand,
+                              const MotionConstraints& motionConstraints,
+                              const Geometry2d::ShapeSet* obstacles) override;
 
 protected:
     MotionConstraints _motionConstraints;
@@ -61,7 +61,7 @@ protected:
     unsigned int _maxIterations;
 
     /// latest obstacles
-    const Geometry2d::CompositeShape* _obstacles;
+    const Geometry2d::ShapeSet* _obstacles;
 
     /** makes a path from the last point of each tree
      *  If the points don't match up...fail!
@@ -73,8 +73,7 @@ protected:
      *  Calles the cubicBezier optimization function.
      */
     Planning::InterpolatedPath* optimize(
-        Planning::InterpolatedPath& path,
-        const Geometry2d::CompositeShape* obstacles,
+        Planning::InterpolatedPath& path, const Geometry2d::ShapeSet* obstacles,
         const MotionConstraints& motionConstraints, Geometry2d::Point vi);
 
     /**
@@ -82,8 +81,7 @@ protected:
      * velocity planning
      */
     Planning::InterpolatedPath* cubicBezier(
-        Planning::InterpolatedPath& path,
-        const Geometry2d::CompositeShape* obstacles,
+        Planning::InterpolatedPath& path, const Geometry2d::ShapeSet* obstacles,
         const MotionConstraints& motionConstraints, Geometry2d::Point vi);
 
     /**

--- a/soccer/planning/SingleRobotPathPlanner.hpp
+++ b/soccer/planning/SingleRobotPathPlanner.hpp
@@ -17,7 +17,7 @@ public:
     virtual std::unique_ptr<Path> run(
         MotionInstant startInstant, MotionInstant endInstant,
         const MotionConstraints& motionConstraints,
-        const Geometry2d::CompositeShape* obstacles) = 0;
+        const Geometry2d::ShapeSet* obstacles) = 0;
 };
 
 }  // namespace Planning

--- a/soccer/planning/TrapezoidalPath.hpp
+++ b/soccer/planning/TrapezoidalPath.hpp
@@ -4,7 +4,7 @@
 #include "MotionConstraints.hpp"
 #include "MotionInstant.hpp"
 #include <Configuration.hpp>
-#include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/Segment.hpp>
 #include <Geometry2d/Segment.hpp>
@@ -71,7 +71,7 @@ public:
                              pathDirection * speedOut);
     }
 
-    virtual bool hit(const Geometry2d::CompositeShape& shape, float& hitTime,
+    virtual bool hit(const Geometry2d::ShapeSet& obstacles, float& hitTime,
                      float startTime = 0) const override {
         throw std::logic_error("This function is not implemented");
     }

--- a/soccer/planning/Tree.cpp
+++ b/soccer/planning/Tree.cpp
@@ -46,13 +46,13 @@ void Tree::clear() {
 }
 
 void Tree::init(Geometry2d::Point start,
-                const Geometry2d::CompositeShape* obstacles) {
+                const Geometry2d::ShapeSet* obstacles) {
     clear();
 
     _obstacles = obstacles;
 
     Point* p = new Point(start, nullptr);
-    _obstacles->hit(p->pos, p->hit);
+    p->hit = _obstacles->hitSet(p->pos);
     points.push_back(p);
 }
 
@@ -134,8 +134,9 @@ Tree::Point* FixedStepTree::extend(Geometry2d::Point pt, Tree::Point* base) {
     // If this move touches any obstacles that the starting point didn't already
     // touch,
     // it has entered an obstacle and will be rejected.
-    std::set<shared_ptr<Geometry2d::Shape>> moveHit;
-    if (_obstacles->hit(Geometry2d::Segment(pos, base->pos), moveHit)) {
+    std::set<shared_ptr<Geometry2d::Shape>> moveHit =
+        _obstacles->hitSet(Geometry2d::Segment(pos, base->pos));
+    if (!moveHit.empty()) {
         // We only care if there are any items in moveHit that are not in
         // point->hit, so
         // we don't store the result of set_difference.
@@ -152,7 +153,7 @@ Tree::Point* FixedStepTree::extend(Geometry2d::Point pt, Tree::Point* base) {
 
     // Allow this point to be added to the tree
     Point* p = new Point(pos, base);
-    _obstacles->hit(p->pos, p->hit);
+    p->hit = std::move(moveHit);
     points.push_back(p);
 
     return p;

--- a/soccer/planning/Tree.hpp
+++ b/soccer/planning/Tree.hpp
@@ -41,8 +41,7 @@ public:
     /** cleanup the tree */
     void clear();
 
-    void init(Geometry2d::Point start,
-              const Geometry2d::CompositeShape* obstacles);
+    void init(Geometry2d::Point start, const Geometry2d::ShapeSet* obstacles);
 
     /** find the point of the tree closest to @a pt */
     Point* nearest(Geometry2d::Point pt);
@@ -72,7 +71,7 @@ public:
     std::list<Point*> points;
 
 protected:
-    const Geometry2d::CompositeShape* _obstacles;
+    const Geometry2d::ShapeSet* _obstacles;
 };
 
 /** tree that grows based on fixed distance step */


### PR DESCRIPTION
This replaces most uses of CompositeShape, which we were using before as a collection of shapes.  Our previous setup had some edge cases where the path `hit()` method would behave incorrectly because the subshapes of separate CompositeShape were being merged into a single CompositeShape.  This fixes that issue and clarifies in many places that we're dealing with a collection of shapes rather than a shape built out of other shapes.

Also fixed the `Rect.hit()` method.