### PR TITLE
Refactored replanning and created IndependentMultiRobotPathPlanner

### DIFF
--- a/common/Geometry2d/CompositeShape.hpp
+++ b/common/Geometry2d/CompositeShape.hpp
@@ -37,7 +37,7 @@ public:
     /// adds @compShape's subshapes to the receiver
     void add(const CompositeShape& compShape);
 
-    const std::vector<std::shared_ptr<Shape> >& subshapes() const {
+    const std::vector<std::shared_ptr<Shape>>& subshapes() const {
         return _subshapes;
     }
 
@@ -47,33 +47,6 @@ public:
     bool empty() { return _subshapes.empty(); }
 
     unsigned int size() const { return _subshapes.size(); }
-
-    /**
-     * Checks if a given object hits obstacles in the group
-     *
-     * @param obj The object to collision test
-     * @param hitSet A set to add the colliding obstacles to
-     * @return A bool telling whether or not there were any collisions
-     */
-    template <typename T>
-    bool hit(const T& obj, std::set<std::shared_ptr<Shape> >& hitSet) const {
-        for (const_iterator it = begin(); it != end(); ++it) {
-            if ((*it)->hit(obj)) {
-                hitSet.insert(*it);
-            }
-        }
-
-        return !hitSet.empty();
-    }
-
-    bool hit(Point pt, std::set<std::shared_ptr<Shape> >& hitSet) const {
-        return hit<Point>(pt, hitSet);
-    }
-
-    bool hit(const Segment& seg,
-             std::set<std::shared_ptr<Shape> >& hitSet) const {
-        return hit<Segment>(seg, hitSet);
-    }
 
     /**
      * Checks if a given shape is in it
@@ -97,8 +70,8 @@ public:
     bool hit(const Segment& seg) const override { return hit<Segment>(seg); }
 
     // STL typedefs
-    typedef std::vector<std::shared_ptr<Shape> >::const_iterator const_iterator;
-    typedef std::vector<std::shared_ptr<Shape> >::iterator iterator;
+    typedef std::vector<std::shared_ptr<Shape>>::const_iterator const_iterator;
+    typedef std::vector<std::shared_ptr<Shape>>::iterator iterator;
     typedef std::shared_ptr<Shape> value_type;
 
     // STL Interface
@@ -110,10 +83,11 @@ public:
 
     std::string toString() override {
         std::stringstream str;
-        str << "Composite<";
+        str << "CompositeShape<";
         for (int i = 0; i < _subshapes.size(); i++) {
             str << _subshapes[i]->toString() << ", ";
         }
+        str << ">";
 
         return str.str();
     }
@@ -122,11 +96,12 @@ public:
         return _subshapes[index];
     }
 
-    std::shared_ptr<Shape> operator[](unsigned int index) const {
+    std::shared_ptr<const Shape> operator[](unsigned int index) const {
         return _subshapes[index];
     }
 
 private:
-    std::vector<std::shared_ptr<Shape> > _subshapes;
+    std::vector<std::shared_ptr<Shape>> _subshapes;
 };
-}
+
+}  // namespace Geometry2d

--- a/common/Geometry2d/Rect.cpp
+++ b/common/Geometry2d/Rect.cpp
@@ -1,6 +1,7 @@
 #include "Rect.hpp"
 #include "Point.hpp"
 #include "Segment.hpp"
+#include <Constants.hpp>
 
 using namespace std;
 
@@ -56,6 +57,8 @@ bool Rect::hit(const Segment& seg) const {
            seg.intersects(
                Segment(Point(maxx(), maxy()), Point(maxx(), miny())));
 }
+
+bool Rect::hit(Point pt) const { return nearPoint(pt, Robot_Radius); }
 
 void Rect::expand(Point p) {
     pt[0].x = min(pt[0].x, p.x);

--- a/common/Geometry2d/Rect.hpp
+++ b/common/Geometry2d/Rect.hpp
@@ -57,7 +57,7 @@ public:
 
     bool containsPoint(Point other) const override;
 
-    bool hit(Point pt) const override { return containsPoint(pt); }
+    bool hit(Point pt) const override;
 
     bool hit(const Segment& seg) const override;
 

--- a/common/Geometry2d/Shape.hpp
+++ b/common/Geometry2d/Shape.hpp
@@ -31,6 +31,7 @@ public:
         return false;
     }
 
+    /// Returns true if the given point is within one robot radius of the shape
     virtual bool hit(Point pt) const {
         throw std::runtime_error("Unimplemented method");
         return false;
@@ -41,15 +42,12 @@ public:
         return false;
     }
 
-    virtual std::string toString() {
-        std::stringstream str;
-        str << "Shape";
-        return str.str();
-    }
+    virtual std::string toString() { return "Shape"; }
 
     friend std::ostream& operator<<(std::ostream& stream, Shape& shape) {
         stream << shape.toString();
         return stream;
     }
 };
-}
+
+}  // namespace Geometry2d

--- a/common/Geometry2d/ShapeSet.hpp
+++ b/common/Geometry2d/ShapeSet.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "Shape.hpp"
+
+#include <vector>
+#include <memory>
+
+namespace Geometry2d {
+
+/// This class maintains a collection of Shape objects.
+class ShapeSet {
+public:
+    ShapeSet() {}
+
+    /// Initializes the set by iterating from @first to @last, which are
+    /// iterators into a collection of std::shared_ptr<Shape>.
+    template <class InputIt>
+    ShapeSet(InputIt first, InputIt last) {
+        while (first != last) {
+            add(*first++);
+        }
+    }
+
+    std::vector<std::shared_ptr<Shape>> shapes() { return _shapes; }
+    const std::vector<std::shared_ptr<Shape>> shapes() const { return _shapes; }
+
+    void add(std::shared_ptr<Shape> shape) { _shapes.push_back(shape); }
+
+    void add(const ShapeSet& other) {
+        for (auto shape : other.shapes()) {
+            add(shape);
+        }
+    }
+
+    /// Remove all shapes
+    void clear() { _shapes.clear(); }
+
+    /**
+     * Get a set of which shapes "hit" the given object.
+     *
+     * @param obj The object to collision test
+     * @return A set of all shapes that collide with the given object
+     */
+    template <typename T>
+    std::set<std::shared_ptr<Shape>> hitSet(const T& obj) const {
+        std::set<std::shared_ptr<Shape>> hits;
+        for (const auto& shape : _shapes) {
+            if (shape->hit(obj)) {
+                hits.insert(shape);
+            }
+        }
+        return hits;
+    }
+
+    /**
+     * Check if any of the shapes in this set "hit" the given object.
+     *
+     * @param obj The object to collision test
+     * @return True if one of the contained shapes hits the object.
+     */
+    template <typename T>
+    bool hit(const T& obj) const {
+        return !hitSet<T>(obj).empty();
+    }
+
+private:
+    std::vector<std::shared_ptr<Shape>> _shapes;
+};
+
+}  // namespace Geometry2d

--- a/common/Geometry2d/ShapeSet.hpp
+++ b/common/Geometry2d/ShapeSet.hpp
@@ -2,8 +2,9 @@
 
 #include "Shape.hpp"
 
-#include <vector>
 #include <memory>
+#include <set>
+#include <vector>
 
 namespace Geometry2d {
 

--- a/soccer/CMakeLists.txt
+++ b/soccer/CMakeLists.txt
@@ -24,6 +24,7 @@ set(ROBOCUP_LIB_SRC
     "NewRefereeModule.cpp"
     "planning/CompositePath.cpp"
     "planning/InterpolatedPath.cpp"
+    "planning/IndependentMultiRobotPathPlanner.cpp"
     "planning/MotionConstraints.cpp"
     "planning/RRTPlanner.cpp"
     "planning/SingleRobotPathPlanner.cpp"

--- a/soccer/CMakeLists.txt
+++ b/soccer/CMakeLists.txt
@@ -26,6 +26,7 @@ set(ROBOCUP_LIB_SRC
     "planning/InterpolatedPath.cpp"
     "planning/MotionConstraints.cpp"
     "planning/RRTPlanner.cpp"
+    "planning/SingleRobotPathPlanner.cpp"
     "planning/Tree.cpp"
     "Processor.cpp"
     "ProtobufTree.cpp"

--- a/soccer/CMakeLists.txt
+++ b/soccer/CMakeLists.txt
@@ -23,6 +23,7 @@ set(ROBOCUP_LIB_SRC
     "motion/TrapezoidalMotion.cpp"
     "NewRefereeModule.cpp"
     "planning/CompositePath.cpp"
+    "planning/DirectTargetPathPlanner.cpp"
     "planning/InterpolatedPath.cpp"
     "planning/IndependentMultiRobotPathPlanner.cpp"
     "planning/MotionConstraints.cpp"

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -31,8 +31,8 @@ QString LiveStyle("border:2px solid transparent");
 QString NonLiveStyle("border:2px solid red");
 
 static const std::vector<QString> defaultHiddenLayers{
-    "MotionControl", "Obstacles", "Planning0", "Planning1",
-    "Planning2",     "Planning3", "Planning4", "Planning5"};
+    "MotionControl", "Global Obstacles", "Planning0", "Planning1",
+    "Planning2",     "Planning3",        "Planning4", "Planning5"};
 
 void calcMinimumWidth(QWidget* widget, QString text) {
     QRect rect = QFontMetrics(widget->font()).boundingRect(text);

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -31,8 +31,8 @@ QString LiveStyle("border:2px solid transparent");
 QString NonLiveStyle("border:2px solid red");
 
 static const std::vector<QString> defaultHiddenLayers{
-    "MotionControl", "Planning0", "Planning1", "Planning2",
-    "Planning3",     "Planning4", "Planning5"};
+    "MotionControl", "Obstacles", "Planning0", "Planning1",
+    "Planning2",     "Planning3", "Planning4", "Planning5"};
 
 void calcMinimumWidth(QWidget* widget, QString text) {
     QRect rect = QFontMetrics(widget->font()).boundingRect(text);
@@ -303,10 +303,9 @@ void MainWindow::updateViews() {
              i < liveFrame->debug_layers_size(); ++i) {
             const QString name =
                 QString::fromStdString(liveFrame->debug_layers(i));
-            bool enabled =
-                !std::any_of(defaultHiddenLayers.begin(),
-                             defaultHiddenLayers.end(),
-                             [&](QString string) { return string == name; });
+            bool enabled = !std::any_of(
+                defaultHiddenLayers.begin(), defaultHiddenLayers.end(),
+                [&](QString string) { return string == name; });
             addLayer(i, name, enabled);
         }
 
@@ -392,9 +391,11 @@ void MainWindow::updateViews() {
     }
 
     _ui.refStage->setText(NewRefereeModuleEnums::stringFromStage(
-                              _processor->refereeModule()->stage).c_str());
+                              _processor->refereeModule()->stage)
+                              .c_str());
     _ui.refCommand->setText(NewRefereeModuleEnums::stringFromCommand(
-                                _processor->refereeModule()->command).c_str());
+                                _processor->refereeModule()->command)
+                                .c_str());
 
     // convert time left from ms to s and display it to two decimal places
     _ui.refTimeLeft->setText(tr("%1 s").arg(QString::number(
@@ -1051,7 +1052,7 @@ void MainWindow::on_debugLayers_customContextMenuRequested(const QPoint& pos) {
     QMenu menu;
     QAction* all = menu.addAction("All");
     QAction* none = menu.addAction("None");
-    QAction* single = nullptr, * notSingle = nullptr;
+    QAction *single = nullptr, *notSingle = nullptr;
     if (item) {
         single = menu.addAction("Only this");
         notSingle = menu.addAction("All except this");

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -303,9 +303,10 @@ void MainWindow::updateViews() {
              i < liveFrame->debug_layers_size(); ++i) {
             const QString name =
                 QString::fromStdString(liveFrame->debug_layers(i));
-            bool enabled = !std::any_of(
-                defaultHiddenLayers.begin(), defaultHiddenLayers.end(),
-                [&](QString string) { return string == name; });
+            bool enabled =
+                !std::any_of(defaultHiddenLayers.begin(),
+                             defaultHiddenLayers.end(),
+                             [&](QString string) { return string == name; });
             addLayer(i, name, enabled);
         }
 
@@ -391,11 +392,9 @@ void MainWindow::updateViews() {
     }
 
     _ui.refStage->setText(NewRefereeModuleEnums::stringFromStage(
-                              _processor->refereeModule()->stage)
-                              .c_str());
+                              _processor->refereeModule()->stage).c_str());
     _ui.refCommand->setText(NewRefereeModuleEnums::stringFromCommand(
-                                _processor->refereeModule()->command)
-                                .c_str());
+                                _processor->refereeModule()->command).c_str());
 
     // convert time left from ms to s and display it to two decimal places
     _ui.refTimeLeft->setText(tr("%1 s").arg(QString::number(
@@ -1052,7 +1051,7 @@ void MainWindow::on_debugLayers_customContextMenuRequested(const QPoint& pos) {
     QMenu menu;
     QAction* all = menu.addAction("All");
     QAction* none = menu.addAction("None");
-    QAction *single = nullptr, *notSingle = nullptr;
+    QAction* single = nullptr, * notSingle = nullptr;
     if (item) {
         single = menu.addAction("Only this");
         notSingle = menu.addAction("All except this");

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -404,7 +404,8 @@ void Processor::run() {
         Geometry2d::ShapeSet globalObstacles =
             _gameplayModule->globalObstacles();
         Geometry2d::ShapeSet globalObstaclesWithGoalZones = globalObstacles;
-        globalObstaclesWithGoalZones.add(_gameplayModule->goalZoneObstacles());
+        Geometry2d::ShapeSet goalZoneObstacles = _gameplayModule->goalZoneObstacles();
+        globalObstaclesWithGoalZones.add(goalZoneObstacles);
 
         // execute path planning for each robot
         for (OurRobot* r : _state.self) {
@@ -455,6 +456,11 @@ void Processor::run() {
                     r->path()->draw(&_state, Qt::magenta, "Planning");
                 }
             }
+        }
+
+        // Visualize obstacles
+        for (auto& shape : globalObstacles.shapes()) {
+            _state.drawShape(shape, Qt::black, "Global Obstacles");
         }
 
         // Run velocity controllers

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -401,6 +401,12 @@ void Processor::run() {
             _gameplayModule->run();
         }
 
+        // TODO: run path planning
+        
+
+
+        
+
         // Run velocity controllers
         for (OurRobot* robot : _state.self) {
             if (robot->visible) {

--- a/soccer/Processor.hpp
+++ b/soccer/Processor.hpp
@@ -27,6 +27,10 @@ namespace Gameplay {
 class GameplayModule;
 }
 
+namespace Planning {
+class MultiRobotPathPlanner;
+}
+
 class DebugQMutex : public QMutex {
 public:
     DebugQMutex(QMutex::RecursionMode mode = QMutex::NonRecursive)
@@ -255,6 +259,7 @@ private:
     // modules
     std::shared_ptr<NewRefereeModule> _refereeModule;
     std::shared_ptr<Gameplay::GameplayModule> _gameplayModule;
+    std::unique_ptr<Planning::MultiRobotPathPlanner> _pathPlanner;
     std::shared_ptr<BallTracker> _ballTracker;
 
     // mixes values from all joysticks to control the single manual robot

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -486,8 +486,7 @@ int OurRobot::consecutivePathChangeCount() const {
     return count > 0 ? count - 1 : 0;
 }
 
-void OurRobot::replanIfNeeded(
-    const Geometry2d::CompositeShape& global_obstacles) {
+void OurRobot::replanIfNeeded(const Geometry2d::ShapeSet& global_obstacles) {
     Planning::MotionCommand::CommandType lastCommandType = _lastCommandType;
     _lastCommandType = _motionCommand.getCommandType();
 
@@ -505,14 +504,14 @@ void OurRobot::replanIfNeeded(
     }
 
     // create and visualize obstacles
-    Geometry2d::CompositeShape full_obstacles(_local_obstacles);
+    Geometry2d::ShapeSet full_obstacles(_local_obstacles);
     // Adds our robots as obstacles only if they're within a certain distance
     // from this robot. This distance increases with velocity.
-    Geometry2d::CompositeShape self_obs = createRobotObstacles(
-                                   _state->self, _self_avoid_mask, this->pos,
-                                   0.6 + this->vel.mag()),
-                               opp_obs = createRobotObstacles(_state->opp,
-                                                              _opp_avoid_mask);
+    Geometry2d::ShapeSet self_obs = createRobotObstacles(
+                             _state->self, _self_avoid_mask, this->pos,
+                             0.6 + this->vel.mag()),
+                         opp_obs =
+                             createRobotObstacles(_state->opp, _opp_avoid_mask);
 
     if (_state->ball.valid) {
         std::shared_ptr<Geometry2d::Shape> ball_obs = createBallObstacle();
@@ -524,10 +523,10 @@ void OurRobot::replanIfNeeded(
     full_obstacles.add(opp_obs);
     full_obstacles.add(global_obstacles);
 
-    _state->drawCompositeShape(self_obs, Qt::gray,
-                               QString("self_obstacles_%1").arg(shell()));
-    _state->drawCompositeShape(opp_obs, Qt::gray,
-                               QString("opp_obstacles_%1").arg(shell()));
+    _state->drawShapeSet(self_obs, Qt::gray,
+                         QString("self_obstacles_%1").arg(shell()));
+    _state->drawShapeSet(opp_obs, Qt::gray,
+                         QString("opp_obstacles_%1").arg(shell()));
     if (_path && lastCommandType == _motionCommand.getCommandType()) {
         if (_motionCommand.getCommandType() ==
             Planning::MotionCommand::PathTarget) {

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -602,7 +602,7 @@ void OurRobot::replanIfNeeded(const Geometry2d::ShapeSet& globalObstacles) {
             switch (_motionCommand.getCommandType()) {
                 case Planning::MotionCommand::PathTarget:
                     path = _planner->run(MotionInstant(pos, vel),
-                                         _motionCommand.getPlanningTarget(),
+                                         _motionCommand,
                                          _motionConstraints, &fullObstacles);
                     break;
                 case Planning::MotionCommand::DirectTarget:

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -83,16 +83,11 @@ OurRobot::OurRobot(int shell, SystemState* state)
 
     _motionControl = new MotionControl(this);
 
-    _planner = nullptr;
-
     resetAvoidRobotRadii();
 
     _clearCmdText();
 }
 
-/**
- * ourrobot deconstructor, deletes motion control and planner
- */
 OurRobot::~OurRobot() {
     if (_motionControl) delete _motionControl;
     delete _cmdText;

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -601,9 +601,9 @@ void OurRobot::replanIfNeeded(const Geometry2d::ShapeSet& globalObstacles) {
             float endSpeed = _motionCommand.getDirectTarget(endTarget);
             switch (_motionCommand.getCommandType()) {
                 case Planning::MotionCommand::PathTarget:
-                    path = _planner->run(MotionInstant(pos, vel),
-                                         _motionCommand,
-                                         _motionConstraints, &fullObstacles);
+                    path =
+                        _planner->run(MotionInstant(pos, vel), _motionCommand,
+                                      _motionConstraints, &fullObstacles);
                     break;
                 case Planning::MotionCommand::DirectTarget:
                     path = unique_ptr<Planning::Path>(

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -462,7 +462,6 @@ std::shared_ptr<Geometry2d::Shape> OurRobot::createBallObstacle() const {
 void OurRobot::setPath(unique_ptr<Planning::Path> path) {
     _path = std::move(path);
     _pathInvalidated = false;
-    _pathStartTime = timestamp();
 }
 
 void OurRobot::replanIfNeeded(const Geometry2d::ShapeSet& globalObstacles) {
@@ -513,13 +512,13 @@ void OurRobot::replanIfNeeded(const Geometry2d::ShapeSet& globalObstacles) {
             // we automatically replan
             const Time kPathExpirationInterval =
                 *_replanTimeout * SecsToTimestamp;
-            if ((timestamp() - _pathStartTime) > kPathExpirationInterval) {
+            if ((timestamp() - _path->startTime()) > kPathExpirationInterval) {
                 _pathInvalidated = true;
             }
 
             MotionInstant target;
             float timeIntoPath =
-                ((float)(timestamp() - _pathStartTime)) * TimestampToSecs +
+                ((float)(timestamp() - _path->startTime())) * TimestampToSecs +
                 1.0f / 60.0f;
 
             boost::optional<MotionInstant> optTarget =
@@ -611,6 +610,7 @@ void OurRobot::replanIfNeeded(const Geometry2d::ShapeSet& globalObstacles) {
                         new Planning::TrapezoidalPath(
                             this->pos, this->vel.mag(), endTarget, endSpeed,
                             _motionConstraints));
+                    path->setStartTime(timestamp());
                     break;
                 default:
                     path = nullptr;

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -77,10 +77,7 @@ void OurRobot::createConfiguration(Configuration* cfg) {
 }
 
 OurRobot::OurRobot(int shell, SystemState* state)
-    : Robot(shell, true),
-      _path(),
-      _state(state),
-      _pathChangeHistory(PathChangeHistoryBufferSize) {
+    : Robot(shell, true), _path(), _state(state) {
     _cmdText = new std::stringstream();
 
     resetAvoidBall();
@@ -154,8 +151,6 @@ void OurRobot::resetForNextIteration() {
     if (verbose && visible)
         cout << "in OurRobot::resetForNextIteration()" << std::endl;
     robotText.clear();
-
-    _didSetPathThisIteration = false;
 
     _clearCmdText();
 
@@ -465,25 +460,9 @@ std::shared_ptr<Geometry2d::Shape> OurRobot::createBallObstacle() const {
 #pragma mark Motion
 
 void OurRobot::setPath(unique_ptr<Planning::Path> path) {
-    _didSetPathThisIteration = true;
-
     _path = std::move(path);
     _pathInvalidated = false;
     _pathStartTime = timestamp();
-}
-
-int OurRobot::consecutivePathChangeCount() const {
-    int count = 0;
-    for (auto itr = _pathChangeHistory.begin(); itr != _pathChangeHistory.end();
-         itr++) {
-        if (*itr) {
-            count++;
-        } else {
-            break;
-        }
-    }
-
-    return count > 0 ? count - 1 : 0;
 }
 
 void OurRobot::replanIfNeeded(const Geometry2d::ShapeSet& global_obstacles) {
@@ -492,8 +471,6 @@ void OurRobot::replanIfNeeded(const Geometry2d::ShapeSet& global_obstacles) {
 
     // if no goal, command robot to stop in place
     if (_state->gameState.state == GameState::Halt) {
-        // clear our history of path change times
-        _pathChangeHistory.clear();
         setPath(nullptr);
         return;
     }
@@ -665,10 +642,6 @@ void OurRobot::replanIfNeeded(const Geometry2d::ShapeSet& global_obstacles) {
     if (_path) {
         _path->draw(_state, Qt::magenta, "Planning");
     }
-
-    _pathChangeHistory.push_back(_didSetPathThisIteration);
-
-    return;
 }
 
 bool OurRobot::charged() const {

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -412,13 +412,6 @@ public:
     double distanceToChipLanding(int chipPower);
     uint8_t chipPowerForDistance(double distance);
 
-    Planning::SingleRobotPathPlanner* pathPlanner() { return _planner.get(); }
-
-    void setPathPlanner(
-        std::unique_ptr<Planning::SingleRobotPathPlanner> planner) {
-        _planner = std::move(planner);
-    }
-
     void setPath(std::unique_ptr<Planning::Path> path);
 
 protected:
@@ -435,9 +428,6 @@ protected:
 
     Planning::MotionCommand _motionCommand;
     MotionConstraints _motionConstraints;
-
-    std::unique_ptr<Planning::SingleRobotPathPlanner>
-        _planner;  /// single-robot RRT planner
 
     std::unique_ptr<Planning::Path> _path;  /// latest path
 

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -438,10 +438,6 @@ protected:
 
     std::unique_ptr<Planning::Path> _path;  /// latest path
 
-    /// whenever the constraints for the robot path are changed, this is set
-    /// to true to trigger a replan
-    bool _pathInvalidated;
-
     /**
      * Creates a set of obstacles from a given robot team mask,
      * where mask values < 0 create no obstacle, and larger values

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -171,7 +171,7 @@ public:
      * Saving the pointer may lead to seg faults as it may be deleted by the
      * Robot who owns it.
      */
-    const Planning::Path* path() const { return _path.get(); }
+    std::unique_ptr<Planning::Path>& path() { return _path; }
 
     /// clears old radioTx stuff, resets robot debug text, and clears local
     /// obstacles
@@ -313,7 +313,8 @@ public:
     }
     void clearLocalObstacles() { _local_obstacles.clear(); }
 
-    Geometry2d::ShapeSet collectAllObstacles(const Geometry2d::ShapeSet& globalObstacles);
+    Geometry2d::ShapeSet collectAllObstacles(
+        const Geometry2d::ShapeSet& globalObstacles);
 
     void approachAllOpponents(bool enable = true);
     void avoidAllOpponents(bool enable = true);
@@ -358,12 +359,6 @@ public:
      * carrier.
      */
     void shieldFromTeammates(float radius);
-
-    /**
-     * Replans the path if needed.
-     * Sets some parameters on the path.
-     */
-    void replanIfNeeded(const Geometry2d::ShapeSet& globalObstacles);
 
     /**
      * status evaluations for choosing robots in behaviors - combines multiple
@@ -417,6 +412,15 @@ public:
     double distanceToChipLanding(int chipPower);
     uint8_t chipPowerForDistance(double distance);
 
+    Planning::SingleRobotPathPlanner* pathPlanner() { return _planner.get(); }
+
+    void setPathPlanner(
+        std::unique_ptr<Planning::SingleRobotPathPlanner> planner) {
+        _planner = std::move(planner);
+    }
+
+    void setPath(std::unique_ptr<Planning::Path> path);
+
 protected:
     MotionControl* _motionControl;
 
@@ -430,13 +434,10 @@ protected:
     float _avoidBallRadius;  /// radius of ball obstacle
 
     Planning::MotionCommand _motionCommand;
-    Planning::MotionCommand::CommandType _lastCommandType;
     MotionConstraints _motionConstraints;
 
-    std::shared_ptr<Planning::SingleRobotPathPlanner>
+    std::unique_ptr<Planning::SingleRobotPathPlanner>
         _planner;  /// single-robot RRT planner
-
-    void setPath(std::unique_ptr<Planning::Path> path);
 
     std::unique_ptr<Planning::Path> _path;  /// latest path
 

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -203,14 +203,6 @@ public:
     Time pathStartTime() const { return _pathStartTime; }
 
     /**
-     * The number of consecutive times since now that we've set our path to
-     * something new. This causes issues in Motion Control because the path
-     * start time is constantly reset, so we track it here and compensate for it
-     * in MotionControl. See _pathChangeHistory for more info
-     */
-    int consecutivePathChangeCount() const;
-
-    /**
      * Sets the angleVelocity in the robot's MotionConstraints
      */
     void angleVelocity(const float angleVelocity);
@@ -518,29 +510,6 @@ protected:
 
 protected:
     friend class MotionControl;
-
-    /**
-     * There are a couple cases where the robot's path gets updated very often
-     * (almost every iteration):
-     * * the current path is blocked by an obstacle
-     * * the move() target keeps changing
-     *
-     * This causes the _pathStartTime to constantly be reset and motion control
-     * looks about zero seconds into the planned path and sends the robot a
-     * velocity command that's really really tiny, causing it to barely move at
-     * all.
-     *
-     * Our solution to this is to track the last N path changes in a circular
-     * buffer so we can tell if we're hitting this scenario.  If so, we can
-     * compensate, by having motion control look further into the path when
-     * commanding the robot.
-     */
-    boost::circular_buffer<bool> _pathChangeHistory;
-
-    /// the size of _pathChangeHistory
-    static const int PathChangeHistoryBufferSize = 10;
-
-    bool _didSetPathThisIteration;
 
 private:
     void _kick(uint8_t strength);

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -527,8 +527,6 @@ private:
     static ConfigDouble* _selfAvoidRadius;
     static ConfigDouble* _oppAvoidRadius;
     static ConfigDouble* _oppGoalieAvoidRadius;
-    static ConfigDouble* _goalChangeThreshold;
-    static ConfigDouble* _replanTimeout;
 };
 
 /**

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -200,8 +200,6 @@ public:
      */
     void moveDirect(Geometry2d::Point goal, float endSpeed = 0);
 
-    Time pathStartTime() const { return _pathStartTime; }
-
     /**
      * Sets the angleVelocity in the robot's MotionConstraints
      */
@@ -439,8 +437,6 @@ protected:
     void setPath(std::unique_ptr<Planning::Path> path);
 
     std::unique_ptr<Planning::Path> _path;  /// latest path
-
-    Time _pathStartTime;
 
     /// whenever the constraints for the robot path are changed, this is set
     /// to true to trigger a replan

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -318,7 +318,7 @@ public:
     void localObstacles(const std::shared_ptr<Geometry2d::Shape>& obs) {
         _local_obstacles.add(obs);
     }
-    const Geometry2d::CompositeShape& localObstacles() const {
+    const Geometry2d::ShapeSet& localObstacles() const {
         return _local_obstacles;
     }
     void clearLocalObstacles() { _local_obstacles.clear(); }
@@ -371,7 +371,7 @@ public:
      * Replans the path if needed.
      * Sets some parameters on the path.
      */
-    void replanIfNeeded(const Geometry2d::CompositeShape& global_obstacles);
+    void replanIfNeeded(const Geometry2d::ShapeSet& global_obstacles);
 
     /**
      * status evaluations for choosing robots in behaviors - combines multiple
@@ -433,7 +433,7 @@ protected:
     SystemState* _state;
 
     /// set of obstacles added by plays
-    Geometry2d::CompositeShape _local_obstacles;
+    Geometry2d::ShapeSet _local_obstacles;
 
     /// masks for obstacle avoidance
     RobotMask _self_avoid_mask, _opp_avoid_mask;
@@ -467,9 +467,9 @@ protected:
      * or opp from _state
      */
     template <class ROBOT>
-    Geometry2d::CompositeShape createRobotObstacles(
-        const std::vector<ROBOT*>& robots, const RobotMask& mask) const {
-        Geometry2d::CompositeShape result;
+    Geometry2d::ShapeSet createRobotObstacles(const std::vector<ROBOT*>& robots,
+                                              const RobotMask& mask) const {
+        Geometry2d::ShapeSet result;
         for (size_t i = 0; i < mask.size(); ++i)
             if (mask[i] > 0 && robots[i] && robots[i]->visible)
                 result.add(std::shared_ptr<Geometry2d::Shape>(
@@ -489,10 +489,11 @@ protected:
      * or opp from _state
      */
     template <class ROBOT>
-    Geometry2d::CompositeShape createRobotObstacles(
-        const std::vector<ROBOT*>& robots, const RobotMask& mask,
-        Geometry2d::Point currentPosition, float checkRadius) const {
-        Geometry2d::CompositeShape result;
+    Geometry2d::ShapeSet createRobotObstacles(const std::vector<ROBOT*>& robots,
+                                              const RobotMask& mask,
+                                              Geometry2d::Point currentPosition,
+                                              float checkRadius) const {
+        Geometry2d::ShapeSet result;
         for (size_t i = 0; i < mask.size(); ++i)
             if (mask[i] > 0 && robots[i] && robots[i]->visible) {
                 if (currentPosition.distTo(robots[i]->pos) <= checkRadius) {

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -363,7 +363,7 @@ public:
      * Replans the path if needed.
      * Sets some parameters on the path.
      */
-    void replanIfNeeded(const Geometry2d::ShapeSet& global_obstacles);
+    void replanIfNeeded(const Geometry2d::ShapeSet& globalObstacles);
 
     /**
      * status evaluations for choosing robots in behaviors - combines multiple
@@ -372,11 +372,9 @@ public:
     bool chipper_available() const;
     bool kicker_available() const;
     bool dribbler_available() const;
-    bool driving_available(bool require_all = true) const;  // checks for motor
-                                                            // faults - allows
-                                                            // one wheel failure
-                                                            // if require_all =
-                                                            // false
+
+    // checks for motor faults - allows one wheel failure if require_all = false
+    bool driving_available(bool require_all = true) const;
 
     // lower level status checks
     bool hasBall() const;

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -313,6 +313,8 @@ public:
     }
     void clearLocalObstacles() { _local_obstacles.clear(); }
 
+    Geometry2d::ShapeSet collectAllObstacles(const Geometry2d::ShapeSet& globalObstacles);
+
     void approachAllOpponents(bool enable = true);
     void avoidAllOpponents(bool enable = true);
 

--- a/soccer/SystemState.cpp
+++ b/soccer/SystemState.cpp
@@ -91,17 +91,24 @@ void SystemState::drawShape(const std::shared_ptr<Geometry2d::Shape>& obs,
         std::dynamic_pointer_cast<Geometry2d::Circle>(obs);
     std::shared_ptr<Geometry2d::Polygon> polyObs =
         std::dynamic_pointer_cast<Geometry2d::Polygon>(obs);
+    std::shared_ptr<Geometry2d::CompositeShape> compObs =
+        std::dynamic_pointer_cast<Geometry2d::CompositeShape>(obs);
     if (circObs)
         drawCircle(circObs->center, circObs->radius(), color, layer);
     else if (polyObs)
         drawPolygon(polyObs->vertices, color, layer);
+    else if (compObs) {
+        for (const std::shared_ptr<Geometry2d::Shape>& obs :
+             compObs->subshapes())
+            drawShape(obs, color, layer);
+    }
 }
 
-void SystemState::drawCompositeShape(const Geometry2d::CompositeShape& group,
-                                     const QColor& color,
-                                     const QString& layer) {
-    for (const std::shared_ptr<Geometry2d::Shape>& obs : group)
-        drawShape(obs, color, layer);
+void SystemState::drawShapeSet(const Geometry2d::ShapeSet& shapes,
+                               const QColor& color, const QString& layer) {
+    for (auto& shape : shapes.shapes()) {
+        drawShape(shape, color, layer);
+    }
 }
 
 void SystemState::drawLine(const Geometry2d::Line& line, const QColor& qc,

--- a/soccer/SystemState.hpp
+++ b/soccer/SystemState.hpp
@@ -112,19 +112,14 @@ public:
 
     /// All possible robots.
     ///
-    /// Robots that aren't on the field are present here because a robot may
-    /// be
-    /// removed and replaced, and that particular robot may be important
-    /// (e.g.
+    /// Robots that aren't on the field are present here because a robot may be
+    /// removed and replaced, and that particular robot may be important (e.g.
     /// goalie).
     ///
-    /// Plays need to keep Robot*'s around, so we can't just delete the
-    /// robot
-    /// since the play needs to see that it is no longer visible.  We don't
-    /// want
+    /// Plays need to keep Robot*'s around, so we can't just delete the robot
+    /// since the play needs to see that it is no longer visible.  We don't want
     /// multiple Robots for the same shell because that would give the
-    /// appearance that a new robot appeared when it was actually just
-    /// pushed
+    /// appearance that a new robot appeared when it was actually just pushed
     /// back on the field.
     std::vector<OurRobot*> self;
     std::vector<OpponentRobot*> opp;

--- a/soccer/SystemState.hpp
+++ b/soccer/SystemState.hpp
@@ -8,6 +8,7 @@
 #include <QColor>
 
 #include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 #include <Geometry2d/Segment.hpp>
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/Polygon.hpp>
@@ -103,23 +104,27 @@ public:
                    const QColor& color = Qt::black,
                    const QString& layer = QString());
     /** @ingroup drawing_functions */
-    void drawCompositeShape(const Geometry2d::CompositeShape& group,
-                            const QColor& color = Qt::black,
-                            const QString& layer = QString());
-
+    void drawShapeSet(const Geometry2d::ShapeSet& shapes,
+                      const QColor& color = Qt::black,
+                      const QString& layer = QString());
     Time timestamp;
     GameState gameState;
 
     /// All possible robots.
     ///
-    /// Robots that aren't on the field are present here because a robot may be
-    /// removed and replaced, and that particular robot may be important (e.g.
+    /// Robots that aren't on the field are present here because a robot may
+    /// be
+    /// removed and replaced, and that particular robot may be important
+    /// (e.g.
     /// goalie).
     ///
-    /// Plays need to keep Robot*'s around, so we can't just delete the robot
-    /// since the play needs to see that it is no longer visible.  We don't want
+    /// Plays need to keep Robot*'s around, so we can't just delete the
+    /// robot
+    /// since the play needs to see that it is no longer visible.  We don't
+    /// want
     /// multiple Robots for the same shell because that would give the
-    /// appearance that a new robot appeared when it was actually just pushed
+    /// appearance that a new robot appeared when it was actually just
+    /// pushed
     /// back on the field.
     std::vector<OurRobot*> self;
     std::vector<OpponentRobot*> opp;

--- a/soccer/gameplay/GameplayModule.cpp
+++ b/soccer/gameplay/GameplayModule.cpp
@@ -244,8 +244,8 @@ void Gameplay::GameplayModule::goalieID(int value) {
 /**
  * returns the group of obstacles for the field
  */
-Geometry2d::CompositeShape Gameplay::GameplayModule::globalObstacles() const {
-    Geometry2d::CompositeShape obstacles;
+Geometry2d::ShapeSet Gameplay::GameplayModule::globalObstacles() const {
+    Geometry2d::ShapeSet obstacles;
     if (_state->gameState.stayOnSide()) {
         obstacles.add(_sideObstacle);
     }
@@ -372,8 +372,8 @@ void Gameplay::GameplayModule::run() {
 
     /// determine global obstacles - field requirements
     /// Two versions - one set with goal area, another without for goalie
-    Geometry2d::CompositeShape global_obstacles = globalObstacles();
-    Geometry2d::CompositeShape obstacles_with_goals = global_obstacles;
+    Geometry2d::ShapeSet global_obstacles = globalObstacles();
+    Geometry2d::ShapeSet obstacles_with_goals = global_obstacles;
     obstacles_with_goals.add(_ourGoalArea);
     obstacles_with_goals.add(_theirGoalArea);
 

--- a/soccer/gameplay/GameplayModule.hpp
+++ b/soccer/gameplay/GameplayModule.hpp
@@ -101,6 +101,14 @@ public:
 
     void calculateFieldObstacles();
 
+    /**
+     * Returns the current set of global obstacles, including the field
+     */
+    Geometry2d::ShapeSet globalObstacles() const;
+
+    /// Returns a ShapeSet containing both goal zones
+    Geometry2d::ShapeSet goalZoneObstacles() const;
+
 protected:
     boost::python::object getRootPlay();
 
@@ -137,11 +145,6 @@ private:
     std::shared_ptr<Geometry2d::Polygon> _theirGoal;
 
     /// utility functions
-
-    /**
-     * Returns the current set of global obstacles, including the field
-     */
-    Geometry2d::ShapeSet globalObstacles() const;
 
     int _our_score_last_frame;
 

--- a/soccer/gameplay/GameplayModule.hpp
+++ b/soccer/gameplay/GameplayModule.hpp
@@ -27,6 +27,7 @@ class SystemState;
  * and the GameplayModule.
  */
 namespace Gameplay {
+
 /**
  * @brief Coordinator of high-level logic
  *

--- a/soccer/gameplay/GameplayModule.hpp
+++ b/soccer/gameplay/GameplayModule.hpp
@@ -9,6 +9,7 @@
 #include <Geometry2d/Polygon.hpp>
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 
 #include <set>
 #include <QMutex>
@@ -139,7 +140,7 @@ private:
     /**
      * Returns the current set of global obstacles, including the field
      */
-    Geometry2d::CompositeShape globalObstacles() const;
+    Geometry2d::ShapeSet globalObstacles() const;
 
     int _our_score_last_frame;
 

--- a/soccer/motion/MotionControl.cpp
+++ b/soccer/motion/MotionControl.cpp
@@ -143,7 +143,8 @@ void MotionControl::run() {
 
         // convert from microseconds to seconds
         float timeIntoPath =
-            ((float)(timestamp() - _robot->pathStartTime())) * TimestampToSecs +
+            ((float)(timestamp() - _robot->path()->startTime())) *
+                TimestampToSecs +
             1.0 / 60.0;
 
         // evaluate path - where should we be right now?

--- a/soccer/motion/MotionControl.hpp
+++ b/soccer/motion/MotionControl.hpp
@@ -57,8 +57,4 @@ private:
 
     static ConfigDouble* _max_acceleration;
     static ConfigDouble* _max_velocity;
-
-    // if the path just changed, we add this boost to the output velocity
-    // command (before velocity scaling to bot 'units')
-    static ConfigDouble* _path_change_boost;
 };

--- a/soccer/planning/CompositePath.cpp
+++ b/soccer/planning/CompositePath.cpp
@@ -43,7 +43,7 @@ boost::optional<MotionInstant> CompositePath::evaluate(float t) const {
     return boost::none;
 }
 
-bool CompositePath::hit(const CompositeShape& shape, float& hitTime,
+bool CompositePath::hit(const ShapeSet& obstacles, float& hitTime,
                         float startTime) const {
     if (paths.empty()) {
         return false;
@@ -54,7 +54,7 @@ bool CompositePath::hit(const CompositeShape& shape, float& hitTime,
         start++;
         float timeLength = path->getDuration();
         if (timeLength == std::numeric_limits<float>::infinity()) {
-            if (path->hit(shape, hitTime, startTime)) {
+            if (path->hit(obstacles, hitTime, startTime)) {
                 hitTime += totalTime;
                 return true;
             } else {
@@ -64,7 +64,7 @@ bool CompositePath::hit(const CompositeShape& shape, float& hitTime,
         startTime -= timeLength;
         if (startTime <= 0) {
             startTime += timeLength;
-            if (path->hit(shape, hitTime, startTime)) {
+            if (path->hit(obstacles, hitTime, startTime)) {
                 hitTime += totalTime;
                 return true;
             }
@@ -75,7 +75,7 @@ bool CompositePath::hit(const CompositeShape& shape, float& hitTime,
     }
 
     for (; start < paths.size(); start++) {
-        if (paths[start]->hit(shape, hitTime, 0)) {
+        if (paths[start]->hit(obstacles, hitTime, 0)) {
             hitTime += totalTime;
             return true;
         }

--- a/soccer/planning/CompositePath.hpp
+++ b/soccer/planning/CompositePath.hpp
@@ -2,7 +2,7 @@
 #include <planning/Path.hpp>
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/Segment.hpp>
-#include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 #include <Configuration.hpp>
 
 namespace Planning {
@@ -35,7 +35,7 @@ public:
     void append(std::unique_ptr<Path> path);
 
     virtual boost::optional<MotionInstant> evaluate(float t) const override;
-    virtual bool hit(const Geometry2d::CompositeShape& shape, float& hitTime,
+    virtual bool hit(const Geometry2d::ShapeSet& shape, float& hitTime,
                      float startTime = 0) const override;
     virtual void draw(SystemState* const state, const QColor& color = Qt::black,
                       const QString& layer = "Motion") const override;

--- a/soccer/planning/CompositePath.hpp
+++ b/soccer/planning/CompositePath.hpp
@@ -11,8 +11,8 @@ namespace Planning {
  * @brief Represents a motion path made up of a series of Paths.
  *
  * @details The path represents a function of position given time that the robot
- * should follow.
- * The path is made up of other Paths and can be made up of CompositePaths.
+ *     should follow. The path is made up of other Paths and can be made up of
+ *     CompositePaths.
  */
 class CompositePath : public Path {
 private:
@@ -45,6 +45,7 @@ public:
         float endTime = std::numeric_limits<float>::infinity()) const override;
     virtual boost::optional<MotionInstant> destination() const override;
     virtual std::unique_ptr<Path> clone() const override;
+    virtual bool valid() const override { return !paths.empty(); }
 };
 
 }  // namespace Planning

--- a/soccer/planning/CompositePath.hpp
+++ b/soccer/planning/CompositePath.hpp
@@ -45,7 +45,6 @@ public:
         float endTime = std::numeric_limits<float>::infinity()) const override;
     virtual boost::optional<MotionInstant> destination() const override;
     virtual std::unique_ptr<Path> clone() const override;
-    virtual bool valid() const override { return !paths.empty(); }
 };
 
 }  // namespace Planning

--- a/soccer/planning/DirectTargetPathPlanner.cpp
+++ b/soccer/planning/DirectTargetPathPlanner.cpp
@@ -5,8 +5,7 @@ namespace Planning {
 std::unique_ptr<Path> DirectTargetPathPlanner::run(
     MotionInstant startInstant, MotionCommand cmd,
     const MotionConstraints& motionConstraints,
-    const Geometry2d::ShapeSet* obstacles,
-    std::unique_ptr<Path> prevPath) {
+    const Geometry2d::ShapeSet* obstacles, std::unique_ptr<Path> prevPath) {
     if (shouldReplan(startInstant, cmd, motionConstraints, obstacles,
                      prevPath.get())) {
         Geometry2d::Point endTarget;

--- a/soccer/planning/DirectTargetPathPlanner.cpp
+++ b/soccer/planning/DirectTargetPathPlanner.cpp
@@ -1,0 +1,59 @@
+#include "DirectTargetPathPlanner.hpp"
+
+namespace Planning {
+
+std::unique_ptr<Path> DirectTargetPathPlanner::run(
+    MotionInstant startInstant, MotionCommand cmd,
+    const MotionConstraints& motionConstraints,
+    const Geometry2d::ShapeSet* obstacles,
+    std::unique_ptr<Path> prevPath) {
+    if (shouldReplan(startInstant, cmd, motionConstraints, obstacles,
+                     prevPath.get())) {
+        Geometry2d::Point endTarget;
+        float endSpeed = cmd.getDirectTarget(endTarget);
+        auto path =
+            std::unique_ptr<Planning::Path>(new Planning::TrapezoidalPath(
+                startInstant.pos, startInstant.vel.mag(), endTarget, endSpeed,
+                motionConstraints));
+        path->setStartTime(timestamp());
+        return std::move(path);
+    } else {
+        return std::move(prevPath);
+    }
+}
+
+bool DirectTargetPathPlanner::shouldReplan(
+    MotionInstant startInstant, MotionCommand cmd,
+    const MotionConstraints& motionConstraints,
+    const Geometry2d::ShapeSet* obstacles, const Path* prevPath) const {
+    if (!prevPath) {
+        return true;
+    } else {
+        // For DirectTarget commands, we replan if the goal position or
+        // velocity
+        // have changed beyond a certain threshold
+        Geometry2d::Point endTarget;
+        float endSpeed = cmd.getDirectTarget(endTarget);
+        float targetPosChange =
+            prevPath->destination()
+                ? (prevPath->destination()->pos - endTarget).mag()
+                : std::numeric_limits<float>::infinity();
+        float targetVelChange =
+            prevPath->destination()
+                ? (prevPath->destination()->vel.mag() - endSpeed)
+                : std::numeric_limits<float>::infinity();
+
+        if (targetPosChange >
+                Planning::SingleRobotPathPlanner::goalChangeThreshold() ||
+            targetVelChange >
+                Planning::SingleRobotPathPlanner::goalChangeThreshold()) {
+            // FIXME: goalChangeThreshold shouldn't be used for checking
+            // speed differences as it is in the above 'if' statement
+            return true;
+        }
+    }
+
+    return false;
+}
+
+}  // namespace Planning

--- a/soccer/planning/DirectTargetPathPlanner.hpp
+++ b/soccer/planning/DirectTargetPathPlanner.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "SingleRobotPathPlanner.hpp"
+#include "TrapezoidalPath.hpp"
+
+
+namespace Planning {
+
+class DirectTargetPathPlanner : public SingleRobotPathPlanner {
+public:
+
+    virtual std::unique_ptr<Path> run(
+        MotionInstant startInstant, MotionCommand cmd,
+        const MotionConstraints& motionConstraints,
+        const Geometry2d::ShapeSet* obstacles,
+        std::unique_ptr<Path> prevPath = nullptr) {
+        if (shouldReplan(startInstant, cmd, motionConstraints, obstacles,
+                         prevPath.get())) {
+            Geometry2d::Point endTarget;
+            float endSpeed = cmd.getDirectTarget(endTarget);
+            auto path =
+                std::unique_ptr<Planning::Path>(new Planning::TrapezoidalPath(
+                    startInstant.pos, startInstant.vel.mag(), endTarget,
+                    endSpeed, motionConstraints));
+            path->setStartTime(timestamp());
+            return std::move(path);
+        } else {
+            return std::move(prevPath);
+        }
+    }
+
+    bool shouldReplan(MotionInstant startInstant, MotionCommand cmd,
+                      const MotionConstraints& motionConstraints,
+                      const Geometry2d::ShapeSet* obstacles,
+                      const Path* prevPath) {
+        if (!prevPath) {
+            return true;
+        } else {
+            // For DirectTarget commands, we replan if the goal position or
+            // velocity
+            // have changed beyond a certain threshold
+            Geometry2d::Point endTarget;
+            float endSpeed = cmd.getDirectTarget(endTarget);
+            float targetPosChange =
+                prevPath->destination()
+                    ? (prevPath->destination()->pos - endTarget).mag()
+                    : std::numeric_limits<float>::infinity();
+            float targetVelChange =
+                prevPath->destination()
+                    ? (prevPath->destination()->vel.mag() - endSpeed)
+                    : std::numeric_limits<float>::infinity();
+
+            if (targetPosChange >
+                    Planning::SingleRobotPathPlanner::goalChangeThreshold() ||
+                targetVelChange >
+                    Planning::SingleRobotPathPlanner::goalChangeThreshold()) {
+                // FIXME: goalChangeThreshold shouldn't be used for checking
+                // speed differences as it is in the above 'if' statement
+                return true;
+            }
+        }
+
+        return false;
+    }
+};
+
+}  // namespace Planning

--- a/soccer/planning/DirectTargetPathPlanner.hpp
+++ b/soccer/planning/DirectTargetPathPlanner.hpp
@@ -5,65 +5,25 @@
 
 namespace Planning {
 
+/// Simple path planner that generates a straight-line path from the start
+/// instant to the goal, ignoring all obstacles.  This class will eventually be
+/// replaced by something better.
 class DirectTargetPathPlanner : public SingleRobotPathPlanner {
 public:
-    virtual std::unique_ptr<Path> run(
-        MotionInstant startInstant, MotionCommand cmd,
-        const MotionConstraints& motionConstraints,
-        const Geometry2d::ShapeSet* obstacles,
-        std::unique_ptr<Path> prevPath = nullptr) override {
-        if (shouldReplan(startInstant, cmd, motionConstraints, obstacles,
-                         prevPath.get())) {
-            Geometry2d::Point endTarget;
-            float endSpeed = cmd.getDirectTarget(endTarget);
-            auto path =
-                std::unique_ptr<Planning::Path>(new Planning::TrapezoidalPath(
-                    startInstant.pos, startInstant.vel.mag(), endTarget,
-                    endSpeed, motionConstraints));
-            path->setStartTime(timestamp());
-            return std::move(path);
-        } else {
-            return std::move(prevPath);
-        }
-    }
-
     MotionCommand::CommandType commandType() const override {
         return MotionCommand::CommandType::DirectTarget;
     }
 
+    virtual std::unique_ptr<Path> run(
+        MotionInstant startInstant, MotionCommand cmd,
+        const MotionConstraints& motionConstraints,
+        const Geometry2d::ShapeSet* obstacles,
+        std::unique_ptr<Path> prevPath = nullptr) override;
+
     bool shouldReplan(MotionInstant startInstant, MotionCommand cmd,
                       const MotionConstraints& motionConstraints,
                       const Geometry2d::ShapeSet* obstacles,
-                      const Path* prevPath) const {
-        if (!prevPath) {
-            return true;
-        } else {
-            // For DirectTarget commands, we replan if the goal position or
-            // velocity
-            // have changed beyond a certain threshold
-            Geometry2d::Point endTarget;
-            float endSpeed = cmd.getDirectTarget(endTarget);
-            float targetPosChange =
-                prevPath->destination()
-                    ? (prevPath->destination()->pos - endTarget).mag()
-                    : std::numeric_limits<float>::infinity();
-            float targetVelChange =
-                prevPath->destination()
-                    ? (prevPath->destination()->vel.mag() - endSpeed)
-                    : std::numeric_limits<float>::infinity();
-
-            if (targetPosChange >
-                    Planning::SingleRobotPathPlanner::goalChangeThreshold() ||
-                targetVelChange >
-                    Planning::SingleRobotPathPlanner::goalChangeThreshold()) {
-                // FIXME: goalChangeThreshold shouldn't be used for checking
-                // speed differences as it is in the above 'if' statement
-                return true;
-            }
-        }
-
-        return false;
-    }
+                      const Path* prevPath) const;
 };
 
 }  // namespace Planning

--- a/soccer/planning/DirectTargetPathPlanner.hpp
+++ b/soccer/planning/DirectTargetPathPlanner.hpp
@@ -3,17 +3,15 @@
 #include "SingleRobotPathPlanner.hpp"
 #include "TrapezoidalPath.hpp"
 
-
 namespace Planning {
 
 class DirectTargetPathPlanner : public SingleRobotPathPlanner {
 public:
-
     virtual std::unique_ptr<Path> run(
         MotionInstant startInstant, MotionCommand cmd,
         const MotionConstraints& motionConstraints,
         const Geometry2d::ShapeSet* obstacles,
-        std::unique_ptr<Path> prevPath = nullptr) {
+        std::unique_ptr<Path> prevPath = nullptr) override {
         if (shouldReplan(startInstant, cmd, motionConstraints, obstacles,
                          prevPath.get())) {
             Geometry2d::Point endTarget;
@@ -29,10 +27,14 @@ public:
         }
     }
 
+    MotionCommand::CommandType commandType() const override {
+        return MotionCommand::CommandType::DirectTarget;
+    }
+
     bool shouldReplan(MotionInstant startInstant, MotionCommand cmd,
                       const MotionConstraints& motionConstraints,
                       const Geometry2d::ShapeSet* obstacles,
-                      const Path* prevPath) {
+                      const Path* prevPath) const {
         if (!prevPath) {
             return true;
         } else {

--- a/soccer/planning/IndependentMultiRobotPathPlanner.cpp
+++ b/soccer/planning/IndependentMultiRobotPathPlanner.cpp
@@ -1,0 +1,31 @@
+#include "IndependentMultiRobotPathPlanner.hpp"
+
+namespace Planning {
+
+std::map<int, std::unique_ptr<Path>> IndependentMultiRobotPathPlanner::run(
+    std::map<int, PlanRequest> requests) {
+    std::map<int, std::unique_ptr<Path>> paths;
+
+    for (auto& entry : requests) {
+        int shell = entry.first;
+        PlanRequest& request = entry.second;
+        auto& prevPlanner = _planners[shell];
+
+        // Make sure we have the right planner.  If it changes from last time,
+        // delete the old path.
+        if (!prevPlanner ||
+            prevPlanner->commandType() != request.command.getCommandType()) {
+            _planners[shell] =
+                PlannerForCommandType(request.command.getCommandType());
+            request.prevPath = nullptr;
+        }
+
+        paths[shell] = _planners[shell]->run(
+            request.start, request.command, request.constraints,
+            request.obstacles.get(), std::move(request.prevPath));
+    }
+
+    return paths;
+}
+
+}  // namespace Planning

--- a/soccer/planning/IndependentMultiRobotPathPlanner.hpp
+++ b/soccer/planning/IndependentMultiRobotPathPlanner.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "MultiRobotPathPlanner.hpp"
+#include "SingleRobotPathPlanner.hpp"
+
+namespace Planning {
+
+/**
+ * @brief Interface for Path Planners that plan paths for a set of robots.
+ */
+class IndependentMultiRobotPathPlanner : public MultiRobotPathPlanner {
+public:
+    virtual std::map<int, std::unique_ptr<Path>> run(
+        std::map<int, PlanRequest> requests) override;
+
+private:
+    /// Map of shell id -> planner
+    std::map<int, std::unique_ptr<SingleRobotPathPlanner>> _planners;
+};
+
+}  // namespace Planning

--- a/soccer/planning/IndependentMultiRobotPathPlanner.hpp
+++ b/soccer/planning/IndependentMultiRobotPathPlanner.hpp
@@ -5,9 +5,9 @@
 
 namespace Planning {
 
-/**
- * @brief Interface for Path Planners that plan paths for a set of robots.
- */
+/// Plans paths for a collection of robots using a SingleRobotPathPlanner for
+/// each.  This planner doesn't take other robots' paths into account when
+/// planning, which means that occasionally the planned paths will collide.
 class IndependentMultiRobotPathPlanner : public MultiRobotPathPlanner {
 public:
     virtual std::map<int, std::unique_ptr<Path>> run(

--- a/soccer/planning/InterpolatedPath.cpp
+++ b/soccer/planning/InterpolatedPath.cpp
@@ -248,8 +248,6 @@ boost::optional<MotionInstant> InterpolatedPath::evaluate(float t) const {
 
 size_t InterpolatedPath::size() const { return waypoints.size(); }
 
-bool InterpolatedPath::valid() const { return !waypoints.empty(); }
-
 float InterpolatedPath::getTime(int index) const {
     return waypoints[index].time;
 }

--- a/soccer/planning/InterpolatedPath.cpp
+++ b/soccer/planning/InterpolatedPath.cpp
@@ -69,7 +69,7 @@ int InterpolatedPath::nearestIndex(Point pt) const {
     return index;
 }
 
-bool InterpolatedPath::hit(const CompositeShape& obstacles, float& hitTime,
+bool InterpolatedPath::hit(const ShapeSet& obstacles, float& hitTime,
                            float startTime) const {
     size_t start = 0;
     for (float t : times) {
@@ -87,15 +87,15 @@ bool InterpolatedPath::hit(const CompositeShape& obstacles, float& hitTime,
 
     // This code disregards obstacles which the robot starts in. This allows the
     // robot to move out a obstacle if it is already in one.
-    std::set<std::shared_ptr<Shape>> startHitSet;
-    obstacles.hit(waypoints[start].pos, startHitSet);
+    std::set<std::shared_ptr<Shape>> startHitSet =
+        obstacles.hitSet(waypoints[start].pos);
 
     for (size_t i = start; i < waypoints.size() - 1; i++) {
-        std::set<std::shared_ptr<Shape>> newHitSet;
-        if (obstacles.hit(Segment(waypoints[i].pos, waypoints[i + 1].pos),
-                          newHitSet)) {
+        std::set<std::shared_ptr<Shape>> newHitSet =
+            obstacles.hitSet(Segment(waypoints[i].pos, waypoints[i + 1].pos));
+        if (!newHitSet.empty()) {
             for (std::shared_ptr<Shape> hit : newHitSet) {
-                // If it hits something, check if the hit was in the origional
+                // If it hits something, check if the hit was in the original
                 // hitSet
                 if (startHitSet.find(hit) == startHitSet.end()) {
                     hitTime = times[i];

--- a/soccer/planning/InterpolatedPath.cpp
+++ b/soccer/planning/InterpolatedPath.cpp
@@ -11,12 +11,12 @@ using namespace Geometry2d;
 namespace Planning {
 
 InterpolatedPath::InterpolatedPath(Point p0) {
-    waypoints.emplace_back(p0, Point());
+    waypoints.emplace_back(MotionInstant(p0, Point()), 0);
 }
 
 InterpolatedPath::InterpolatedPath(Point p0, Point p1) {
-    waypoints.emplace_back(p0, Point());
-    waypoints.emplace_back(p1, Point());
+    waypoints.emplace_back(MotionInstant(p0, Point()), 0);
+    waypoints.emplace_back(MotionInstant(p1, Point()), 1);
 }
 
 float InterpolatedPath::length(unsigned int start) const {
@@ -30,7 +30,7 @@ float InterpolatedPath::length(unsigned int start, unsigned int end) const {
 
     float length = 0;
     for (unsigned int i = start; i < end; ++i) {
-        length += (waypoints[i + 1].pos - waypoints[i].pos).mag();
+        length += (waypoints[i + 1].pos() - waypoints[i].pos()).mag();
     }
     return length;
 }
@@ -39,14 +39,14 @@ boost::optional<MotionInstant> InterpolatedPath::start() const {
     if (waypoints.empty())
         return boost::none;
     else
-        return waypoints.front();
+        return waypoints.front().instant;
 }
 
 boost::optional<MotionInstant> InterpolatedPath::destination() const {
     if (waypoints.empty())
         return boost::none;
     else
-        return waypoints.back();
+        return waypoints.back().instant;
 }
 
 // Returns the index of the point in this path nearest to pt.
@@ -56,10 +56,10 @@ int InterpolatedPath::nearestIndex(Point pt) const {
     }
 
     int index = 0;
-    float dist = pt.distTo(waypoints[0].pos);
+    float dist = pt.distTo(waypoints[0].pos());
 
     for (unsigned int i = 1; i < waypoints.size(); ++i) {
-        float d = pt.distTo(waypoints[i].pos);
+        float d = pt.distTo(waypoints[i].pos());
         if (d < dist) {
             dist = d;
             index = i;
@@ -72,9 +72,9 @@ int InterpolatedPath::nearestIndex(Point pt) const {
 bool InterpolatedPath::hit(const ShapeSet& obstacles, float& hitTime,
                            float startTime) const {
     size_t start = 0;
-    for (float t : times) {
+    for (auto& entry : waypoints) {
         start++;
-        if (t > startTime) {
+        if (entry.time > startTime) {
             start--;
             break;
         }
@@ -88,17 +88,17 @@ bool InterpolatedPath::hit(const ShapeSet& obstacles, float& hitTime,
     // This code disregards obstacles which the robot starts in. This allows the
     // robot to move out a obstacle if it is already in one.
     std::set<std::shared_ptr<Shape>> startHitSet =
-        obstacles.hitSet(waypoints[start].pos);
+        obstacles.hitSet(waypoints[start].pos());
 
     for (size_t i = start; i < waypoints.size() - 1; i++) {
-        std::set<std::shared_ptr<Shape>> newHitSet =
-            obstacles.hitSet(Segment(waypoints[i].pos, waypoints[i + 1].pos));
+        std::set<std::shared_ptr<Shape>> newHitSet = obstacles.hitSet(
+            Segment(waypoints[i].pos(), waypoints[i + 1].pos()));
         if (!newHitSet.empty()) {
             for (std::shared_ptr<Shape> hit : newHitSet) {
                 // If it hits something, check if the hit was in the original
                 // hitSet
                 if (startHitSet.find(hit) == startHitSet.end()) {
-                    hitTime = times[i];
+                    hitTime = waypoints[i].time;
                     return true;
                 }
             }
@@ -115,7 +115,7 @@ float InterpolatedPath::distanceTo(Point pt) const {
 
     float dist = -1;
     for (unsigned int i = 0; i < (waypoints.size() - 1); ++i) {
-        Segment s(waypoints[i].pos, waypoints[i + 1].pos);
+        Segment s(waypoints[i].pos(), waypoints[i + 1].pos());
         const float d = s.distTo(pt);
 
         if (dist < 0 || d < dist) {
@@ -134,7 +134,7 @@ Segment InterpolatedPath::nearestSegment(Point pt) const {
     }
 
     for (unsigned int i = 0; i < (waypoints.size() - 1); ++i) {
-        Segment s(waypoints[i].pos, waypoints[i + 1].pos);
+        Segment s(waypoints[i].pos(), waypoints[i + 1].pos());
         const float d = s.distTo(pt);
 
         if (dist < 0 || d < dist) {
@@ -154,7 +154,7 @@ float InterpolatedPath::length(Point pt) const {
     }
 
     for (unsigned int i = 0; i < (waypoints.size() - 1); ++i) {
-        Segment s(waypoints[i].pos, waypoints[i + 1].pos);
+        Segment s(waypoints[i].pos(), waypoints[i + 1].pos());
 
         // add the segment length
         length += s.length();
@@ -183,8 +183,8 @@ void InterpolatedPath::draw(SystemState* const state,
                             const QString& layer = "Motion") const {
     Packet::DebugPath* dbg = state->logFrame->add_debug_paths();
     dbg->set_layer(state->findDebugLayer(layer));
-    for (const MotionInstant& waypoint : waypoints) {
-        *dbg->add_points() = waypoint.pos;
+    for (const Entry& entry : waypoints) {
+        *dbg->add_points() = entry.pos();
     }
     dbg->set_color(color(col));
     return;
@@ -216,46 +216,47 @@ boost::optional<MotionInstant> InterpolatedPath::evaluate(float t) const {
 
     targetVelOut = direction * linearSpeed;
     */
-    if (times.size() == 0) {
-        return boost::none;
-    } else if (times.size() == 1) {
+    if (waypoints.size() == 0 || waypoints.size() == 1) {
         return boost::none;
     }
-    if (t < times[0]) {
+    if (t < waypoints[0].time) {
         debugThrow(
             invalid_argument("The start time should not be less than zero"));
     }
 
     int i = 0;
-    while (times[i] <= t) {
-        if (times[i] == t) {
-            return waypoints[i];
+    while (waypoints[i].time <= t) {
+        if (waypoints[i].time == t) {
+            return waypoints[i].instant;
         }
         i++;
         if (i == size()) {
             return boost::none;
         }
     }
-    float deltaT = (times[i] - times[i - 1]);
+    float deltaT = (waypoints[i].time - waypoints[i - 1].time);
     if (deltaT == 0) {
-        return waypoints[i];
+        return waypoints[i].instant;
     }
-    float constant = (t - times[i - 1]) / deltaT;
+    float constant = (t - waypoints[i - 1].time) / deltaT;
 
-    return MotionInstant(
-        waypoints[i - 1].pos * (1 - constant) + waypoints[i].pos * (constant),
-        waypoints[i - 1].vel * (1 - constant) + waypoints[i].vel * (constant));
+    return MotionInstant(waypoints[i - 1].pos() * (1 - constant) +
+                             waypoints[i].pos() * (constant),
+                         waypoints[i - 1].vel() * (1 - constant) +
+                             waypoints[i].vel() * (constant));
 }
 
 size_t InterpolatedPath::size() const { return waypoints.size(); }
 
 bool InterpolatedPath::valid() const { return !waypoints.empty(); }
 
-float InterpolatedPath::getTime(int index) const { return times[index]; }
+float InterpolatedPath::getTime(int index) const {
+    return waypoints[index].time;
+}
 
 float InterpolatedPath::getDuration() const {
-    if (times.size() > 0) {
-        return times.back();
+    if (waypoints.size() > 0) {
+        return waypoints.back().time;
     } else {
         return 0;
     }
@@ -294,7 +295,7 @@ unique_ptr<Path> InterpolatedPath::subPath(float startTime,
         return this->clone();
     }
 
-    InterpolatedPath* path = new InterpolatedPath();
+    InterpolatedPath* subpath = new InterpolatedPath();
 
     // Bound the endTime to a reasonable time.
     endTime = min(endTime, getDuration());
@@ -302,24 +303,23 @@ unique_ptr<Path> InterpolatedPath::subPath(float startTime,
     // Find the first point in the vector of points which will be included in
     // the subPath
     size_t start = 0;
-    while (times[start] <= startTime) {
+    while (waypoints[start].time <= startTime) {
         start++;
     }
     start--;
 
     // Add the first points to the InterpolatedPath
-    path->times.push_back(0);
-    if (times[start] == startTime) {
-        path->waypoints.push_back(waypoints[start]);
+    if (waypoints[start].time == startTime) {
+        subpath->waypoints.emplace_back(waypoints[start].instant, 0);
     } else {
-        float deltaT = (times[start + 1] - times[start]);
-        float constant = (times[start + 1] - startTime) / deltaT;
-        Point startPos = waypoints[start + 1].pos * (1 - constant) +
-                         waypoints[start].pos * (constant);
-        Point vi = waypoints[start + 1].vel * (1 - constant) +
-                   waypoints[start].vel * (constant);
+        float deltaT = (waypoints[start + 1].time - waypoints[start].time);
+        float constant = (waypoints[start + 1].time - startTime) / deltaT;
+        Point startPos = waypoints[start + 1].pos() * (1 - constant) +
+                         waypoints[start].pos() * (constant);
+        Point vi = waypoints[start + 1].vel() * (1 - constant) +
+                   waypoints[start].vel() * (constant);
 
-        path->waypoints.emplace_back(startPos, vi);
+        subpath->waypoints.emplace_back(MotionInstant(startPos, vi), 0);
     }
 
     // Find the last point in the InterpolatedPath
@@ -328,40 +328,39 @@ unique_ptr<Path> InterpolatedPath::subPath(float startTime,
     size_t end;
     if (endTime >= getDuration()) {
         end = size() - 1;
-        vf = waypoints[end].vel;
-        endPos = waypoints[end].pos;
+        vf = waypoints[end].vel();
+        endPos = waypoints[end].pos();
     } else {
         end = start + 1;
-        while (times[end] < endTime) {
+        while (waypoints[end].time < endTime) {
             end++;
         }
-        float deltaT = (times[end] - times[end - 1]);
-        float constant = (times[end] - endTime) / deltaT;
-        vf = waypoints[end].vel * (1 - constant) +
-             waypoints[end - 1].vel * (constant);
-        endPos = waypoints[end].pos * (1 - constant) +
-                 waypoints[end - 1].pos * constant;
+        float deltaT = (waypoints[end].time - waypoints[end - 1].time);
+        float constant = (waypoints[end].time - endTime) / deltaT;
+        vf = waypoints[end].vel() * (1 - constant) +
+             waypoints[end - 1].vel() * (constant);
+        endPos = waypoints[end].pos() * (1 - constant) +
+                 waypoints[end - 1].pos() * constant;
     }
 
     // Add all the points in the middle
     size_t i = start + 1;
     while (i < end) {
-        path->waypoints.push_back(waypoints[i]);
-        path->times.push_back(times[i] - startTime);
+        subpath->waypoints.emplace_back(waypoints[i].instant,
+                                        waypoints[i].time - startTime);
         i++;
     }
 
     // Add the last point
-    path->waypoints.emplace_back(endPos, vf);
-    path->times.push_back(endTime - startTime);
+    subpath->waypoints.emplace_back(MotionInstant(endPos, vf),
+                                    endTime - startTime);
 
-    return unique_ptr<Path>(path);
+    return unique_ptr<Path>(subpath);
 }
 
 unique_ptr<Path> InterpolatedPath::clone() const {
     InterpolatedPath* cp = new InterpolatedPath();
     cp->waypoints = waypoints;
-    cp->times = times;
     cp->setStartTime(startTime());
     return std::unique_ptr<Path>(cp);
 }

--- a/soccer/planning/InterpolatedPath.cpp
+++ b/soccer/planning/InterpolatedPath.cpp
@@ -359,7 +359,11 @@ unique_ptr<Path> InterpolatedPath::subPath(float startTime,
 }
 
 unique_ptr<Path> InterpolatedPath::clone() const {
-    return unique_ptr<Path>(new InterpolatedPath(*this));
+    InterpolatedPath* cp = new InterpolatedPath();
+    cp->waypoints = waypoints;
+    cp->times = times;
+    cp->setStartTime(startTime());
+    return std::unique_ptr<Path>(cp);
 }
 
 }  // namespace Planning

--- a/soccer/planning/InterpolatedPath.hpp
+++ b/soccer/planning/InterpolatedPath.hpp
@@ -3,7 +3,7 @@
 #include <planning/Path.hpp>
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/Segment.hpp>
-#include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 #include <Configuration.hpp>
 
 namespace Planning {
@@ -44,7 +44,7 @@ public:
 
     // Overridden Path Methods
     virtual boost::optional<MotionInstant> destination() const override;
-    virtual bool hit(const Geometry2d::CompositeShape& shape, float& hitTime,
+    virtual bool hit(const Geometry2d::ShapeSet& obstacles, float& hitTime,
                      float startTime) const override;
     virtual std::unique_ptr<Path> subPath(
         float startTime = 0,

--- a/soccer/planning/InterpolatedPath.hpp
+++ b/soccer/planning/InterpolatedPath.hpp
@@ -66,6 +66,7 @@ public:
     virtual boost::optional<MotionInstant> evaluate(float t) const override;
     virtual float getDuration() const override;
     virtual std::unique_ptr<Path> clone() const override;
+    bool valid() const override { return !empty(); }
 
     bool empty() const { return waypoints.empty(); }
 
@@ -96,9 +97,6 @@ public:
 
     /** Returns number of waypoints */
     size_t size() const;
-
-    /** returns true if the path has non-zero size */
-    bool valid() const;
 
     // Returns the index of the point in this path nearest to pt.
     int nearestIndex(Geometry2d::Point pt) const;

--- a/soccer/planning/InterpolatedPath.hpp
+++ b/soccer/planning/InterpolatedPath.hpp
@@ -66,7 +66,6 @@ public:
     virtual boost::optional<MotionInstant> evaluate(float t) const override;
     virtual float getDuration() const override;
     virtual std::unique_ptr<Path> clone() const override;
-    bool valid() const override { return !empty(); }
 
     bool empty() const { return waypoints.empty(); }
 

--- a/soccer/planning/MotionCommand.hpp
+++ b/soccer/planning/MotionCommand.hpp
@@ -5,11 +5,10 @@
 #include "planning/MotionInstant.hpp"
 
 namespace Planning {
+
 /**
- * This class contains the motion constraints that the high-level logic sets for
+ * This class contains the motion constraints that the gameplay logic sets for
  * a robot.
- * For position: set EITHER @motionTarget OR @targetWorldVel.
- * For angle: set EITHER @targetAngleVel OR @faceTarget.
  */
 class MotionCommand {
 public:
@@ -63,4 +62,5 @@ private:
     // The type of command
     CommandType _commandType;
 };
-}
+
+}  // namespace Planning

--- a/soccer/planning/MotionInstant.hpp
+++ b/soccer/planning/MotionInstant.hpp
@@ -10,7 +10,7 @@ namespace Planning {
  */
 struct MotionInstant {
     explicit MotionInstant(Geometry2d::Point pos = {0, 0},
-                  Geometry2d::Point vel = {0, 0})
+                           Geometry2d::Point vel = {0, 0})
         : pos(pos), vel(vel) {}
 
     Geometry2d::Point pos;

--- a/soccer/planning/MotionInstant.hpp
+++ b/soccer/planning/MotionInstant.hpp
@@ -9,7 +9,7 @@ namespace Planning {
  * position and velocity.
  */
 struct MotionInstant {
-    MotionInstant(Geometry2d::Point pos = {0, 0},
+    explicit MotionInstant(Geometry2d::Point pos = {0, 0},
                   Geometry2d::Point vel = {0, 0})
         : pos(pos), vel(vel) {}
 

--- a/soccer/planning/MultiRobotPathPlanner.hpp
+++ b/soccer/planning/MultiRobotPathPlanner.hpp
@@ -10,6 +10,8 @@
 
 namespace Planning {
 
+/// The PlanRequest encapsulates all information that the planner needs to know
+/// about an individual robot in order to generate a path for it.
 struct PlanRequest {
     PlanRequest(MotionInstant start, MotionCommand command,
                 MotionConstraints constraints, std::unique_ptr<Path> prevPath,

--- a/soccer/planning/MultiRobotPathPlanner.hpp
+++ b/soccer/planning/MultiRobotPathPlanner.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <planning/MotionCommand.hpp>
+#include <planning/MotionConstraints.hpp>
+#include <planning/MotionInstant.hpp>
+#include <planning/Path.hpp>
+
+#include <map>
+#include <memory>
+
+namespace Planning {
+
+struct PlanRequest {
+    PlanRequest(MotionInstant start, MotionCommand command,
+                MotionConstraints constraints, std::unique_ptr<Path> prevPath,
+                std::shared_ptr<const Geometry2d::ShapeSet> obstacles)
+        : start(start),
+          command(command),
+          constraints(constraints),
+          prevPath(std::move(prevPath)),
+          obstacles(obstacles) {}
+
+    PlanRequest() {}
+
+    MotionInstant start;
+    MotionCommand command;
+    MotionConstraints constraints;
+    std::unique_ptr<Path> prevPath;
+    std::shared_ptr<const Geometry2d::ShapeSet> obstacles;
+};
+
+/**
+ * @brief Interface for Path Planners that plan paths for a set of robots.
+ */
+class MultiRobotPathPlanner {
+public:
+    virtual std::map<int, std::unique_ptr<Path>> run(
+        std::map<int, PlanRequest> requests) = 0;
+};
+
+}  // namespace Planning

--- a/soccer/planning/Path.hpp
+++ b/soccer/planning/Path.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Geometry2d/Point.hpp>
-#include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 #include <SystemState.hpp>
 #include "MotionInstant.hpp"
 
@@ -38,7 +38,7 @@ public:
      * @param[in] 	startTime The time on the path to start checking from
      * @return 		true if it hits an obstacle, otherwise false
      */
-    virtual bool hit(const Geometry2d::CompositeShape& shape, float& hitTime,
+    virtual bool hit(const Geometry2d::ShapeSet& obstacles, float& hitTime,
                      float startTime) const = 0;
 
     /**

--- a/soccer/planning/Path.hpp
+++ b/soccer/planning/Path.hpp
@@ -18,8 +18,6 @@ public:
     Path() : _startTime(0) {}
     virtual ~Path() {}
 
-    virtual bool valid() const = 0;
-
     /**
      * This method evalates the path at a given time and returns the target
      * position and velocity of the robot.

--- a/soccer/planning/Path.hpp
+++ b/soccer/planning/Path.hpp
@@ -18,6 +18,8 @@ public:
     Path() : _startTime(0) {}
     virtual ~Path() {}
 
+    virtual bool valid() const = 0;
+
     /**
      * This method evalates the path at a given time and returns the target
      * position and velocity of the robot.

--- a/soccer/planning/Path.hpp
+++ b/soccer/planning/Path.hpp
@@ -15,6 +15,7 @@ namespace Planning {
  */
 class Path {
 public:
+    Path() : _startTime(0) {}
     virtual ~Path() {}
 
     /**
@@ -82,5 +83,13 @@ public:
      * Returns a deep copy of the Path
      */
     virtual std::unique_ptr<Path> clone() const = 0;
+
+    /// The time the path starts at
+    const Time startTime() const { return _startTime; }
+    void setStartTime(Time t) { _startTime = t; }
+
+protected:
+    Time _startTime;
 };
-}
+
+}  // namespace Planning

--- a/soccer/planning/PathTest.cpp
+++ b/soccer/planning/PathTest.cpp
@@ -13,10 +13,10 @@ TEST(Path, nearestSegment) {
     Point p0, p1(1.0, 0.0), p2(2.0, 0.0), p3(3.0, 0.0);
 
     InterpolatedPath path;
-    path.waypoints.emplace_back(p0, Point());
-    path.waypoints.emplace_back(p1, Point());
-    path.waypoints.emplace_back(p2, Point());
-    path.waypoints.emplace_back(p3, Point());
+    path.waypoints.emplace_back(MotionInstant(p0, Point()), 0);
+    path.waypoints.emplace_back(MotionInstant(p1, Point()), 0);
+    path.waypoints.emplace_back(MotionInstant(p2, Point()), 0);
+    path.waypoints.emplace_back(MotionInstant(p3, Point()), 0);
 
     Segment actSeg = path.nearestSegment(Point(0.5, -0.5));
     EXPECT_FLOAT_EQ(p0.x, actSeg.pt[0].x);
@@ -29,12 +29,9 @@ TEST(InterpolatedPath, evaluate) {
     Point p0(1, 1), p1(1, 2), p2(2, 2);
 
     InterpolatedPath path;
-    path.waypoints.emplace_back(p0, Point());
-    path.waypoints.emplace_back(p1, p1);
-    path.waypoints.emplace_back(p2, Point());
-    path.times.push_back(0);
-    path.times.push_back(3);
-    path.times.push_back(6);
+    path.waypoints.emplace_back(MotionInstant(p0, Point()), 0);
+    path.waypoints.emplace_back(MotionInstant(p1, p1), 3);
+    path.waypoints.emplace_back(MotionInstant(p2, Point()), 6);
 
     // path should be invalid and at end state when t > duration
     auto out = path.evaluate(1000);
@@ -43,12 +40,9 @@ TEST(InterpolatedPath, evaluate) {
 
 TEST(InterpolatedPath, subPath1) {
     InterpolatedPath path;
-    path.waypoints.emplace_back(Point(1, 1), Point(0, 0));
-    path.waypoints.emplace_back(Point(1, 2), Point(1, 1));
-    path.waypoints.emplace_back(Point(1, 3), Point(0, 0));
-    path.times.push_back(0);
-    path.times.push_back(3);
-    path.times.push_back(6);
+    path.waypoints.emplace_back(MotionInstant(Point(1, 1), Point(0, 0)), 0);
+    path.waypoints.emplace_back(MotionInstant(Point(1, 2), Point(1, 1)), 3);
+    path.waypoints.emplace_back(MotionInstant(Point(1, 3), Point(0, 0)), 6);
 
     //  test invalid parameters to subPath()
     EXPECT_THROW(path.subPath(-1, 5), invalid_argument);
@@ -88,14 +82,10 @@ TEST(InterpolatedPath, subPath1) {
 TEST(InterpolatedPath, subpath2) {
     // Create a test path
     InterpolatedPath path;
-    path.waypoints.emplace_back(Point(1, 0), Point(0, 0));
-    path.waypoints.emplace_back(Point(1, 2), Point(-1, -1));
-    path.waypoints.emplace_back(Point(-2, 19), Point(1, 1));
-    path.waypoints.emplace_back(Point(1, 6), Point(0, 0));
-    path.times.push_back(0);
-    path.times.push_back(1);
-    path.times.push_back(3);
-    path.times.push_back(9);
+    path.waypoints.emplace_back(MotionInstant(Point(1, 0), Point(0, 0)), 0);
+    path.waypoints.emplace_back(MotionInstant(Point(1, 2), Point(-1, -1)), 1);
+    path.waypoints.emplace_back(MotionInstant(Point(-2, 19), Point(1, 1)), 3);
+    path.waypoints.emplace_back(MotionInstant(Point(1, 6), Point(0, 0)), 9);
 
     // Create 6 subPaths of length 1.5
     vector<unique_ptr<Path>> subPaths;
@@ -124,14 +114,10 @@ TEST(InterpolatedPath, subpath2) {
 TEST(CompositePath, CompositeSubPath) {
     // Create a test path
     InterpolatedPath path;
-    path.waypoints.emplace_back(Point(1, 0), Point(0, 0));
-    path.waypoints.emplace_back(Point(1, 2), Point(-1, -1));
-    path.waypoints.emplace_back(Point(-2, 19), Point(1, 1));
-    path.waypoints.emplace_back(Point(1, 6), Point(0, 0));
-    path.times.push_back(0);
-    path.times.push_back(1);
-    path.times.push_back(3);
-    path.times.push_back(9);
+    path.waypoints.emplace_back(MotionInstant(Point(1, 0), Point(0, 0)), 0);
+    path.waypoints.emplace_back(MotionInstant(Point(1, 2), Point(-1, -1)), 1);
+    path.waypoints.emplace_back(MotionInstant(Point(-2, 19), Point(1, 1)), 3);
+    path.waypoints.emplace_back(MotionInstant(Point(1, 6), Point(0, 0)), 9);
 
     // Create 6 subPaths and rejoin them together into one compositePath
     CompositePath compositePath;

--- a/soccer/planning/RRTPlanner.cpp
+++ b/soccer/planning/RRTPlanner.cpp
@@ -38,7 +38,10 @@ std::unique_ptr<Path> RRTPlanner::run(
         return unique_ptr<Path>(path);
     }
 
-    /// Locate a goal point that is obstacle-free
+    // Locate a goal point that is obstacle-free
+    //
+    // TODO: only use this new non- blocked goal if it's better than the one
+    // from the previous planning iteration (if any)
     goal.pos = findNonBlockedGoal(goal.pos, obstacles);
 
     // Run bi-directional RRT to generate a path.

--- a/soccer/planning/RRTPlanner.cpp
+++ b/soccer/planning/RRTPlanner.cpp
@@ -26,9 +26,11 @@ Geometry2d::Point randomPoint() {
 RRTPlanner::RRTPlanner(int maxIterations) : _maxIterations(maxIterations) {}
 
 std::unique_ptr<Path> RRTPlanner::run(
-    MotionInstant start, MotionInstant goal,
+    MotionInstant start, MotionCommand cmd,
     const MotionConstraints& motionConstraints,
     const Geometry2d::ShapeSet* obstacles) {
+    MotionInstant goal = cmd.getPlanningTarget();
+
     // Simple case: no path
     if (start.pos == goal.pos) {
         InterpolatedPath* path = new InterpolatedPath();

--- a/soccer/planning/RRTPlanner.cpp
+++ b/soccer/planning/RRTPlanner.cpp
@@ -29,6 +29,7 @@ std::unique_ptr<Path> RRTPlanner::run(
     const MotionConstraints& motionConstraints,
     const Geometry2d::ShapeSet* obstacles) {
     Planning::InterpolatedPath* path = new Planning::InterpolatedPath();
+    path->setStartTime(timestamp());
     Geometry2d::Point goal = endInstant.pos;
     _motionConstraints = motionConstraints;
     vi = startInstant.vel;
@@ -128,6 +129,7 @@ std::unique_ptr<Path> RRTPlanner::run(
 
 Planning::InterpolatedPath* RRTPlanner::makePath() {
     Planning::InterpolatedPath* newPath = new Planning::InterpolatedPath();
+    newPath->setStartTime(timestamp());
 
     Tree::Point* p0 = _fixedStepTree0.last();
     Tree::Point* p1 = _fixedStepTree1.last();

--- a/soccer/planning/RRTPlanner.cpp
+++ b/soccer/planning/RRTPlanner.cpp
@@ -36,8 +36,6 @@ std::unique_ptr<Path> RRTPlanner::run(
     vi = startInstant.vel;
     vf = endInstant.vel;
 
-    _obstacles = obstacles;
-
     // Simple case: no path
     if (startInstant.pos == goal) {
         path->times.push_back(0);
@@ -76,7 +74,7 @@ std::unique_ptr<Path> RRTPlanner::run(
     }
 
     // Extract the Path from the RRT trees
-    path = makePath(motionConstraints);
+    path = makePath(motionConstraints, obstacles);
 
     if (path && path->waypoints.empty()) {
         // FIXME: without these two lines, an empty path is returned which
@@ -113,7 +111,7 @@ Geometry2d::Point RRTPlanner::findNonBlockedGoal(
 }
 
 InterpolatedPath* RRTPlanner::makePath(
-    const MotionConstraints& motionConstraints) {
+    const MotionConstraints& motionConstraints, const Geometry2d::ShapeSet* obstacles) {
     InterpolatedPath* newPath = new InterpolatedPath();
     newPath->setStartTime(timestamp());
 
@@ -132,7 +130,7 @@ InterpolatedPath* RRTPlanner::makePath(
     _fixedStepTree1.addPath(
         *newPath, p1, true);  // add the goal tree in reverse (aka p1 to root)
 
-    newPath = optimize(*newPath, _obstacles, motionConstraints, vi);
+    newPath = optimize(*newPath, obstacles, motionConstraints, vi);
 
     // TODO: evaluate the old path based on the closest segment and the distance
     // to the endpoint of that segment Otherwise, a new path will always be

--- a/soccer/planning/RRTPlanner.cpp
+++ b/soccer/planning/RRTPlanner.cpp
@@ -29,12 +29,12 @@ std::unique_ptr<Path> RRTPlanner::run(
     MotionInstant startInstant, MotionInstant endInstant,
     const MotionConstraints& motionConstraints,
     const Geometry2d::ShapeSet* obstacles) {
-    InterpolatedPath* path = new InterpolatedPath();
-    path->setStartTime(timestamp());
     Geometry2d::Point goal = endInstant.pos;
 
     // Simple case: no path
     if (startInstant.pos == goal) {
+        InterpolatedPath* path = new InterpolatedPath();
+        path->setStartTime(timestamp());
         path->times.push_back(0);
         path->waypoints.emplace_back(startInstant.pos, Geometry2d::Point());
         return unique_ptr<Path>(path);
@@ -71,7 +71,7 @@ std::unique_ptr<Path> RRTPlanner::run(
     }
 
     // Extract the Path from the RRT trees
-    path = makePath(startInstant.vel, endInstant.vel, motionConstraints,
+    InterpolatedPath* path = makePath(startInstant.vel, endInstant.vel, motionConstraints,
                     obstacles);
 
     if (path && path->waypoints.empty()) {

--- a/soccer/planning/RRTPlanner.cpp
+++ b/soccer/planning/RRTPlanner.cpp
@@ -159,7 +159,7 @@ Geometry2d::Point RRTPlanner::findNonBlockedGoal(
         // obstacles.
         float oldDist = (*prevGoal - goal).mag();
         float newDist = (newGoal - goal).mag();
-        if (newDist + Robot_Radius < oldDist || obstacles->hit(goal)) {
+        if (newDist + Robot_Radius < oldDist || obstacles->hit(*prevGoal)) {
             return newGoal;
         } else {
             return *prevGoal;

--- a/soccer/planning/RRTPlanner.cpp
+++ b/soccer/planning/RRTPlanner.cpp
@@ -31,8 +31,8 @@ bool RRTPlanner::shouldReplan(MotionInstant start, MotionInstant goal,
                               const Path* prevPath) const {
     if (!prevPath || !prevPath->valid()) return true;
 
-    // if this number of microseconds passes since our last path plan,
-    // we automatically replan
+    // if this number of microseconds passes since our last path plan, we
+    // automatically replan
     const Time kPathExpirationInterval = replanTimeout() * SecsToTimestamp;
     if ((timestamp() - prevPath->startTime()) > kPathExpirationInterval) {
         return true;
@@ -47,34 +47,28 @@ bool RRTPlanner::shouldReplan(MotionInstant start, MotionInstant goal,
     if (optTarget) {
         target = *optTarget;
     } else {
-        // We went off the end of the path, so use the end for
-        // calculations.
+        // We went off the end of the path, so use the end for calculations.
         target = *prevPath->destination();
     }
 
     float pathError = (target.pos - start.pos).mag();
     float replanThreshold = *motionConstraints._replan_threshold;
-    // state()->drawCircle(target.pos, replanThreshold, Qt::green,
-    //                     "MotionControl");
-    // addText(QString("velocity: %1 %2").arg(this->vel.x).arg(this->vel.y));
 
     //  invalidate path if current position is more than the
     //  replanThreshold
     if (*motionConstraints._replan_threshold != 0 &&
         pathError > replanThreshold) {
         return true;
-        // addText("pathError", Qt::red, "Motion");
     }
 
+    // FIXME: we need to figure out what is causing NaN values here
     if (std::isnan(target.pos.x) || std::isnan(target.pos.y)) {
         return true;
-        // addText("Evaulate Returned an invalid result", Qt::red, "Motion");
     }
 
     float hitTime = 0;
     if (prevPath->hit(*obstacles, hitTime, timeIntoPath)) {
         return true;
-        // addText("Hit Obstacle", Qt::red, "Motion");
     }
 
     // if the destination of the current path is greater than X m away

--- a/soccer/planning/RRTPlanner.cpp
+++ b/soccer/planning/RRTPlanner.cpp
@@ -29,7 +29,7 @@ bool RRTPlanner::shouldReplan(MotionInstant start, MotionInstant goal,
                               const MotionConstraints& motionConstraints,
                               const Geometry2d::ShapeSet* obstacles,
                               const Path* prevPath) const {
-    if (!prevPath || !prevPath->valid()) return true;
+    if (!prevPath || !prevPath->destination()) return true;
 
     // if this number of microseconds passes since our last path plan, we
     // automatically replan

--- a/soccer/planning/RRTPlanner.cpp
+++ b/soccer/planning/RRTPlanner.cpp
@@ -33,7 +33,6 @@ std::unique_ptr<Path> RRTPlanner::run(
     InterpolatedPath* path = new InterpolatedPath();
     path->setStartTime(timestamp());
     Geometry2d::Point goal = endInstant.pos;
-    _motionConstraints = motionConstraints;
     vi = startInstant.vel;
     vf = endInstant.vel;
 
@@ -77,7 +76,7 @@ std::unique_ptr<Path> RRTPlanner::run(
     }
 
     // Extract the Path from the RRT trees
-    path = makePath();
+    path = makePath(motionConstraints);
 
     if (path && path->waypoints.empty()) {
         // FIXME: without these two lines, an empty path is returned which
@@ -113,7 +112,8 @@ Geometry2d::Point RRTPlanner::findNonBlockedGoal(
     return goal;
 }
 
-InterpolatedPath* RRTPlanner::makePath() {
+InterpolatedPath* RRTPlanner::makePath(
+    const MotionConstraints& motionConstraints) {
     InterpolatedPath* newPath = new InterpolatedPath();
     newPath->setStartTime(timestamp());
 
@@ -132,7 +132,7 @@ InterpolatedPath* RRTPlanner::makePath() {
     _fixedStepTree1.addPath(
         *newPath, p1, true);  // add the goal tree in reverse (aka p1 to root)
 
-    newPath = optimize(*newPath, _obstacles, _motionConstraints, vi);
+    newPath = optimize(*newPath, _obstacles, motionConstraints, vi);
 
     // TODO: evaluate the old path based on the closest segment and the distance
     // to the endpoint of that segment Otherwise, a new path will always be

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -9,6 +9,7 @@
 #include <planning/MotionConstraints.hpp>
 #include <planning/MotionInstant.hpp>
 
+#include <boost/optional.hpp>
 #include <Eigen/Dense>
 #include <list>
 
@@ -64,9 +65,9 @@ protected:
 
     /// If the given goal point is in an obstacle, uses an RRT to attempt to
     /// find a point that is close, but not blocked.
-    Geometry2d::Point findNonBlockedGoal(Geometry2d::Point goal,
-                                         const Geometry2d::ShapeSet* obstacles,
-                                         int maxItr = 100);
+    Geometry2d::Point findNonBlockedGoal(
+        Geometry2d::Point goal, boost::optional<Geometry2d::Point> prevGoal,
+        const Geometry2d::ShapeSet* obstacles, int maxItr = 100);
 
     /// Runs a bi-directional RRT to attempt to join the start and end states.
     Planning::InterpolatedPath* runRRT(

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -51,9 +51,6 @@ protected:
     FixedStepTree _fixedStepTree0;
     FixedStepTree _fixedStepTree1;
 
-    /** best goal point */
-    Geometry2d::Point _bestGoal;
-
     Geometry2d::Point vi;
     Geometry2d::Point vf;
     /// maximum number of rrt iterations to run
@@ -62,6 +59,12 @@ protected:
 
     /// latest obstacles
     const Geometry2d::ShapeSet* _obstacles;
+
+    /// If the given goal point is in an obstacle, uses an RRT to attempt to
+    /// find a point that is close, but not blocked.
+    Geometry2d::Point findNonBlockedGoal(Geometry2d::Point goal,
+                                         const Geometry2d::ShapeSet* obstacles,
+                                         int maxItr = 100);
 
     /** makes a path from the last point of each tree
      *  If the points don't match up...fail!

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -2,7 +2,7 @@
 
 #include "SingleRobotPathPlanner.hpp"
 #include "Tree.hpp"
-#include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 #include <Geometry2d/Point.hpp>
 #include <planning/InterpolatedPath.hpp>
 #include <planning/MotionCommand.hpp>
@@ -40,10 +40,10 @@ public:
 
     /// run the path RRTplanner
     /// this will always populate path to be the path we need to travel
-    std::unique_ptr<Path> run(
-        MotionInstant startInstant, MotionInstant motionCommand,
-        const MotionConstraints& motionConstraints,
-        const Geometry2d::CompositeShape* obstacles) override;
+    std::unique_ptr<Path> run(MotionInstant startInstant,
+                              MotionInstant motionCommand,
+                              const MotionConstraints& motionConstraints,
+                              const Geometry2d::ShapeSet* obstacles) override;
 
 protected:
     MotionConstraints _motionConstraints;
@@ -61,7 +61,7 @@ protected:
     unsigned int _maxIterations;
 
     /// latest obstacles
-    const Geometry2d::CompositeShape* _obstacles;
+    const Geometry2d::ShapeSet* _obstacles;
 
     /** makes a path from the last point of each tree
      *  If the points don't match up...fail!
@@ -73,8 +73,7 @@ protected:
      *  Calles the cubicBezier optimization function.
      */
     Planning::InterpolatedPath* optimize(
-        Planning::InterpolatedPath& path,
-        const Geometry2d::CompositeShape* obstacles,
+        Planning::InterpolatedPath& path, const Geometry2d::ShapeSet* obstacles,
         const MotionConstraints& motionConstraints, Geometry2d::Point vi);
 
     /**
@@ -82,8 +81,7 @@ protected:
      * velocity planning
      */
     Planning::InterpolatedPath* cubicBezier(
-        Planning::InterpolatedPath& path,
-        const Geometry2d::CompositeShape* obstacles,
+        Planning::InterpolatedPath& path, const Geometry2d::ShapeSet* obstacles,
         const MotionConstraints& motionConstraints, Geometry2d::Point vi);
 
     /**

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -55,9 +55,6 @@ protected:
     /// this does not include connect attempts
     unsigned int _maxIterations;
 
-    /// latest obstacles
-    const Geometry2d::ShapeSet* _obstacles;
-
     /// If the given goal point is in an obstacle, uses an RRT to attempt to
     /// find a point that is close, but not blocked.
     Geometry2d::Point findNonBlockedGoal(Geometry2d::Point goal,
@@ -69,7 +66,7 @@ protected:
      *  The final path will be from the start of tree0
      *  to the start of tree1 */
     Planning::InterpolatedPath* makePath(
-        const MotionConstraints& motionConstraints);
+        const MotionConstraints& motionConstraints, const Geometry2d::ShapeSet* obstacles);
 
     /** optimize the path
      *  Calles the cubicBezier optimization function.

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -49,8 +49,6 @@ protected:
     FixedStepTree _fixedStepTree0;
     FixedStepTree _fixedStepTree1;
 
-    Geometry2d::Point vi;
-    Geometry2d::Point vf;
     /// maximum number of rrt iterations to run
     /// this does not include connect attempts
     unsigned int _maxIterations;
@@ -65,15 +63,17 @@ protected:
      *  If the points don't match up...fail!
      *  The final path will be from the start of tree0
      *  to the start of tree1 */
-    Planning::InterpolatedPath* makePath(
-        const MotionConstraints& motionConstraints, const Geometry2d::ShapeSet* obstacles);
+    Planning::InterpolatedPath* makePath(Geometry2d::Point vi, Geometry2d::Point vf,
+        const MotionConstraints& motionConstraints,
+        const Geometry2d::ShapeSet* obstacles);
 
     /** optimize the path
-     *  Calles the cubicBezier optimization function.
+     *  Calls the cubicBezier optimization function.
      */
     Planning::InterpolatedPath* optimize(
         Planning::InterpolatedPath& path, const Geometry2d::ShapeSet* obstacles,
-        const MotionConstraints& motionConstraints, Geometry2d::Point vi);
+        const MotionConstraints& motionConstraints, Geometry2d::Point vi,
+        Geometry2d::Point vf);
 
     /**
      * Uses a cubicBezier to interpolate between the points on the path and add
@@ -81,7 +81,8 @@ protected:
      */
     Planning::InterpolatedPath* cubicBezier(
         Planning::InterpolatedPath& path, const Geometry2d::ShapeSet* obstacles,
-        const MotionConstraints& motionConstraints, Geometry2d::Point vi);
+        const MotionConstraints& motionConstraints, Geometry2d::Point vi,
+        Geometry2d::Point vf);
 
     /**
      * Helper function for cubicBezier() which uses Eigen matrices to solve for

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -46,8 +46,6 @@ public:
                               const Geometry2d::ShapeSet* obstacles) override;
 
 protected:
-    MotionConstraints _motionConstraints;
-
     FixedStepTree _fixedStepTree0;
     FixedStepTree _fixedStepTree1;
 
@@ -70,7 +68,8 @@ protected:
      *  If the points don't match up...fail!
      *  The final path will be from the start of tree0
      *  to the start of tree1 */
-    Planning::InterpolatedPath* makePath();
+    Planning::InterpolatedPath* makePath(
+        const MotionConstraints& motionConstraints);
 
     /** optimize the path
      *  Calles the cubicBezier optimization function.

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -40,14 +40,23 @@ public:
 
     /// run the path RRTplanner
     /// this will always populate path to be the path we need to travel
-    std::unique_ptr<Path> run(MotionInstant start, MotionCommand cmd,
-                              const MotionConstraints& motionConstraints,
-                              const Geometry2d::ShapeSet* obstacles) override;
+    std::unique_ptr<Path> run(
+        MotionInstant start, MotionCommand cmd,
+        const MotionConstraints& motionConstraints,
+        const Geometry2d::ShapeSet* obstacles,
+        std::unique_ptr<Path> prevPath = nullptr) override;
 
 protected:
     /// maximum number of rrt iterations to run
     /// this does not include connect attempts
     unsigned int _maxIterations;
+
+    /// Check to see if the previous path (if any) should be discarded and
+    /// replaced with a newly-planned one
+    bool shouldReplan(MotionInstant start, MotionInstant goal,
+                      const MotionConstraints& motionConstraints,
+                      const Geometry2d::ShapeSet* obstacles,
+                      const Path* prevPath) const;
 
     /// If the given goal point is in an obstacle, uses an RRT to attempt to
     /// find a point that is close, but not blocked.

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -38,6 +38,10 @@ public:
      */
     void maxIterations(int value) { _maxIterations = value; }
 
+    MotionCommand::CommandType commandType() const override {
+        return MotionCommand::CommandType::PathTarget;
+    }
+
     /// run the path RRTplanner
     /// this will always populate path to be the path we need to travel
     std::unique_ptr<Path> run(

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -40,15 +40,11 @@ public:
 
     /// run the path RRTplanner
     /// this will always populate path to be the path we need to travel
-    std::unique_ptr<Path> run(MotionInstant startInstant,
-                              MotionInstant motionCommand,
+    std::unique_ptr<Path> run(MotionInstant start, MotionInstant goal,
                               const MotionConstraints& motionConstraints,
                               const Geometry2d::ShapeSet* obstacles) override;
 
 protected:
-    FixedStepTree _fixedStepTree0;
-    FixedStepTree _fixedStepTree1;
-
     /// maximum number of rrt iterations to run
     /// this does not include connect attempts
     unsigned int _maxIterations;
@@ -59,11 +55,9 @@ protected:
                                          const Geometry2d::ShapeSet* obstacles,
                                          int maxItr = 100);
 
-    /** makes a path from the last point of each tree
-     *  If the points don't match up...fail!
-     *  The final path will be from the start of tree0
-     *  to the start of tree1 */
-    Planning::InterpolatedPath* makePath(Geometry2d::Point vi, Geometry2d::Point vf,
+    /// Runs a bi-directional RRT to attempt to join the start and end states.
+    Planning::InterpolatedPath* runRRT(
+        MotionInstant start, MotionInstant goal,
         const MotionConstraints& motionConstraints,
         const Geometry2d::ShapeSet* obstacles);
 

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -40,7 +40,7 @@ public:
 
     /// run the path RRTplanner
     /// this will always populate path to be the path we need to travel
-    std::unique_ptr<Path> run(MotionInstant start, MotionInstant goal,
+    std::unique_ptr<Path> run(MotionInstant start, MotionCommand cmd,
                               const MotionConstraints& motionConstraints,
                               const Geometry2d::ShapeSet* obstacles) override;
 

--- a/soccer/planning/SingleRobotPathPlanner.cpp
+++ b/soccer/planning/SingleRobotPathPlanner.cpp
@@ -1,0 +1,16 @@
+#include "SingleRobotPathPlanner.hpp"
+
+namespace Planning {
+
+REGISTER_CONFIGURABLE(SingleRobotPathPlanner);
+
+ConfigDouble* SingleRobotPathPlanner::_goalChangeThreshold;
+ConfigDouble* SingleRobotPathPlanner::_replanTimeout;
+
+void SingleRobotPathPlanner::createConfiguration(Configuration* cfg) {
+    _replanTimeout = new ConfigDouble(cfg, "PathPlanner/replanTimeout", 5);
+    _goalChangeThreshold =
+        new ConfigDouble(cfg, "PathPlanner/goalChangeThreshold", 0.025);
+}
+
+}  // namespace Planning

--- a/soccer/planning/SingleRobotPathPlanner.cpp
+++ b/soccer/planning/SingleRobotPathPlanner.cpp
@@ -1,4 +1,6 @@
 #include "SingleRobotPathPlanner.hpp"
+#include "DirectTargetPathPlanner.hpp"
+#include "RRTPlanner.hpp"
 
 namespace Planning {
 
@@ -11,6 +13,24 @@ void SingleRobotPathPlanner::createConfiguration(Configuration* cfg) {
     _replanTimeout = new ConfigDouble(cfg, "PathPlanner/replanTimeout", 5);
     _goalChangeThreshold =
         new ConfigDouble(cfg, "PathPlanner/goalChangeThreshold", 0.025);
+}
+
+std::unique_ptr<Planning::SingleRobotPathPlanner> PlannerForCommandType(
+    Planning::MotionCommand::CommandType type) {
+    Planning::SingleRobotPathPlanner* planner = nullptr;
+
+    switch (type) {
+        case Planning::MotionCommand::PathTarget:
+            planner = new Planning::RRTPlanner(250);
+            break;
+        case Planning::MotionCommand::DirectTarget:
+            planner = new Planning::DirectTargetPathPlanner();
+            break;
+        default:
+            break;
+    }
+
+    return std::unique_ptr<Planning::SingleRobotPathPlanner>(planner);
 }
 
 }  // namespace Planning

--- a/soccer/planning/SingleRobotPathPlanner.hpp
+++ b/soccer/planning/SingleRobotPathPlanner.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Configuration.hpp>
 #include <planning/MotionConstraints.hpp>
 #include <planning/MotionCommand.hpp>
 #include <planning/MotionInstant.hpp>
@@ -18,7 +19,17 @@ public:
     virtual std::unique_ptr<Path> run(
         MotionInstant startInstant, MotionCommand cmd,
         const MotionConstraints& motionConstraints,
-        const Geometry2d::ShapeSet* obstacles) = 0;
+        const Geometry2d::ShapeSet* obstacles,
+        std::unique_ptr<Path> prevPath = nullptr) = 0;
+
+    static double goalChangeThreshold() { return *_goalChangeThreshold; }
+    static double replanTimeout() { return *_replanTimeout; }
+
+    static void createConfiguration(Configuration* cfg);
+
+private:
+    static ConfigDouble* _goalChangeThreshold;
+    static ConfigDouble* _replanTimeout;
 };
 
 }  // namespace Planning

--- a/soccer/planning/SingleRobotPathPlanner.hpp
+++ b/soccer/planning/SingleRobotPathPlanner.hpp
@@ -17,7 +17,7 @@ public:
     virtual std::unique_ptr<Path> run(
         MotionInstant startInstant, MotionInstant endInstant,
         const MotionConstraints& motionConstraints,
-        const Geometry2d::CompositeShape* obstacles) = 0;
+        const Geometry2d::ShapeSet* obstacles) = 0;
 };
 
 }  // namespace Planning

--- a/soccer/planning/SingleRobotPathPlanner.hpp
+++ b/soccer/planning/SingleRobotPathPlanner.hpp
@@ -22,6 +22,9 @@ public:
         const Geometry2d::ShapeSet* obstacles,
         std::unique_ptr<Path> prevPath = nullptr) = 0;
 
+    /// The MotionCommand type that this planner handles
+    virtual MotionCommand::CommandType commandType() const = 0;
+
     static double goalChangeThreshold() { return *_goalChangeThreshold; }
     static double replanTimeout() { return *_replanTimeout; }
 
@@ -31,5 +34,11 @@ private:
     static ConfigDouble* _goalChangeThreshold;
     static ConfigDouble* _replanTimeout;
 };
+
+/// Gets the subclass of SingleRobotPathPlanner responsible for handling the
+/// given command type.  Any new SingleRobotPathPlanner classes should be
+/// registered by placing them in this function's implementation in the .cpp file.
+std::unique_ptr<Planning::SingleRobotPathPlanner> PlannerForCommandType(
+    Planning::MotionCommand::CommandType type);
 
 }  // namespace Planning

--- a/soccer/planning/SingleRobotPathPlanner.hpp
+++ b/soccer/planning/SingleRobotPathPlanner.hpp
@@ -37,7 +37,8 @@ private:
 
 /// Gets the subclass of SingleRobotPathPlanner responsible for handling the
 /// given command type.  Any new SingleRobotPathPlanner classes should be
-/// registered by placing them in this function's implementation in the .cpp file.
+/// registered by placing them in this function's implementation in the .cpp
+/// file.
 std::unique_ptr<Planning::SingleRobotPathPlanner> PlannerForCommandType(
     Planning::MotionCommand::CommandType type);
 

--- a/soccer/planning/SingleRobotPathPlanner.hpp
+++ b/soccer/planning/SingleRobotPathPlanner.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <planning/MotionConstraints.hpp>
+#include <planning/MotionCommand.hpp>
 #include <planning/MotionInstant.hpp>
 #include <planning/Path.hpp>
 
@@ -15,7 +16,7 @@ public:
      * Returns an obstacle-free Path subject to the specified MotionContraints.
      */
     virtual std::unique_ptr<Path> run(
-        MotionInstant startInstant, MotionInstant endInstant,
+        MotionInstant startInstant, MotionCommand cmd,
         const MotionConstraints& motionConstraints,
         const Geometry2d::ShapeSet* obstacles) = 0;
 };

--- a/soccer/planning/TrapezoidalPath.hpp
+++ b/soccer/planning/TrapezoidalPath.hpp
@@ -4,7 +4,7 @@
 #include "MotionConstraints.hpp"
 #include "MotionInstant.hpp"
 #include <Configuration.hpp>
-#include <Geometry2d/CompositeShape.hpp>
+#include <Geometry2d/ShapeSet.hpp>
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/Segment.hpp>
 #include <Geometry2d/Segment.hpp>
@@ -71,7 +71,7 @@ public:
                              pathDirection * speedOut);
     }
 
-    virtual bool hit(const Geometry2d::CompositeShape& shape, float& hitTime,
+    virtual bool hit(const Geometry2d::ShapeSet& obstacles, float& hitTime,
                      float startTime = 0) const override {
         throw std::logic_error("This function is not implemented");
     }

--- a/soccer/planning/TrapezoidalPath.hpp
+++ b/soccer/planning/TrapezoidalPath.hpp
@@ -9,6 +9,7 @@
 #include <Geometry2d/Segment.hpp>
 #include <Geometry2d/Segment.hpp>
 #include <planning/Path.hpp>
+#include <protobuf/LogFrame.pb.h>
 
 namespace Planning {
 

--- a/soccer/planning/TrapezoidalPath.hpp
+++ b/soccer/planning/TrapezoidalPath.hpp
@@ -55,8 +55,6 @@ public:
                                         maxSpeed, maxAcc, startSpeed, endSpeed);
     }
 
-    virtual bool valid() const override { return true; }
-
     virtual boost::optional<MotionInstant> evaluate(float time) const override {
         float distance;
         float speedOut;

--- a/soccer/planning/TrapezoidalPath.hpp
+++ b/soccer/planning/TrapezoidalPath.hpp
@@ -54,6 +54,8 @@ public:
                                         maxSpeed, maxAcc, startSpeed, endSpeed);
     }
 
+    virtual bool valid() const override { return true; }
+
     virtual boost::optional<MotionInstant> evaluate(float time) const override {
         float distance;
         float speedOut;

--- a/soccer/planning/Tree.cpp
+++ b/soccer/planning/Tree.cpp
@@ -73,7 +73,10 @@ void Tree::addPath(Planning::InterpolatedPath& path, Point* dest,
 
     path.waypoints.reserve(path.waypoints.size() + n);
     for (Point* pt : points) {
-        path.waypoints.emplace_back(pt->pos, Geometry2d::Point());
+        // Each point in the path is given a time of zero - the actual time will
+        // be calculated later by the planner
+        path.waypoints.emplace_back(MotionInstant(pt->pos, Geometry2d::Point()),
+                                    0);
     }
 }
 

--- a/soccer/planning/Tree.cpp
+++ b/soccer/planning/Tree.cpp
@@ -46,13 +46,13 @@ void Tree::clear() {
 }
 
 void Tree::init(Geometry2d::Point start,
-                const Geometry2d::CompositeShape* obstacles) {
+                const Geometry2d::ShapeSet* obstacles) {
     clear();
 
     _obstacles = obstacles;
 
     Point* p = new Point(start, nullptr);
-    _obstacles->hit(p->pos, p->hit);
+    p->hit = _obstacles->hitSet(p->pos);
     points.push_back(p);
 }
 
@@ -134,8 +134,9 @@ Tree::Point* FixedStepTree::extend(Geometry2d::Point pt, Tree::Point* base) {
     // If this move touches any obstacles that the starting point didn't already
     // touch,
     // it has entered an obstacle and will be rejected.
-    std::set<shared_ptr<Geometry2d::Shape>> moveHit;
-    if (_obstacles->hit(Geometry2d::Segment(pos, base->pos), moveHit)) {
+    std::set<shared_ptr<Geometry2d::Shape>> moveHit =
+        _obstacles->hitSet(Geometry2d::Segment(pos, base->pos));
+    if (!moveHit.empty()) {
         // We only care if there are any items in moveHit that are not in
         // point->hit, so
         // we don't store the result of set_difference.
@@ -152,7 +153,7 @@ Tree::Point* FixedStepTree::extend(Geometry2d::Point pt, Tree::Point* base) {
 
     // Allow this point to be added to the tree
     Point* p = new Point(pos, base);
-    _obstacles->hit(p->pos, p->hit);
+    p->hit = std::move(moveHit);
     points.push_back(p);
 
     return p;

--- a/soccer/planning/Tree.hpp
+++ b/soccer/planning/Tree.hpp
@@ -41,8 +41,7 @@ public:
     /** cleanup the tree */
     void clear();
 
-    void init(Geometry2d::Point start,
-              const Geometry2d::CompositeShape* obstacles);
+    void init(Geometry2d::Point start, const Geometry2d::ShapeSet* obstacles);
 
     /** find the point of the tree closest to @a pt */
     Point* nearest(Geometry2d::Point pt);
@@ -72,7 +71,7 @@ public:
     std::list<Point*> points;
 
 protected:
-    const Geometry2d::CompositeShape* _obstacles;
+    const Geometry2d::ShapeSet* _obstacles;
 };
 
 /** tree that grows based on fixed distance step */


### PR DESCRIPTION
Should be merged after #421.

* Planning is now run by the Processor
* Processor has a single MultiRobotPathPlanner that handles planning for all robots
* Robots no longer store a reference to their Planner
* IndependentMultiRobotPathPlanner is a subclass of MultiRobotPathPlanner that runs a SingleRobotPathPlanner for each robot.
* Field obstacles are drawn to the "Obstacles" layer, which is hidden by default
* Refactored InterpolatedPath to store a single vector of waypoints, rather than separate vectors for positions, velocities, and times
* SingleRobotPathPlanner objects now handle their own replanning.  `run()` is called every iteration and it's up to the individual planner to decide whether to return the same path as before or make a new one.

closes #415 