### PR TITLE
specify to compare diffbase with origin/master instead of master

### DIFF
--- a/makefile
+++ b/makefile
@@ -103,8 +103,8 @@ STYLE_EXCLUDE_DIRS=build \
 	firmware/common2015
 # automatically format code according to our style config defined in .clang-format
 pretty:
-	@stylize --diffbase=master --clang_style=file --yapf_style=file --exclude_dirs $(STYLE_EXCLUDE_DIRS)
+	@stylize --diffbase=origin/master --clang_style=file --yapf_style=file --exclude_dirs $(STYLE_EXCLUDE_DIRS)
 # check if everything in our codebase is in accordance with the style config defined in .clang-format
 # a nonzero exit code indicates that there's a formatting error somewhere
 checkstyle:
-	@stylize --diffbase=master --clang_style=file --yapf_style=file --exclude_dirs $(STYLE_EXCLUDE_DIRS) --check
+	@stylize --diffbase=origin/master --clang_style=file --yapf_style=file --exclude_dirs $(STYLE_EXCLUDE_DIRS) --check


### PR DESCRIPTION
Quick fix for stylize diffbase. Just wanted to make sure I didn't screw up the diffbase option with slashes or something.