### PR TITLE
PassReceive now removes its capture behavior upon state transition

### DIFF
--- a/soccer/gameplay/skills/pass_receive.py
+++ b/soccer/gameplay/skills/pass_receive.py
@@ -213,6 +213,9 @@ class PassReceive(single_robot_composite_behavior.SingleRobotCompositeBehavior):
         self.reset_correct_location()
         self.kicked_time = time.time()
 
+    def on_exit_receiving(self):
+        self.remove_subbehavior('capture')
+
     ## Create a good_area, that determines where a good pass should be,
     # return true if the ball has exited that area.
     #


### PR DESCRIPTION
There was an issue previously that happened when the PassReceive behavior was restarted.

~~~{.sh}
  File "/Users/justbuchanan/src/rj/robocup-software/soccer/gameplay/composite_behavior.py", line 84, in spin
    bhvr.spin()
  File "/Users/justbuchanan/src/rj/robocup-software/soccer/gameplay/composite_behavior.py", line 87, in spin
    self.handle_subbehavior_exception(name, exc)
  File "/Users/justbuchanan/src/rj/robocup-software/soccer/gameplay/composite_behavior.py", line 84, in spin
    bhvr.spin()
  File "/Users/justbuchanan/src/rj/robocup-software/soccer/gameplay/composite_behavior.py", line 87, in spin
    self.handle_subbehavior_exception(name, exc)
  File "/Users/justbuchanan/src/rj/robocup-software/soccer/gameplay/composite_behavior.py", line 84, in spin
    bhvr.spin()
  File "/Users/justbuchanan/src/rj/robocup-software/soccer/gameplay/composite_behavior.py", line 68, in spin
    super().spin()
  File "/Users/justbuchanan/src/rj/robocup-software/soccer/gameplay/fsm.py", line 76, in spin
    self.transition(next_states[0])
  File "/Users/justbuchanan/src/rj/robocup-software/soccer/gameplay/fsm.py", line 120, in transition
    state_method()
  File "/Users/justbuchanan/src/rj/robocup-software/soccer/gameplay/skills/pass_receive.py", line 211, in on_enter_receiving
    self.add_subbehavior(capture, 'capture', required=True)
  File "/Users/justbuchanan/src/rj/robocup-software/soccer/gameplay/single_robot_composite_behavior.py", line 16, in add_subbehavior
    raise AssertionError("Attempt to add more than one subbehavior to SingleRobotCompositeBehavior")
AssertionError: Attempt to add more than one subbehavior to SingleRobotCompositeBehavior
~~~