### PR TITLE
fixed issue with path following

### DIFF
--- a/soccer/motion/MotionControl.cpp
+++ b/soccer/motion/MotionControl.cpp
@@ -147,8 +147,9 @@ void MotionControl::run() {
         boost::optional<MotionInstant> optTarget =
             _robot->path()->evaluate(timeIntoPath);
         if (!optTarget) {
+            // use the path end if our timeIntoPath is greater than the duration
             target.vel = Point();
-            target.pos = _robot->pos;
+            target.pos = _robot->path()->end().pos;
         } else {
             target = *optTarget;
         }


### PR DESCRIPTION
If the robot took longer than expected to reach the endpoint of the path,
it would end up stopping in place rather than targeting the end point of the path.