### PR TITLE
fixed udev rules for mbed

### DIFF
--- a/util/arch-setup
+++ b/util/arch-setup
@@ -4,7 +4,7 @@ BASE=$(readlink -f $(dirname $0)/..)
 
 echo "-- Installing udev rules"
 sudo cp -f $BASE/util/robocup.rules /etc/udev/rules.d/
-sudo udevadm control -R # reload rules
+sudo udevadm control --reload || true # reload rules
 
 echo "-- Installing required packages"
 sudo pacman -S --needed --noconfirm $(sed 's/#.*//;/^$/d' $BASE/util/arch-packages.txt)

--- a/util/arch-setup
+++ b/util/arch-setup
@@ -4,6 +4,7 @@ BASE=$(readlink -f $(dirname $0)/..)
 
 echo "-- Installing udev rules"
 sudo cp -f $BASE/util/robocup.rules /etc/udev/rules.d/
+sudo udevadm control -R # reload rules
 
 echo "-- Installing required packages"
 sudo pacman -S --needed --noconfirm $(sed 's/#.*//;/^$/d' $BASE/util/arch-packages.txt)

--- a/util/robocup.rules
+++ b/util/robocup.rules
@@ -15,10 +15,11 @@ ATTR{idVendor}=="0403", ATTR{idProduct}=="6010", MODE="0660", GROUP="plugdev"
 # Robot
 ATTR{idVendor}=="03eb", ATTR{idProduct}=="6119", MODE="0660", GROUP="plugdev", SYMLINK+="robot"
 
-# MBED
-ATTR{idVendor}=="0d28", ATTR{idProduct}=="0204", MODE="0660", GROUP="plugdev", SYMLINK+="mbed"
-
 LABEL="robocup_rules_end"
 
 KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="6119", SYMLINK+="robot"
-KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", SYMLINK+="mbed"
+
+# MBED
+# Note: the '%n' in SYMLINK is replaced with the device number so if there are multiple
+#       mbeds connected, they get unique names
+KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", SYMLINK+="mbed%n"

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -140,7 +140,7 @@ BASE=$(readlink -f $(dirname $0)/..)
 
 echo "-- Installing udev rules"
 cp -f $BASE/util/robocup.rules /etc/udev/rules.d/
-sudo udevadm control -R # reload rules
+sudo udevadm control --reload || true # reload rules
 
 echo "-- Installing required packages"
 

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -140,6 +140,7 @@ BASE=$(readlink -f $(dirname $0)/..)
 
 echo "-- Installing udev rules"
 cp -f $BASE/util/robocup.rules /etc/udev/rules.d/
+sudo udevadm control -R # reload rules
 
 echo "-- Installing required packages"
 


### PR DESCRIPTION
* if multiple mbeds are plugged in, they each get their own name at /dev/mbed[0-9]+
* {arch, ubuntu}-setup scripts now reload udev rules after installing