### PR TITLE
initialize ref time left variable to zero.  fixes #520

### DIFF
--- a/soccer/NewRefereeModule.hpp
+++ b/soccer/NewRefereeModule.hpp
@@ -163,7 +163,7 @@ public:
     //
     // If the stage runs over its specified time, this value
     // becomes negative.
-    int stage_time_left;
+    int stage_time_left = 0;
 
     // The number of commands issued since startup (mod 2^32).
     uint command_counter;


### PR DESCRIPTION
@jedyang97, give this a try.  I think the issue is just that the variable is never initialized so it uses whatever was in memory before.  Sometimes this is zero, sometimes it's something ridiculous.