### PR TITLE
fixed issue with boost 1.6

### DIFF
--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -1,5 +1,6 @@
 #include "robocup-py.hpp"
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <boost/python/register_ptr_to_python.hpp>
 #include <string>
 #include <sstream>
 #include <iostream>
@@ -641,6 +642,8 @@ BOOST_PYTHON_MODULE(robocup) {
         .def("draw_arc", &State_draw_arc)
         .def("draw_raw_polygon", &State_draw_raw_polygon)
         .def("draw_arc", &State_draw_arc);
+
+    register_ptr_to_python< SystemState* >();
 
     class_<Field_Dimensions>("Field_Dimensions")
         .def("Length", &Field_Dimensions::Length)


### PR DESCRIPTION
Boost 1.6 seems to require a call to `reigister_ptr_to_python()` that wasn't needed before...  This adds that call, which fixes an issue that caused soccer to crash on launch when built with boost 1.60.

@jedyang97 can you try this out with the latest versions of things from `homebrew` and see if it works for you?

cc @mosdragon 