### PR TITLE
use DISCOVER port instead of LINK for radio-tx and radio-rx commands

### DIFF
--- a/firmware/common2015/drivers/cc1201/CC1201.cpp
+++ b/firmware/common2015/drivers/cc1201/CC1201.cpp
@@ -11,6 +11,11 @@ void ASSERT_IS_ADDR(uint16_t addr) {
            (addr == 0x007F) || (addr == 0x00BF) || (addr == 0x00FF));
 }
 
+
+// TODO(justin): remove this
+CC1201 *global_radio = nullptr;
+
+
 CC1201::CC1201(PinName mosi, PinName miso, PinName sck, PinName cs,
                PinName intPin, const registerSetting_t* regs, size_t len,
                int rssiOffset)
@@ -60,9 +65,10 @@ int32_t CC1201::sendData(uint8_t* buf, uint8_t size) {
         strobe(CC1201_STROBE_SRX);
 
         return COMM_DEV_BUF_ERR;
-    } else {
-        strobe(CC1201_STROBE_STX);  // Enter TX mode
     }
+    
+    // Enter TX mode
+    strobe(CC1201_STROBE_STX);
 
     // Wait until radio's TX buffer is emptied
     uint8_t bts = 1;
@@ -71,7 +77,8 @@ int32_t CC1201::sendData(uint8_t* buf, uint8_t size) {
         Thread::wait(2);
     } while (bts != 0);
 
-    LOG(INF2, "packet sent successfully! (I think?)");
+    // send a NOP to read and log the radio's state
+    if (_debugEnabled) strobe(CC1201_STROBE_SNOP);
 
     return COMM_SUCCESS;
 }
@@ -199,6 +206,63 @@ uint8_t CC1201::strobe(uint8_t addr) {
     radio_select();
     uint8_t ret = _spi->write(addr);
     radio_deselect();
+
+    // If debug is enabled, we wait for a brief interval, then send a NOP to get
+    // the radio's status, then log it to the console
+    if (_debugEnabled) {
+        // wait a bit to allow the previous strobe to take effect
+        // TODO: how long should this delay actually be?
+        int delay = 2;
+        Thread::wait(delay);
+
+        radio_select();
+        uint8_t ret2 = _spi->write(CC1201_STROBE_SNOP);
+        radio_deselect();
+    
+
+        const char* strobe_names[] = {
+            "RES",      // 0x30
+            "FSTXON",   // 0x31
+            "XOFF",     // 0x32
+            "CAL",      // 0x33
+            "RX",       // 0x34
+            "TX",       // 0x35
+            "IDLE",     // 0x36
+            "AFC",      // 0x37
+            "WOR",      // 0x38
+            "PWD",      // 0x39
+            "FRX",      // 0x3a
+            "FTX",      // 0x3b
+            "WORRST",   // 0x3c
+            "NOP"       // 0x3d
+        };
+
+        const char* state_names[] = {
+            "IDLE",
+            "RX",
+            "TX",
+            "FSTXON",
+            "CALIB",
+            "SETTLE",
+            "RX_FIFO_ERR",
+            "TX_FIFO_ERR"
+        };
+
+        // The status byte returned from strobe() contains from (msb to lsb):
+        // * 1 bit - chip ready
+        // * 3 bits - state
+        // * 4 bits - unused
+        int rdy = ret & (1<<7);
+        int state = (ret >> 4) & 7;
+        int rdy2 = ret2 & (1<<7);
+        int state2 = (ret2 >> 4) & 7;
+        LOG(INF2, "strobe '%s' sent, status = {rdy: %d, state: %s}, "
+            "after %dms = {rdy: %d, state: %s}",
+            strobe_names[addr - 0x30],
+            rdy, state_names[state],
+            delay,
+            rdy2, state_names[state2]);
+    }
 
     return ret;
 }

--- a/firmware/common2015/drivers/cc1201/CC1201.cpp
+++ b/firmware/common2015/drivers/cc1201/CC1201.cpp
@@ -249,19 +249,19 @@ uint8_t CC1201::strobe(uint8_t addr) {
         };
 
         // The status byte returned from strobe() contains from (msb to lsb):
-        // * 1 bit - chip ready
+        // * 1 bit - chip ready (0 indicates xosc is stable)
         // * 3 bits - state
         // * 4 bits - unused
-        int rdy = ret & (1<<7);
+        int rdy_n = ret & (1<<7);
         int state = (ret >> 4) & 7;
-        int rdy2 = ret2 & (1<<7);
+        int rdy2_n = ret2 & (1<<7);
         int state2 = (ret2 >> 4) & 7;
-        LOG(INF2, "strobe '%s' sent, status = {rdy: %d, state: %s}, "
-            "after %dms = {rdy: %d, state: %s}",
+        LOG(INF2, "strobe '%s' sent, status = {rdy_n: %d, state: %s}, "
+            "after %dms = {rdy_n: %d, state: %s}",
             strobe_names[addr - 0x30],
-            rdy, state_names[state],
+            rdy_n, state_names[state],
             delay,
-            rdy2, state_names[state2]);
+            rdy2_n, state_names[state2]);
     }
 
     return ret;

--- a/firmware/common2015/drivers/cc1201/CC1201.cpp
+++ b/firmware/common2015/drivers/cc1201/CC1201.cpp
@@ -71,6 +71,8 @@ int32_t CC1201::sendData(uint8_t* buf, uint8_t size) {
         Thread::wait(2);
     } while (bts != 0);
 
+    LOG(INF2, "packet sent successfully! (I think?)");
+
     return COMM_SUCCESS;
 }
 

--- a/firmware/common2015/drivers/cc1201/CC1201.hpp
+++ b/firmware/common2015/drivers/cc1201/CC1201.hpp
@@ -49,6 +49,13 @@ public:
 
     bool isLocked();
 
+    /// Enable or disable logging of all strobe() commands
+    void setDebugEnabled(bool enabled = true) {
+        _debugEnabled = enabled;
+    }
+    bool isDebugEnabled() const { return _debugEnabled; }
+
+
 protected:
     void set_rssi_offset(int8_t offset);
 
@@ -82,4 +89,12 @@ private:
     bool _isInit;
     bool _offset_reg_written;
     float _rssi;
+
+    // In debug mode, all strobe commands are logged at INF2
+    // note that this decreases performance, so shouldn't be used normally
+    bool _debugEnabled = false;
 };
+
+
+// TODO(justin): remove this
+extern CC1201* global_radio;

--- a/firmware/common2015/modules/CommLink/CommLink.cpp
+++ b/firmware/common2015/modules/CommLink/CommLink.cpp
@@ -124,7 +124,11 @@ void CommLink::rxThread(void const* arg) {
 // Called by the derived class to begin thread operations
 void CommLink::ready() { osSignalSet(_rxID, COMM_LINK_SIGNAL_START_THREAD); }
 
-void CommLink::sendPacket(rtp::packet* p) { sendData(p->packed(), p->size()); }
+void CommLink::sendPacket(rtp::packet* p) {
+    std::vector<uint8_t> buffer;
+    p->pack(&buffer);
+    sendData(buffer.data(), buffer.size());
+}
 
 void CommLink::ISR() { osSignalSet(_rxID, COMM_LINK_SIGNAL_RX_TRIGGER); }
 

--- a/firmware/common2015/utils/rtp.hpp
+++ b/firmware/common2015/utils/rtp.hpp
@@ -53,19 +53,6 @@ public:
 
     size_t size() const { return 2; }
 
-    // datav_it_t pack(size_t payload_size, bool headless = false) {
-    //     if (d.size()) return d.begin();
-    //     // payload size + number of bytes in header is top byte
-    //     // since that's required for the cc1101/cc1201 with
-    //     // variable packet sizes
-    //     d.push_back(payload_size + (headless ? 0 : 2));
-    //     if (headless == false) {
-    //         d.push_back(address);
-    //         d.push_back(port_fields);
-    //     }
-    //     return d.begin();
-    // }
-
     type t;
     data_t address;
 
@@ -155,10 +142,9 @@ public:
     }
 
     void pack(std::vector<data_t> *buffer, bool includeHeader = false) const {
-        buffer->reserve(MAX_DATA_SZ);
-
         // first byte is total size (excluding the size byte)
-        const uint8_t total_size = payload.size() + (includeHeader ? 2 : 0);
+        const uint8_t total_size = payload.size() + (includeHeader ? header.size() : 0);
+        buffer->reserve(total_size + 1);
         buffer->push_back(total_size);
 
         // header data

--- a/firmware/common2015/utils/rtp.hpp
+++ b/firmware/common2015/utils/rtp.hpp
@@ -41,66 +41,30 @@ namespace {
 // type of data field used in all packet classes
 // - must be 8 bits, (typedef used for eaiser compiler
 // type error debugging)
-typedef uint8_t packet_data_t;
+typedef uint8_t data_t;
 }
 
-/**
- * @brief [brief description]
- * @details [long description]
- * @return [description]
- */
-class layer_map {
-public:
-    typedef packet_data_t data_t;
 
-protected:
-    typedef std::vector<data_t> datav_t;
-    typedef datav_t::iterator datav_it_t;
-    std::vector<data_t> d;
-
-public:
-    layer_map(size_t resv) { d.reserve(resv); }
-
-    datav_it_t pack() {
-        // make sure all files are in contiguous memory,
-        // then return iterator to beginning
-        return d.begin();
-    }
-
-    data_t* data() { return d.data(); }
-
-    void show_data() {
-        for (auto const& i : d) printf("%02X ", i);
-    }
-
-    size_t size() const { return static_cast<size_t>(d.size()); }
-};
-
-/**
- * @brief [brief description]
- * @details [long description]
- *
- * @param p [description]
- * @return [description]
- */
-class header_data : public layer_map {
+class header_data {
 public:
     enum type { control, tuning, ota, misc };
 
-    header_data() : layer_map(3), t(control), address(0), port_fields(0){};
+    header_data() : t(control), address(0), port_fields(0){};
 
-    datav_it_t pack(size_t payload_size, bool headless = false) {
-        if (d.size()) return d.begin();
-        // payload size + number of bytes in header is top byte
-        // since that's required for the cc1101/cc1201 with
-        // variable packet sizes
-        d.push_back(payload_size + (headless ? 0 : 2));
-        if (headless == false) {
-            d.push_back(address);
-            d.push_back(port_fields);
-        }
-        return d.begin();
-    }
+    size_t size() const { return 2; }
+
+    // datav_it_t pack(size_t payload_size, bool headless = false) {
+    //     if (d.size()) return d.begin();
+    //     // payload size + number of bytes in header is top byte
+    //     // since that's required for the cc1101/cc1201 with
+    //     // variable packet sizes
+    //     d.push_back(payload_size + (headless ? 0 : 2));
+    //     if (headless == false) {
+    //         d.push_back(address);
+    //         d.push_back(port_fields);
+    //     }
+    //     return d.begin();
+    // }
 
     type t;
     data_t address;
@@ -108,38 +72,26 @@ public:
     friend class payload_data;
 
     // common header byte - union so it's easier to put into vector
+    data_t port_fields;
     struct {
-        union {
-            struct {
-                data_t port_fields;
-            } __attribute__((packed));
-            struct {
 #if __BIG_ENDIAN
-                data_t sfs : 1, ack : 1, subclass : 2, port : 4;
+        data_t sfs : 1, ack : 1, subclass : 2, port : 4;
 #else
-                data_t port : 4, subclass : 2, ack : 1, sfs : 1;
+        data_t port : 4, subclass : 2, ack : 1, sfs : 1;
 #endif
-            } __attribute__((packed));
-        };
-    };
+    } __attribute__((packed));
 };
 
-/**
- * @brief [brief description]
- * @details [long description]
- *
- * @param p [description]
- * @return [description]
- */
-class payload_data : public layer_map {
+
+
+class payload_data {
 public:
-    payload_data() : layer_map(MAX_DATA_SZ){};
+    payload_data() {};
 
-    datav_it_t pack() { return d.begin(); }
+    std::vector<data_t> d;
 
-    datav_it_t add_header(const header_data& h) {
-        d.insert(d.begin(), h.d.begin(), h.d.end());
-        return d.begin();
+    size_t size() const {
+        return d.size();
     }
 
     template <class T>
@@ -159,7 +111,6 @@ class packet {
 public:
     rtp::header_data header;
     rtp::payload_data payload;
-    bool _packed;
 
     packet(){};
     packet(const std::string& s) { payload.fill(s); }
@@ -169,17 +120,11 @@ public:
         payload.fill(v);
     }
 
-    packet_data_t* packed() {
-        if (_packed == false) pack();
-
-        return payload.data();
-    }
-
-    size_t size() {
-        if (_packed == true)
-            return payload.size();
-        else
+    size_t size(bool includeHeader = true) {
+        if (includeHeader)
             return payload.size() + header.size();
+        else
+            return payload.size();
     }
 
     int port() const { return static_cast<int>(header.port); }
@@ -209,13 +154,21 @@ public:
         // sort out header
     }
 
-private:
-    void pack() {
-        payload.pack();
-        // pack the header, but do a "headless" pack
-        header.pack(payload.size(), true);
-        payload.add_header(header);
-        _packed = true;
+    void pack(std::vector<data_t> *buffer, bool includeHeader = false) const {
+        buffer->reserve(MAX_DATA_SZ);
+
+        // first byte is total size (excluding the size byte)
+        const uint8_t total_size = payload.size() + (includeHeader ? 2 : 0);
+        buffer->push_back(total_size);
+
+        // header data
+        if (includeHeader) {
+            buffer->push_back(header.address);
+            buffer->push_back(header.port_fields);
+        }
+
+        // payload
+        buffer->insert(buffer->end(), payload.d.begin(), payload.d.end());
     }
 };
 }

--- a/firmware/robot2015/src-ctrl/modules/CommTaskThread.cpp
+++ b/firmware/robot2015/src-ctrl/modules/CommTaskThread.cpp
@@ -31,8 +31,8 @@ void legacy_rx_cb(rtp::packet* p) {
     if (p->payload.size()) {
         LOG(OK,
             "Legacy rx successful!\r\n"
-            "    Received:\t'%s' (%u bytes)\r\n",
-            p->payload.data(), p->payload.size());
+            "    Received: %u bytes\r\n",
+            p->payload.size());
     } else if (p->sfs()) {
         LOG(OK, "Legacy rx ACK successful!\r\n");
     } else {
@@ -55,9 +55,9 @@ void loopback_rx_cb(rtp::packet* p) {
     if (p->payload.size()) {
         LOG(OK,
             "Loopback rx successful!\r\n"
-            "    Received:\t'%s' (%u bytes)\r\n"
+            "    Received: %u bytes\r\n"
             "    ACK:\t%s\r\n",
-            p->payload.data(), p->payload.size(), (p->ack() ? "SET" : "UNSET"));
+            p->payload.size(), (p->ack() ? "SET" : "UNSET"));
 
         if (p->subclass() == 1) {
             uint16_t status_byte = FPGA::Instance()->set_duty_cycles(
@@ -105,9 +105,9 @@ void loopback_tx_cb(rtp::packet* p) {
     if (p->payload.size()) {
         LOG(OK,
             "Loopback tx successful!\r\n"
-            "    Sent:\t'%s' (%u bytes)\r\n"
+            "    Sent: %u bytes\r\n"
             "    ACK:\t%s\r\n",
-            p->payload.data(), p->payload.size(), (p->ack() ? "SET" : "UNSET"));
+            p->payload.size(), (p->ack() ? "SET" : "UNSET"));
     } else if (p->sfs()) {
         LOG(OK, "Loopback tx ACK successful!\r\n");
     } else {

--- a/firmware/robot2015/src-ctrl/modules/CommTaskThread.cpp
+++ b/firmware/robot2015/src-ctrl/modules/CommTaskThread.cpp
@@ -154,6 +154,9 @@ void Task_CommCtrl(void const* args) {
     CC1201 radio(RJ_SPI_BUS, RJ_RADIO_nCS, RJ_RADIO_INT, preferredSettings,
                  sizeof(preferredSettings) / sizeof(registerSetting_t));
 
+    // TODO(justin): remove this
+    global_radio = &radio;
+
     /*
      * Ports are always displayed in ascending (lowest -> highest) order
      * according

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
@@ -849,7 +849,7 @@ int cmd_radio(cmd_args_t& args) {
 
     if (args.size() == 1 || args.size() == 2) {
         rtp::packet pck("LINK TEST PAYLOAD");
-        unsigned int portNbr = rtp::port::LINK;
+        unsigned int portNbr = rtp::port::DISCOVER;
 
         if (args.size() > 1) portNbr = atoi(args.at(1).c_str());
 
@@ -871,6 +871,8 @@ int cmd_radio(cmd_args_t& args) {
             CommModule::receive(pck);
 
         } else if (args.front().compare("loopback") == 0) {
+            pck.port(rtp::port::LINK);
+
             unsigned int i = 1;
             if (args.size() > 1) {
                 i = atoi(args.at(1).c_str());

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
@@ -6,6 +6,7 @@
 #include <rtos.h>
 #include <mbed_rpc.h>
 #include <CommModule.hpp>
+#include <CC1201.hpp>
 #include <numparser.hpp>
 #include <logger.hpp>
 
@@ -143,8 +144,10 @@ static const vector<command_t> commands = {
      cmd_radio,
      "test radio connectivity.",
      "radio [show, {set {up,down,reset} <port>, {test-tx,test-rx} [<port>], "
-     "loopback "
-     "[<count>], stress-test <count> <delay> <pck-size>}]"},
+     "loopback [<count>], "
+     "debug, "
+     "strobe <num>, "
+     "stress-test <count> <delay> <pck-size>}]"},
 
     {{"reboot", "reset", "restart"},
      false,
@@ -895,6 +898,13 @@ int cmd_radio(cmd_args_t& args) {
                 Thread::wait(50);
             }
 
+        } else if (args.front() == "strobe") {
+            global_radio->strobe(0x30+atoi(args.at(1).c_str()));
+        } else if (args.front() == "debug") {
+            bool wasEnabled = global_radio->isDebugEnabled();
+            global_radio->setDebugEnabled(!wasEnabled);
+            printf("Radio debugging now %s\r\n", wasEnabled ? "DISABLED" : "ENABLED");
+            if (!wasEnabled) printf("All strobes will appear in the INF2 logs\r\n");
         } else {
             show_invalid_args(args.front());
             return 1;


### PR DESCRIPTION
@jjones646 want to change `radio-tx` and `radio-rx` to use the actual radio rather than a loopback test?

When running this version of the firmware, I get an error when running `radio-tx`:
~~~{.sh}
Placing 18 byte packet in TX buffer.
Thu Jan  1 01:33:22 1970 [SEVERE] [/home/justin/src/rj/robocup-software/firmware/common2015/drivers/cc1201/CC1201.cpp:41] <sendData>
  Packet size is inconsistent with expected number of bytes! 18 bytes expected, 76 bytes found in buffer.
~~~

I think it may be related to your recent changes to the rtp stuff and the `pack()` method.  Any ideas?