### PR TITLE
Adds configurable values for robot speed and rotation, closes #343

### DIFF
--- a/soccer/CMakeLists.txt
+++ b/soccer/CMakeLists.txt
@@ -12,6 +12,7 @@ set(ROBOCUP_LIB_SRC
     "FieldView.cpp"
     "gameplay/GameplayModule.cpp"
     "gameplay/robocup-py.cpp"
+    "joystick/Joystick.cpp"
     "joystick/GamepadJoystick.cpp"
     "joystick/SpaceNavJoystick.cpp"
     "Logger.cpp"

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -674,7 +674,8 @@ JoystickControlValues Processor::getJoystickControlValues() {
     if (vals.rotation > 1) vals.rotation = 1;
     if (vals.rotation < -1) vals.rotation = -1;
 
-    // scale up speeds, respecting the damping modes
+    // Gets values from the configured joystick control values,respecting damped
+    // state
     if (_dampedTranslation) {
         vals.translation *=
             Joystick::JoystickTranslationMaxDampedSpeed->value();

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -10,6 +10,7 @@
 #include <multicast.hpp>
 #include <Constants.hpp>
 #include <Utils.hpp>
+#include <joystick/Joystick.hpp>
 #include <joystick/GamepadJoystick.hpp>
 #include <joystick/SpaceNavJoystick.hpp>
 #include <LogUtils.hpp>
@@ -38,13 +39,6 @@ RobotConfig* Processor::robotConfig2011;
 RobotConfig* Processor::robotConfig2015;
 std::vector<RobotStatus*>
     Processor::robotStatuses;  ///< FIXME: verify that this is correct
-
-// Joystick speed limits (for damped and non-damped mode)
-// Translation in m/s, Rotation in rad/s
-static const float JoystickRotationMaxSpeed = 4 * M_PI;
-static const float JoystickRotationMaxDampedSpeed = 1 * M_PI;
-static const float JoystickTranslationMaxSpeed = 3.0;
-static const float JoystickTranslationMaxDampedSpeed = 1.0;
 
 void Processor::createConfiguration(Configuration* cfg) {
     robotConfig2008 = new RobotConfig(cfg, "Rev2008");
@@ -682,14 +676,15 @@ JoystickControlValues Processor::getJoystickControlValues() {
 
     // scale up speeds, respecting the damping modes
     if (_dampedTranslation) {
-        vals.translation *= JoystickTranslationMaxDampedSpeed;
+        vals.translation *=
+            Joystick::JoystickTranslationMaxDampedSpeed->value();
     } else {
-        vals.translation *= JoystickRotationMaxSpeed;
+        vals.translation *= Joystick::JoystickRotationMaxSpeed->value();
     }
     if (_dampedRotation) {
-        vals.rotation *= JoystickRotationMaxDampedSpeed;
+        vals.rotation *= Joystick::JoystickRotationMaxDampedSpeed->value();
     } else {
-        vals.rotation *= JoystickRotationMaxSpeed;
+        vals.rotation *= Joystick::JoystickRotationMaxSpeed->value();
     }
 
     // scale up kicker and dribbler speeds

--- a/soccer/joystick/Joystick.cpp
+++ b/soccer/joystick/Joystick.cpp
@@ -1,0 +1,20 @@
+
+#include "joystick/Joystick.hpp"
+
+REGISTER_CONFIGURABLE(Joystick);
+
+ConfigDouble* Joystick::JoystickRotationMaxSpeed;
+ConfigDouble* Joystick::JoystickRotationMaxDampedSpeed;
+ConfigDouble* Joystick::JoystickTranslationMaxSpeed;
+ConfigDouble* Joystick::JoystickTranslationMaxDampedSpeed;
+
+void Joystick::createConfiguration(Configuration* cfg) {
+    JoystickRotationMaxSpeed =
+        new ConfigDouble(cfg, "Joystick/Max Rotation Speed", 4 * M_PI);
+    JoystickRotationMaxDampedSpeed =
+        new ConfigDouble(cfg, "Joystick/Max Damped Rotation Speed", 1 * M_PI);
+    JoystickTranslationMaxSpeed =
+        new ConfigDouble(cfg, "Joystick/Max Translation Speed", 3.0);
+    JoystickTranslationMaxDampedSpeed =
+        new ConfigDouble(cfg, "Joystick/Max Damped Translation Speed", 1.0);
+}

--- a/soccer/joystick/Joystick.hpp
+++ b/soccer/joystick/Joystick.hpp
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <Robot.hpp>
@@ -60,6 +61,12 @@ public:
      * @return The control values for this joystick
      */
     virtual JoystickControlValues getJoystickControlValues() = 0;
+    static void createConfiguration(Configuration* cfg);
+
+    static ConfigDouble* JoystickRotationMaxSpeed;
+    static ConfigDouble* JoystickRotationMaxDampedSpeed;
+    static ConfigDouble* JoystickTranslationMaxSpeed;
+    static ConfigDouble* JoystickTranslationMaxDampedSpeed;
 
 protected:
     QMutex& mutex() { return _mutex; }


### PR DESCRIPTION
Also adds configurable values for the damped joystick rotation and translation. The starting values of the configurable values may be adjusted in Joystick.cpp

EDIT: Just realized that when I rolled back some changes I also deleted all my comments, going through and putting those in right now