### PR TITLE
fixed issues with diffbase and ci checkstyle

### DIFF
--- a/config.docif
+++ b/config.docif
@@ -100,7 +100,7 @@ TEST_COMMANDS+=( 'make test-soccer;test-soccer;A check to see if soccer tests pa
 TEST_COMMANDS+=( 'make robot2015;firmware;A check to see if firmware compiles' )
 TEST_COMMANDS+=( 'make base2015;base2015;A check to see if base station firmware compiles' )
 TEST_COMMANDS+=( 'make test-firmware;test-firmware;A check to see if firmware tests pass' )
-TEST_COMMANDS+=( 'git fetch -f origin master:master && make checkstyle;style;A check to see if style passes' )
+TEST_COMMANDS+=( 'STYLIZE_DIFFBASE=origin/master make checkstyle;style;A check to see if style passes' )
 TEST_COMMANDS+=( 'make test-python;test-python;A check to see if python unit tests pass' )
 TEST_COMMANDS+=('make coverage;coverage;A coverage build task.')
 # @RECCOMENDED

--- a/config.docif
+++ b/config.docif
@@ -100,7 +100,7 @@ TEST_COMMANDS+=( 'make test-soccer;test-soccer;A check to see if soccer tests pa
 TEST_COMMANDS+=( 'make robot2015;firmware;A check to see if firmware compiles' )
 TEST_COMMANDS+=( 'make base2015;base2015;A check to see if base station firmware compiles' )
 TEST_COMMANDS+=( 'make test-firmware;test-firmware;A check to see if firmware tests pass' )
-TEST_COMMANDS+=( 'STYLIZE_DIFFBASE=origin/master make checkstyle;style;A check to see if style passes' )
+TEST_COMMANDS+=( 'git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle;style;A check to see if style passes' )
 TEST_COMMANDS+=( 'make test-python;test-python;A check to see if python unit tests pass' )
 TEST_COMMANDS+=('make coverage;coverage;A coverage build task.')
 # @RECCOMENDED

--- a/makefile
+++ b/makefile
@@ -179,7 +179,7 @@ apidocs:
 	cp doc/doxygen.css api_docs/html/
 	@echo "\n=> Open up 'api_docs/html/index.html' in a browser to view a local copy of the documentation"
 
-
+STYLIZE_DIFFBASE ?= master
 STYLE_EXCLUDE_DIRS=build \
 	external \
 	firmware/robot/cpu/at91sam7s256 \
@@ -189,9 +189,9 @@ STYLE_EXCLUDE_DIRS=build \
 	firmware/robot/cpu/invensense
 # automatically format code according to our style config defined in .clang-format
 pretty:
-	@stylize --diffbase=master --clang_style=file --yapf_style=.style.yapf --exclude_dirs $(STYLE_EXCLUDE_DIRS)
+	@stylize --diffbase=$(STYLIZE_DIFFBASE) --clang_style=file --yapf_style=.style.yapf --exclude_dirs $(STYLE_EXCLUDE_DIRS)
 # check if everything in our codebase is in accordance with the style config defined in .clang-format
 # a nonzero exit code indicates that there's a formatting error somewhere
 checkstyle:
 	@printf "Run this command to reformat code if needed:\n\ngit apply <(curl $${LINK_PREFIX:-file://}clean.patch)\n\n"
-	@stylize --diffbase=master --clang_style=file --yapf_style=.style.yapf --exclude_dirs $(STYLE_EXCLUDE_DIRS) --check --output_patch_file="$${CIRCLE_ARTIFACTS:-.}/clean.patch"
+	@stylize --diffbase=$(STYLIZE_DIFFBASE) --clang_style=file --yapf_style=.style.yapf --exclude_dirs $(STYLE_EXCLUDE_DIRS) --check --output_patch_file="$${CIRCLE_ARTIFACTS:-.}/clean.patch"


### PR DESCRIPTION
@jgkamat, the fix you had worked great for non-master branches, but seems to fail when the branch being CI'd is the master branch.  See the current [checkstyle log](https://circle-artifacts.com/gh/RoboJackets/robocup-software/1270/artifacts/0/tmp/circle-artifacts.dwZ0bAA/style.txt).

I think this should fix it up.  origin/master should always be up-to-date, it's just the ci-local version of master that wasn't always updated when the CI was running for a non-master branch.