### PR TITLE
Added ping command for testing radio

### DIFF
--- a/firmware/common2015/drivers/cc1201/CC1201.cpp
+++ b/firmware/common2015/drivers/cc1201/CC1201.cpp
@@ -48,7 +48,7 @@ int32_t CC1201::sendData(uint8_t* buf, uint8_t size) {
         return COMM_FUNC_BUF_ERR;
     }
 
-    flush_tx();
+    strobe(CC1201_STROBE_SFTX);
 
     strobe(CC1201_STROBE_SIDLE);
 
@@ -63,8 +63,8 @@ int32_t CC1201::sendData(uint8_t* buf, uint8_t size) {
     if ((device_state & CC1201_STATE_TXFIFO_ERROR) ==
         CC1201_STATE_TXFIFO_ERROR) {
         LOG(WARN, "STATE AT TX ERROR: 0x%02X", device_state);
-        flush_tx();  // flush the TX buffer & return if the FIFO is in a corrupt
-        // state
+        // flush the TX buffer & return if the FIFO is in a corrupt state
+        flush_tx();
 
         // set in IDLE mode and strobe back into RX to ensure the states will
         // fall through calibration then return
@@ -310,14 +310,14 @@ void CC1201::flush_tx() {
     idle();
     size_t bytes = readReg(CC1201_NUM_TXBYTES);
     strobe(CC1201_STROBE_SFTX);
-    // LOG(WARN, "%u bytes flushed from TX FIFO buffer.", bytes);
+    LOG(WARN, "%u bytes flushed from TX FIFO buffer.", bytes);
 }
 
 void CC1201::flush_rx() {
     idle();
     size_t bytes = readReg(CC1201_NUM_RXBYTES);
     strobe(CC1201_STROBE_SFRX);
-    // LOG(WARN, "%u bytes flushed from RX FIFO buffer.", bytes);
+    LOG(WARN, "%u bytes flushed from RX FIFO buffer.", bytes);
 }
 
 void CC1201::calibrate() {

--- a/firmware/common2015/drivers/cc1201/CC1201.cpp
+++ b/firmware/common2015/drivers/cc1201/CC1201.cpp
@@ -310,14 +310,14 @@ void CC1201::flush_tx() {
     idle();
     size_t bytes = readReg(CC1201_NUM_TXBYTES);
     strobe(CC1201_STROBE_SFTX);
-    LOG(WARN, "%u bytes flushed from TX FIFO buffer.", bytes);
+    // LOG(WARN, "%u bytes flushed from TX FIFO buffer.", bytes);
 }
 
 void CC1201::flush_rx() {
     idle();
     size_t bytes = readReg(CC1201_NUM_RXBYTES);
     strobe(CC1201_STROBE_SFRX);
-    LOG(WARN, "%u bytes flushed from RX FIFO buffer.", bytes);
+    // LOG(WARN, "%u bytes flushed from RX FIFO buffer.", bytes);
 }
 
 void CC1201::calibrate() {

--- a/firmware/common2015/modules/CommModule/CommPort.hpp
+++ b/firmware/common2015/modules/CommModule/CommPort.hpp
@@ -12,35 +12,11 @@
 template <class T>
 class CommPort {
 public:
-    CommPort(uint8_t number = 0, std::function<T> rxC = nullptr,
-             std::function<T> txC = nullptr)
-        : _isOpen(false), _rxCallback(rxC), _txCallback(txC) {
-        portNbr(number);
-        resetPacketCount();
-    };
+    CommPort(std::function<T> rxC = nullptr, std::function<T> txC = nullptr)
+        : _rxCallback(rxC), _txCallback(txC){};
 
-    // Compare between 2 CommPort objects
-    bool operator==(const CommPort& p) const {
-        return portNbr() == p.portNbr();
-    }
-
-    // Overload the less than operator for sorting/finding ports using iterators
-    bool operator<(const CommPort& p) const { return portNbr() < p.portNbr(); }
-
-    uint8_t portNbr() const { return _nbr; }
-    void portNbr(uint8_t nbr) { _nbr = nbr; }
-
-    bool valid() const { return _nbr != 0; }
-
-    // Open a port or check if a port is capable of providing communication.
-    void open() { _isOpen = true; }
-    void close() { _isOpen = false; }
-
-    bool isOpen() const { return _isOpen; }
-
-    bool isReady() const {
-        return isOpen() && hasTxCallback() && hasRxCallback();
-    }
+    /// Counters for the number of packets sent/received via this port
+    unsigned int rxCount = 0, txCount = 0;
 
     // Set functions for each RX/TX callback.
     void setRxCallback(const std::function<T>& func) { _rxCallback = func; }
@@ -50,120 +26,22 @@ public:
     std::function<T>& rxCallback() { return _rxCallback; }
     std::function<T>& txCallback() { return _txCallback; }
 
-    // Check if an RX/TX callback function has been set for the port.
-    bool hasTxCallback() const { return _txCallback != nullptr; }
-    bool hasRxCallback() const { return _rxCallback != nullptr; }
-
-    // Get a value or reference to the TX/RX packet count for modifying
-    unsigned int txCount() const { return _txCount; }
-    unsigned int rxCount() const { return _rxCount; }
-
-    void incTxCount() { _txCount++; }
-    void incRxCount() { _rxCount++; }
+    // Returns the current packet counts to zero
+    void resetPacketCount() {
+        rxCount = 0;
+        txCount = 0;
+    }
 
     // Standard display function for a CommPort
     void printPort() const {
-        printf("%2u\t\t%u\t%u\t%s\t\t%s\t\t%s\r\n", portNbr(), rxCount(),
-               txCount(), hasRxCallback() ? "YES" : "NO",
-               hasTxCallback() ? "YES" : "NO", isOpen() ? "OPEN" : "CLOSED");
+        printf("%u\t%u\t%s\t\t%s\r\n", rxCount, txCount,
+               _rxCallback != nullptr ? "YES" : "NO",
+               _txCallback != nullptr ? "YES" : "NO");
 
         Console::Instance()->Flush();
     }
 
-    // Returns the current packet counts to zero
-    void resetPacketCount() {
-        _rxCount = 0;
-        _txCount = 0;
-    }
-
 private:
-    // The number assigned to the port
-    uint8_t _nbr;
-
-    // If the port is open, it will also be valid
-    bool _isOpen;
-
-    // Where each upstream & downstream packet count is stored
-    unsigned int _rxCount, _txCount;
-
     // the class members that hold the function pointers
     std::function<T> _rxCallback, _txCallback;
-};
-
-/// Class to manage the available/unavailable ports
-template <class T>
-class CommPorts {
-public:
-    CommPorts<T> operator+=(const CommPort<T>& p) {
-        if (_ports.find(p.portNbr()) != _ports.end()) {
-            // the port already exists
-            LOG(WARN, "Overwriting existing port '%d'", p.portNbr());
-        }
-
-        _ports[p.portNbr()] = p;
-
-        return *this;
-    }
-
-    CommPort<T>& operator[](uint8_t portportNbr) { return _ports[portportNbr]; }
-
-    bool hasPort(uint8_t portportNbr) const {
-        return _ports.find(portportNbr) != _ports.end();
-    }
-
-    int count() const { return _ports.size(); }
-
-    int countOpen() const {
-        int count = 0;
-
-        for (auto& kvpair : _ports) {
-            if (kvpair.second.isOpen()) count++;
-        }
-
-        return count;
-    }
-
-    bool empty() const { return _ports.empty(); }
-
-    // Get the total count (across all ports) of each RX/TX packet count
-    unsigned int totalRxCount() const {
-        unsigned int count = 0;
-
-        for (auto& kvpair : _ports) {
-            count += kvpair.second.rxCount();
-        }
-
-        return count;
-    }
-    unsigned int totalTxCount() const {
-        unsigned int count = 0;
-
-        for (auto& kvpair : _ports) {
-            count += kvpair.second.txCount();
-        }
-
-        return count;
-    }
-
-    void printPorts() const {
-        for (auto& kvpair : _ports) {
-            kvpair.second.printPort();
-        }
-    }
-
-    void printHeader() const {
-        printf("PORT\t\tIN\tOUT\tRX CBCK\t\tTX CBCK\t\tSTATE\r\n");
-        Console::Instance()->Flush();
-    }
-
-    void printFooter() const {
-        printf(
-            "==========================\r\n"
-            "Total:\t\t%u\t%u\r\n",
-            totalRxCount(), totalTxCount());
-        Console::Instance()->Flush();
-    }
-
-private:
-    std::map<uint8_t, CommPort<T>> _ports;
 };

--- a/firmware/common2015/utils/rtp.hpp
+++ b/firmware/common2015/utils/rtp.hpp
@@ -24,7 +24,8 @@ enum port {
     DISCOVER,
     LOGGER,
     TCP,
-    LEGACY
+    LEGACY,
+    PING
 };
 
 struct header_data {

--- a/firmware/common2015/utils/rtp.hpp
+++ b/firmware/common2015/utils/rtp.hpp
@@ -67,7 +67,8 @@ public:
     }
 
     template <class T>
-    packet(const std::vector<T>& v, uint8_t p = SINK) : header(p) {
+    packet(const std::vector<T>& v, uint8_t p = SINK)
+        : header(p) {
         for (T val : v) payload.push_back(val);
     }
 

--- a/firmware/robot2015/src-ctrl/modules/CommInitialization.cpp
+++ b/firmware/robot2015/src-ctrl/modules/CommInitialization.cpp
@@ -22,7 +22,6 @@ using namespace std;
  * Information about the radio protocol can be found at:
  * https://www.overleaf.com/2187548nsfdps
  */
-
 void loopback_ack_pck(rtp::packet* p) {
     rtp::packet ack_pck = *p;
     // ack_pck.ack(false);
@@ -151,7 +150,6 @@ void InitializeCommModule() {
     // working radio is connected.
     commModule->setRxHandler(&loopback_rx_cb, rtp::port::LINK);
     commModule->setTxHandler(&loopback_tx_cb, rtp::port::LINK);
-    commModule->openSocket(rtp::port::LINK);
 
     /*
      * Ports are always displayed in ascending (lowest -> highest) order
@@ -165,20 +163,17 @@ void InitializeCommModule() {
         commModule->setRxHandler(&loopback_rx_cb, rtp::port::DISCOVER);
         commModule->setTxHandler((CommLink*)global_radio, &CommLink::sendPacket,
                                  rtp::port::DISCOVER);
-        commModule->openSocket(rtp::port::DISCOVER);
 
         // This port won't open since there's no RX callback to invoke. The
         // packets are simply dropped.
         commModule->setRxHandler(&loopback_rx_cb, rtp::port::LOGGER);
         commModule->setTxHandler((CommLink*)global_radio, &CommLink::sendPacket,
                                  rtp::port::LOGGER);
-        commModule->openSocket(rtp::port::LOGGER);
 
         // Legacy port
         commModule->setTxHandler((CommLink*)global_radio, &CommLink::sendPacket,
                                  rtp::port::LEGACY);
         commModule->setRxHandler(&legacy_rx_cb, rtp::port::LEGACY);
-        commModule->openSocket(rtp::port::LEGACY);
 
         LOG(INIT, "%u sockets opened", commModule->numOpenSockets());
 

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
@@ -136,6 +136,8 @@ static const vector<command_t> commands = {
      "show motor info (until receiving Ctrl-C).",
      "motorscroll"},
 
+    {{"serialping"}, true, cmd_serial_ping, "check the console's responsiveness.", "serialping"},
+
     {{"ps"}, false, cmd_ps, "list the active threads.", "ps"},
 
     {{"radio"},
@@ -372,6 +374,25 @@ int cmd_help_detail(cmd_args_t& args) {
         if (!commandFound) {
             printf("Command \"%s\" not found.\r\n", args[argInd].c_str());
         }
+    }
+
+    return 0;
+}
+
+/**
+ * Console responsiveness test.
+ */
+int cmd_serial_ping(cmd_args_t& args) {
+    if (!args.empty()) {
+        show_invalid_args(args);
+        return 1;
+    } else {
+        time_t sys_time = time(nullptr);
+        Console::Instance()->Flush();
+        printf("reply: %lu\r\n", sys_time);
+        Console::Instance()->Flush();
+
+        Thread::wait(600);
     }
 
     return 0;

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
@@ -136,7 +136,11 @@ static const vector<command_t> commands = {
      "show motor info (until receiving Ctrl-C).",
      "motorscroll"},
 
-    {{"serialping"}, true, cmd_serial_ping, "check the console's responsiveness.", "serialping"},
+    {{"serialping"},
+     true,
+     cmd_serial_ping,
+     "check the console's responsiveness.",
+     "serialping"},
 
     {{"ps"}, false, cmd_ps, "list the active threads.", "ps"},
 
@@ -152,15 +156,12 @@ static const vector<command_t> commands = {
      "strobe <num>, "
      "stress-test <count> <delay> <pck-size>}]"},
 
-     {{"ping"},
+    {{"ping"},
      false,
      cmd_ping,
      "periodically send ping packets out over radio broadcast"},
 
-     {{"pong"},
-     false,
-     cmd_pong,
-     "reply to ping"},
+    {{"pong"}, false, cmd_pong, "reply to ping"},
 
     {{"reboot", "reset", "restart"},
      false,
@@ -977,11 +978,10 @@ int cmd_radio(cmd_args_t& args) {
 }
 
 int cmd_pong(cmd_args_t& args) {
-    CommModule::Instance()->setTxHandler((CommLink*)global_radio,
-        &CommLink::sendPacket,
-        rtp::port::PING);
+    CommModule::Instance()->setTxHandler(
+        (CommLink*)global_radio, &CommLink::sendPacket, rtp::port::PING);
     Queue<rtp::packet, 2> pings;
-    CommModule::Instance()->setRxHandler( [&pings](rtp::packet* pkt) {
+    CommModule::Instance()->setRxHandler([&pings](rtp::packet* pkt) {
         pings.put(new rtp::packet(*pkt));
     }, rtp::port::PING);
 
@@ -996,7 +996,8 @@ int cmd_pong(cmd_args_t& args) {
             printf("Got ping %d\r\n", pingNbr);
 
             // reply with ack
-            CommModule::Instance()->send(rtp::packet({(uint8_t)pingNbr}, rtp::port::PING));
+            CommModule::Instance()->send(
+                rtp::packet({(uint8_t)pingNbr}, rtp::port::PING));
         }
 
         if (Console::Instance()->IterCmdBreakReq()) break;
@@ -1012,11 +1013,10 @@ int cmd_pong(cmd_args_t& args) {
 }
 
 int cmd_ping(cmd_args_t& args) {
-    CommModule::Instance()->setTxHandler((CommLink*)global_radio,
-        &CommLink::sendPacket,
-        rtp::port::PING);
+    CommModule::Instance()->setTxHandler(
+        (CommLink*)global_radio, &CommLink::sendPacket, rtp::port::PING);
     Queue<rtp::packet, 2> acks;
-    CommModule::Instance()->setRxHandler( [&acks](rtp::packet* pkt) {
+    CommModule::Instance()->setRxHandler([&acks](rtp::packet* pkt) {
         acks.put(new rtp::packet(*pkt));
     }, rtp::port::PING);
 
@@ -1028,7 +1028,8 @@ int cmd_ping(cmd_args_t& args) {
         if ((clock() - lastPingTime) / CLOCKS_PER_SEC > PingInterval) {
             lastPingTime = clock();
 
-            CommModule::Instance()->send(rtp::packet({(uint8_t)pingCount}, rtp::port::PING));
+            CommModule::Instance()->send(
+                rtp::packet({(uint8_t)pingCount}, rtp::port::PING));
 
             printf("Sent ping %d\r\n", pingCount);
 

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
@@ -908,7 +908,7 @@ int cmd_radio(cmd_args_t& args) {
                 unsigned int portNbr = atoi(args[2].c_str());
 
                 if (args[1] == "up") {
-                    commModule->openSocket(portNbr);
+                    // commModule->openSocket(portNbr);
 
                 } else if (args[1] == "down") {
                     commModule->close(portNbr);

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
@@ -971,13 +971,10 @@ int cmd_pong(cmd_args_t& args) {
     if (maybePing.status == 16) {
         rtp::packet* ping = (rtp::packet*)maybePing.value.p;
 
-        int pingNbr = ping->payload.d[0];
+        int pingNbr = ping->payload[0];
 
         // reply with ack
-        rtp::packet ack;
-        ack.payload.d.push_back(pingNbr);
-        ack.port(rtp::port::PING);
-        CommModule::Instance()->send(ack);
+        CommModule::Instance()->send(rtp::packet({pingNbr}, rtp::port::PING));
 
         printf("Got ping %d\r\n", pingNbr);
 
@@ -1003,10 +1000,7 @@ int cmd_ping(cmd_args_t& args) {
     if ((clock() - last_ping) / CLOCKS_PER_SEC > Interval) {
         last_ping = clock();
 
-        rtp::packet pck;
-        pck.payload.d.push_back(ping_count);
-        pck.port(rtp::port::PING);
-        CommModule::Instance()->send(pck);
+        CommModule::Instance()->send(rtp::packet({ping_count}, rtp::port::PING));
 
         printf("Sent ping %d\r\n", ping_count);
 
@@ -1017,7 +1011,7 @@ int cmd_ping(cmd_args_t& args) {
     osEvent maybeAck = acks.get(timeout_ms);
     if (maybeAck.status == 16) {
         rtp::packet* ack = (rtp::packet*)maybeAck.value.p;
-        printf("  got ack %d\r\n", ack->payload.d[0]);
+        printf("  got ack %d\r\n", ack->payload[0]);
         delete ack;
     }
 

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
@@ -966,17 +966,17 @@ int cmd_pong(cmd_args_t& args) {
         pings.put(new rtp::packet(*pkt));
     }, rtp::port::PING);
 
-    uint32_t timeout_ms = 10;
+    uint32_t timeout_ms = 1;
     osEvent maybePing = pings.get(timeout_ms);
-    if (maybePing.status == 16) {
+    if (maybePing.status == osEventMessage) {
         rtp::packet* ping = (rtp::packet*)maybePing.value.p;
 
         int pingNbr = ping->payload[0];
 
         // reply with ack
-        CommModule::Instance()->send(rtp::packet({pingNbr}, rtp::port::PING));
+        CommModule::Instance()->send(rtp::packet({(uint8_t)pingNbr}, rtp::port::PING));
 
-        printf("Got ping %d\r\n", pingNbr);
+        LOG(WARN, "Got ping %d\r\n", pingNbr);
 
         delete ping;
     }
@@ -995,21 +995,21 @@ int cmd_ping(cmd_args_t& args) {
 
     static int ping_count = 0;
     static int last_ping = 0;
-    static const int Interval = 2;
+    static const int Interval = 3;
 
     if ((clock() - last_ping) / CLOCKS_PER_SEC > Interval) {
         last_ping = clock();
 
-        CommModule::Instance()->send(rtp::packet({ping_count}, rtp::port::PING));
+        CommModule::Instance()->send(rtp::packet({(uint8_t)ping_count}, rtp::port::PING));
 
         printf("Sent ping %d\r\n", ping_count);
 
         ping_count++;
     }
 
-    uint32_t timeout_ms = 10;
+    uint32_t timeout_ms = 1;
     osEvent maybeAck = acks.get(timeout_ms);
-    if (maybeAck.status == 16) {
+    if (maybeAck.status == osEventMessage) {
         rtp::packet* ack = (rtp::packet*)maybeAck.value.p;
         printf("  got ack %d\r\n", ack->payload[0]);
         delete ack;

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
@@ -966,7 +966,7 @@ int cmd_pong(cmd_args_t& args) {
         pings.put(new rtp::packet(*pkt));
     }, rtp::port::PING);
 
-    uint32_t timeout_ms = 200;
+    uint32_t timeout_ms = 10;
     osEvent maybePing = pings.get(timeout_ms);
     if (maybePing.status == 16) {
         rtp::packet* ping = (rtp::packet*)maybePing.value.p;

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.hpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.hpp
@@ -81,6 +81,7 @@ int cmd_console_hostname(cmd_args_t&);
 int cmd_console_user(cmd_args_t&);
 int cmd_help(cmd_args_t&);
 int cmd_help_detail(cmd_args_t&);
+int cmd_serial_ping(cmd_args_t&);
 int cmd_info(cmd_args_t&);
 int cmd_interface_check_conn(cmd_args_t&);
 int cmd_interface_disconnect(cmd_args_t&);

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.hpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.hpp
@@ -91,5 +91,7 @@ int cmd_ls(cmd_args_t&);
 int cmd_ping(cmd_args_t&);
 int cmd_ps(cmd_args_t&);
 int cmd_radio(cmd_args_t&);
+int cmd_ping(cmd_args_t&);
+int cmd_pong(cmd_args_t&);
 int cmd_rpc(cmd_args_t&);
 int cmd_imu(cmd_args_t&);


### PR DESCRIPTION
TODO:

- [x] Restore old serial connection `ping` command
- [ ] Document the ping/pong commands a bit
- [ ] Something is off with the timing in our commands.
- [x] fix or remove RX/TX flush logging
- [ ] fix port printing for `radio` command
- [x] init and de-init for iterative commands?
- [ ] fix radio `up`/`down` commands now that port api has changed
- [ ] how to use keyboard to break out of command loop?

Note: I also removed the `CommPorts` class since it was basically just a wrapper around `std::map`.  Also, removed the open/closed flag for ports.  To close a port now, just remove the TX/RX handlers.