### PR TITLE
fixed out-of-memory issue introduced by PR #567

### DIFF
--- a/firmware/common2015/utils/logger/logger.cpp
+++ b/firmware/common2015/utils/logger/logger.cpp
@@ -42,7 +42,7 @@ void log(uint8_t logLevel, const char* source, int line, const char* func,
         log_mutex.lock();
 
         va_list args;
-        char newFormat[1024];
+        static char newFormat[300];
         char time_buf[25];
         time_t sys_time = time(NULL);
         strftime(time_buf, 25, "%H:%M:%S", localtime(&sys_time));


### PR DESCRIPTION
I noticed that the changes in #567 were causing a segfault in our firmware.  It seems that it's caused by a lack of available memory (on the stack).  I changed the `log()` method to use a smaller temporary buffer and made it `static`.  Making the buffer `static` means only one buffer is allocated globally (and its not on the stack), rather than one buffer per call to `log()`, which could cause multiple simultaneous buffer allocations when multiple threads call `log()` at the same time.  The mutex protecting the buffer still ensures that only one thread can use it at a time.  I changed the size from 1024 to 300, which is a pretty arbitrary number, but seems reasonable.

cc @JNeiger @jjones646 