### PR TITLE
Setup error LEDs

### DIFF
--- a/firmware/robot2015/src-ctrl/config/pins-ctrl-2015.hpp
+++ b/firmware/robot2015/src-ctrl/config/pins-ctrl-2015.hpp
@@ -97,23 +97,23 @@
 #define RJ_IO_EXPANDER_I2C_ADDRESS (0x42)
 
 // Port A bit masks
-#define RJ_IOEXP_A0 (0)
-#define RJ_IOEXP_A1 (1)
-#define RJ_IOEXP_A2 (2)
-#define RJ_IOEXP_A3 (3)
-#define RJ_IOEXP_A4 (4)
-#define RJ_IOEXP_A5 (5)
-#define RJ_IOEXP_A6 (6)
-#define RJ_IOEXP_A7 (7)
+#define RJ_IOEXP_A0 0
+#define RJ_IOEXP_A1 1
+#define RJ_IOEXP_A2 2
+#define RJ_IOEXP_A3 3
+#define RJ_IOEXP_A4 4
+#define RJ_IOEXP_A5 5
+#define RJ_IOEXP_A6 6
+#define RJ_IOEXP_A7 7
 // Port B bit masks
-#define RJ_IOEXP_B0 (8)
-#define RJ_IOEXP_B1 (9)
-#define RJ_IOEXP_B2 (10)
-#define RJ_IOEXP_B3 (11)
-#define RJ_IOEXP_B4 (12)
-#define RJ_IOEXP_B5 (13)
-#define RJ_IOEXP_B6 (14)
-#define RJ_IOEXP_B7 (15)
+#define RJ_IOEXP_B0 8
+#define RJ_IOEXP_B1 9
+#define RJ_IOEXP_B2 10
+#define RJ_IOEXP_B3 11
+#define RJ_IOEXP_B4 12
+#define RJ_IOEXP_B5 13
+#define RJ_IOEXP_B6 14
+#define RJ_IOEXP_B7 15
 
 enum IOExpanderPin {
     RJ_HEX_SWITCH_BIT0 = RJ_IOEXP_A0,
@@ -132,5 +132,8 @@ enum IOExpanderPin {
     RJ_ERR_LED_MPU = RJ_IOEXP_B4,
     RJ_ERR_LED_BSENSE = RJ_IOEXP_B5,
     RJ_ERR_LED_DRIB = RJ_IOEXP_B6,
-    RJ_ERR_LED_RADIO = RJ_IOEXP_B7
+    RJ_ERR_LED_RADIO = RJ_IOEXP_B7,
+    RJ_ERR_LED_FPGA = RJ_IOEXP_B6,  // TODO(justin): fix
 };
+
+constexpr uint16_t IOExpanderErrorLEDMask = 0xFF00;

--- a/firmware/robot2015/src-ctrl/config/pins-ctrl-2015.hpp
+++ b/firmware/robot2015/src-ctrl/config/pins-ctrl-2015.hpp
@@ -133,7 +133,6 @@ enum IOExpanderPin {
     RJ_ERR_LED_BSENSE = RJ_IOEXP_B5,
     RJ_ERR_LED_DRIB = RJ_IOEXP_B6,
     RJ_ERR_LED_RADIO = RJ_IOEXP_B7,
-    RJ_ERR_LED_FPGA = RJ_IOEXP_B6,  // TODO(justin): fix
 };
 
 constexpr uint16_t IOExpanderErrorLEDMask = 0xFF00;

--- a/firmware/robot2015/src-ctrl/drivers/mcp23017/mcp23017.cpp
+++ b/firmware/robot2015/src-ctrl/drivers/mcp23017/mcp23017.cpp
@@ -3,15 +3,6 @@
 #include <mbed.h>
 #include <logger.hpp>
 
-// Declaration for the pointer to the global object
-shared_ptr<MCP23017> MCP23017::instance;
-
-shared_ptr<MCP23017>& MCP23017::Instance() {
-    if (!instance) instance.reset(new MCP23017(RJ_I2C_BUS, 0));
-
-    return instance;
-}
-
 MCP23017::MCP23017(PinName sda, PinName scl, int i2cAddress)
     : _i2c(sda, scl), _i2cAddress(i2cAddress) {
     _i2c.frequency(400000);

--- a/firmware/robot2015/src-ctrl/drivers/mcp23017/mcp23017.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/mcp23017/mcp23017.hpp
@@ -29,8 +29,6 @@ public:
 
     MCP23017(PinName sda, PinName scl, int i2cAddress);
 
-    static std::shared_ptr<MCP23017>& Instance();
-
     /** Reset MCP23017 device to its power-on state
      */
     void reset();
@@ -102,8 +100,6 @@ public:
     void write(int data);
 
 private:
-    static std::shared_ptr<MCP23017> instance;
-
     I2CMasterRtos _i2c;
     int _i2cAddress;  // physical I2C address
 

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -196,7 +196,7 @@ int main() {
             make_pair(4, RJ_ERR_LED_DRIB)};
         for (auto& pair : motorErrLedMapping) {
             const motorErr_t& status = global_motors[pair.first].status;
-            errorBitmask |= (!status.encOK || !status.hallOK) << pair.second;
+            errorBitmask |= !status.hallOK << pair.second;
         }
 
         // Set error-indicating leds on the control board

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -17,11 +17,7 @@
 #include "fpga.hpp"
 #include "io-expander.hpp"
 #include "neostrip.hpp"
-
-// task globals
-uint16_t comm_err = 0;
-uint16_t fpga_err = 0;
-uint16_t imu_err = 0;
+#include "CC1201.cpp"
 
 void Task_Controller(void const* args);
 
@@ -128,12 +124,8 @@ int main() {
         LOG(FATAL, "FPGA Configuration Failed!");
     }
 
-    fpga_err |= 1 << !fpga_ready;
-    // the error code is valid now
-    fpga_err |= 1 << 0;
-
     // Init IO Expander and turn  all LEDs
-    MCP23017::Instance();
+    MCP23017 ioExpander(RJ_I2C_BUS, 0);
 
     // Startup the 3 separate threads, being sure that we wait for it
     // to signal back to us that we can startup the next thread. Not doing
@@ -157,35 +149,6 @@ int main() {
     // Make sure all of the motors are enabled
     motors_Init();
 
-    // Set error indicators
-    if (fpga_err > 1) {
-        // orange - error
-        rgbLED.brightness(4 * defaultBrightness);
-        rgbLED.setPixel(0, 0xFF, 0xA5, 0x00);
-    } else {
-        // green - no error...yet
-        rgbLED.brightness(defaultBrightness);
-        rgbLED.setPixel(0, 0x00, 0xFF, 0x00);
-    }
-
-    if (comm_err > 1) {
-        // orange - error
-        rgbLED.brightness(6 * defaultBrightness);
-        rgbLED.setPixel(1, 0xFF, 0xA5, 0x00);
-    } else {
-        // green - no error...yet
-        rgbLED.brightness(6 * defaultBrightness);
-        rgbLED.setPixel(1, 0x00, 0xFF, 0x00);
-    }
-
-    if (comm_err > 1 && fpga_err > 1) {
-        // bright as hell to make sure they know
-        rgbLED.brightness(10 * defaultBrightness);
-        // well, damn. everything is broke as hell
-        rgbLED.setPixel(0, 0xFF, 0x00, 0x00);
-        rgbLED.setPixel(1, 0xFF, 0x00, 0x00);
-    }
-
     // push out the LED changes to the hardware
     rgbLED.write();
 
@@ -203,7 +166,8 @@ int main() {
 
     unsigned int ll = 0;
 
-    MCP23017::Instance()->writeMask(0xFF00, 0xFF00);
+    // turn all error LEDs on
+    ioExpander.writeMask(IOExpanderErrorLEDMask, IOExpanderErrorLEDMask);
 
     while (true) {
         // make sure we can always reach back to main by
@@ -220,29 +184,45 @@ int main() {
 
         Thread::wait(RJ_WATCHDOG_TIMER_VALUE * 250);
 
-        // M1
-        // MCP23017::write_mask(~(1 << (8 + 1)), 0xFF00);
+        // Pack errors into bitmask
+        // clang-format off
+        uint16_t errorBitmask =
+            global_radio->isConnected() << RJ_ERR_LED_RADIO
+            | fpga_ready << RJ_ERR_LED_FPGA
+            ;
+        // clang-format on
 
-        // // M2
-        // MCP23017::write_mask(~(1 << (8 + 0)), 0xFF00);
+        // Set error-indicating leds on the control board
+        ioExpander.writeMask(IOExpanderErrorLEDMask, errorBitmask);
 
-        // // M3
-        // MCP23017::write_mask(~(1 << (8 + 5)), 0xFF00);
+        // Set error indicators
+        if (!fpga_ready) {
+            // orange - error
+            rgbLED.brightness(4 * defaultBrightness);
+            rgbLED.setPixel(0, 0xFF, 0xA5, 0x00);
+        } else {
+            // green - no error...yet
+            rgbLED.brightness(defaultBrightness);
+            rgbLED.setPixel(0, 0x00, 0xFF, 0x00);
+        }
 
-        // // M4
-        // MCP23017::write_mask(~(1 << (8 + 7)), 0xFF00);
+        if (errorBitmask & RJ_ERR_LED_RADIO) {
+            // orange - error
+            rgbLED.brightness(6 * defaultBrightness);
+            rgbLED.setPixel(1, 0xFF, 0xA5, 0x00);
+        } else {
+            // green - no error...yet
+            rgbLED.brightness(6 * defaultBrightness);
+            rgbLED.setPixel(1, 0x00, 0xFF, 0x00);
+        }
 
-        // IMU
-        // MCP23017::write_mask(~(1 << (8 + 6)), 0xFF00);
-
-        // Det
-        // MCP23017::write_mask(~(1 << (8 + 3)), 0xFF00);
-
-        // Sense
-        // MCP23017::write_mask(~(1 << (8 + 4)), 0xFF00);
-
-        // Radio
-        // MCP23017::write_mask(~(1 << (8 + 2)), 0xFF00);
+        if ((errorBitmask & RJ_ERR_LED_RADIO) && !fpga_ready) {
+            // bright as hell to make sure they know
+            rgbLED.brightness(10 * defaultBrightness);
+            // well, damn. everything is broke as hell
+            rgbLED.setPixel(0, 0xFF, 0x00, 0x00);
+            rgbLED.setPixel(1, 0xFF, 0x00, 0x00);
+        }
     }
 }
 

--- a/firmware/robot2015/src-ctrl/modules/CommInitialization.cpp
+++ b/firmware/robot2015/src-ctrl/modules/CommInitialization.cpp
@@ -128,28 +128,13 @@ void InitializeCommModule() {
         while (!commModule->isReady()) {
             Thread::wait(50);
         }
-
-        MCP23017::Instance()->writeMask(1 << (8 + 2), 1 << (8 + 2));
-
-        // Set the error code's valid bit
-        comm_err |= 1 << 0;
-
     } else {
         LOG(FATAL, "No radio interface found!\r\n");
-
-        // Set the error flag - bit positions are pretty arbitruary as of now
-        comm_err |= 1 << 1;
-
-        // Set the error code's valid bit
-        comm_err |= 1 << 0;
 
         // Wait until the threads with the commModule are all started up
         // and ready
         while (!commModule->isReady()) {
             Thread::wait(50);
         }
-
-        // Radio error LED
-        MCP23017::Instance()->writeMask(~(1 << (8 + 2)), 1 << (8 + 2));
     }
 }

--- a/firmware/robot2015/src-ctrl/modules/ControllerTaskThread.cpp
+++ b/firmware/robot2015/src-ctrl/modules/ControllerTaskThread.cpp
@@ -71,22 +71,11 @@ void Task_Controller(void const* args) {
 
         LOG(INIT, "Control loop ready!\r\n    Thread ID: %u, Priority: %d",
             threadID, threadPriority);
-
-        // Set the error code's valid bit
-        imu_err |= 1 << 0;
-
-        MCP23017::Instance()->writeMask(1 << (8 + 6), 1 << (8 + 6));
-
     } else {
         LOG(SEVERE,
             "MPU6050 not found!\t(response: 0x%02X)\r\n    Falling back to "
             "sensorless control loop.",
             testResp);
-
-        // Set the error flag - bit positions are pretty arbitruary as of now
-        imu_err |= 1 << 1;
-        // Set the error code's valid bit
-        imu_err |= 1 << 0;
 
         // Start a thread that can function without the IMU, terminate us if it
         // ever returns
@@ -168,9 +157,6 @@ void Task_Controller_Sensorless(const osThreadId mainID) {
     LOG(INIT,
         "Sensorless control loop ready!\r\n    Thread ID: %u, Priority: %d",
         threadID, threadPriority);
-
-    // IMU error LED
-    MCP23017::Instance()->writeMask(~(1 << (8 + 6)), 1 << (8 + 6));
 
     // signal back to main and wait until we're signaled to continue
     osSignalSet(mainID, MAIN_TASK_CONTINUE);

--- a/firmware/robot2015/src-ctrl/modules/motors/motors.cpp
+++ b/firmware/robot2015/src-ctrl/modules/motors/motors.cpp
@@ -11,12 +11,11 @@
 namespace {
 const int NUM_MOTORS = 5;
 
-motor_t mtrEx = {
-    .vel = 0x4D,
-    .hall = 0x0A,
-    .enc = {0x23, 0x18},
-    .status = {.encOK = false, .hallOK = true, .drvStatus = {0x26, 0x0F}},
-    .desc = "Motor"};
+motor_t mtrEx = {.vel = 0x4D,
+                 .hall = 0x0A,
+                 .enc = {0x23, 0x18},
+                 .status = {.hallOK = true, .drvStatus = {0x26, 0x0F}},
+                 .desc = "Motor"};
 }
 
 std::vector<motor_t> global_motors(NUM_MOTORS, mtrEx);

--- a/firmware/robot2015/src-ctrl/modules/motors/motors.cpp
+++ b/firmware/robot2015/src-ctrl/modules/motors/motors.cpp
@@ -19,17 +19,17 @@ motor_t mtrEx = {
     .desc = "Motor"};
 }
 
-std::vector<motor_t> motors(NUM_MOTORS, mtrEx);
+std::vector<motor_t> global_motors(NUM_MOTORS, mtrEx);
 int start_s = clock();
 
 void motors_Init() {
     // not sure why this sometimes causes a hard fault...
     // this will be changed anyways once motors are working
-    motors.at(0).desc += "1";
-    motors.at(1).desc += "2";
-    motors.at(2).desc += "3";
-    motors.at(3).desc += "4";
-    motors.at(4).desc = "Dribb.";
+    global_motors[0].desc += "1";
+    global_motors[1].desc += "2";
+    global_motors[2].desc += "3";
+    global_motors[3].desc += "4";
+    global_motors[4].desc = "Dribb.";
 }
 
 void motors_show() {
@@ -57,15 +57,15 @@ void motors_show() {
     printf("\033[K    ID\t\tVEL\tHALL\tENC\tDIR\tSTATUS\t\tFAULTS\033E");
     for (size_t i = 0; i < duty_cycles.size() - 1; i++) {
         printf("\033[K    %s\t%-3u\t%-3u\t%-5u\t%s\t%s\t0x%03X\033E",
-               motors.at(i).desc.c_str(), duty_cycles.at(i) & 0x1FF,
+               global_motors.at(i).desc.c_str(), duty_cycles.at(i) & 0x1FF,
                halls.at(i), enc_deltas.at(i),
                duty_cycles.at(i) & (1 << 9) ? "CW" : "CCW",
                (status_byte & (1 << i)) ? "[OK]    " : "[UNCONN]",
                driver_regs.at(i));
     }
     printf("\033[K    %s\t%-3u\t%-3u\tN/A\t%s\t%s\t0x%03X\033E",
-           motors.back().desc.c_str(), duty_cycles.back() & 0x1FF, halls.back(),
-           duty_cycles.back() & (1 << 9) ? "CW" : "CCW",
+           global_motors.back().desc.c_str(), duty_cycles.back() & 0x1FF,
+           halls.back(), duty_cycles.back() & (1 << 9) ? "CW" : "CCW",
            (status_byte & (1 << (enc_deltas.size() - 1))) ? "[OK]    "
                                                           : "[UNCONN]",
            driver_regs.back());
@@ -120,7 +120,7 @@ int cmd_motors(const std::vector<std::string>& args) {
                 FPGA::Instance()->set_duty_cycles(duty_cycles.data(),
                                                   duty_cycles.size());
                 printf("%s velocity set to %u (%s)\r\n",
-                       motors.at(motor_id).desc.c_str(), new_vel & 0x1FF,
+                       global_motors.at(motor_id).desc.c_str(), new_vel & 0x1FF,
                        new_vel & (1 << 9) ? "CW" : "CCW");
             } else {
                 // return an error if an invalid duty cycle was given

--- a/firmware/robot2015/src-ctrl/modules/motors/motors.hpp
+++ b/firmware/robot2015/src-ctrl/modules/motors/motors.hpp
@@ -26,7 +26,6 @@ struct motorErr_t {
     FETHB_OC, FETLB_OC
     FETHC_OC, FETLC_OC
     */
-    bool encOK;
     bool hallOK;
     std::array<uint16_t, 2> drvStatus;
 };

--- a/firmware/robot2015/src-ctrl/modules/motors/motors.hpp
+++ b/firmware/robot2015/src-ctrl/modules/motors/motors.hpp
@@ -39,6 +39,9 @@ struct motor_t {
     std::string desc;
 };
 
+// TODO(justin): is there a better solution than having a global variable?
+extern std::vector<motor_t> global_motors;
+
 void motors_Init();
 void motors_show();
 int cmd_motors(const std::vector<std::string>&);


### PR DESCRIPTION
I got bored of debugging radio problems, so I took a break and looked into the error leds.  I think I've got them mostly setup, although I don't have a control board to test on.  Btw, I noticed there wasn't an error led for the fpga.  Are we just using the rgb led for that?

TODO:

- [ ] add imu error
- [ ] ball sense
- [x] radio connected/unconnected
- [ ] errors from motors (this is sent back in the first byte for all FPGA SPI transfers)
- [x] remove motor `encOK` flag

cc @jjones646