### PR TITLE
Added a mutex for spi bus access

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -21,6 +21,8 @@ set(MBED_COPY_SCRIPT sudo ${PROJECT_SOURCE_DIR}/util/mbed/mbed-copy.py)
 
 # enable C++ exceptions
 set(MBED_CMAKE_CXX_FLAGS "${MBED_CMAKE_CXX_FLAGS} -fexceptions")
+# the mbed libraries are compiled with -fno-rtti, so we need to as well
+set(MBED_CMAKE_CXX_FLAGS "${MBED_CMAKE_CXX_FLAGS} -fno-rtti")
 # enable C++14
 set(MBED_CMAKE_CXX_FLAGS "${MBED_CMAKE_CXX_FLAGS} -std=c++14")
 # Enable logging for the common2015 library

--- a/firmware/common2015/CMakeLists.txt
+++ b/firmware/common2015/CMakeLists.txt
@@ -21,7 +21,7 @@ set(DRIVERS_ROOT_NAME   drivers)
 set(MODULES_ROOT_NAME   modules)
 set(UTILS_ROOT_NAME     utils)
 # subdirectories
-set(DRIVERS             cc1101 cc1201 cc1201/cfg rtos-i2c software-spi)
+set(DRIVERS             cc1101 cc1201 cc1201/cfg rtos-i2c shared-spi software-spi)
 set(MODULES             CommModule CommLink Console)
 set(UTILS               assert logger numparser rtos-mgmt)
 

--- a/firmware/common2015/drivers/cc1201/CC1201.hpp
+++ b/firmware/common2015/drivers/cc1201/CC1201.hpp
@@ -38,7 +38,7 @@ public:
      * @param regs An array of registereSetting_t values
      * @param len The length of the @regs array
      */
-    CC1201(PinName mosi, PinName miso, PinName sck, PinName nCs, PinName intPin,
+    CC1201(std::shared_ptr<SharedSPI> sharedSPI, PinName nCs, PinName intPin,
            const registerSetting_t* regs, size_t len,
            int rssiOffset = DEFAULT_RSSI_OFFSET);
 

--- a/firmware/common2015/drivers/shared-spi/SharedSPI.hpp
+++ b/firmware/common2015/drivers/shared-spi/SharedSPI.hpp
@@ -2,6 +2,9 @@
 
 #include <mbed.h>
 #include <rtos.h>
+
+#include <memory>
+
 #include "assert.hpp"
 
 /**
@@ -10,18 +13,45 @@
  * This makes it easier to correctly use a shared SPI bus (with multiple
  * devices) in a multi-threaded environment.
  */
-class SharedSPI : public mbed::SPI {
+class SharedSPI : public mbed::SPI, public Mutex {
 public:
     SharedSPI(PinName mosi, PinName miso, PinName sck) : SPI(mosi, miso, sck) {}
+};
 
-    osStatus lock(uint32_t millisec = osWaitForever) {
-        return _mutex.lock(millisec);
+
+/**
+ * Classes that provide an interface to a device on the shared spi bus should
+ * inherit from this class.
+ */
+template<class DIGITAL_OUT = mbed::DigitalOut>
+class SharedSPIDevice {
+public:
+    SharedSPIDevice(std::shared_ptr<SharedSPI> spi, DIGITAL_OUT cs,
+                    bool csInverted = true)
+        : _spi(spi), _cs(cs) {
+
+        /// The value we set the chip select pin to in order to assert it (it's
+        /// often inverted).
+        _csAssertValue = csInverted ? 0 : 1;
+
+        /// Initialize to a de-asserted state
+        _cs = !_csAssertValue;
     }
 
-    bool trylock() { return _mutex.trylock(); }
+    void chip_select() {
+        _spi->lock();
+        _cs = _csAssertValue;
+    }
 
-    osStatus unlock() { return _mutex.unlock(); }
+    void chip_deselect() {
+        _cs = _csAssertValue;
+        _spi->unlock();
+    }
+
+protected:
+    std::shared_ptr<SharedSPI> _spi;
+    DIGITAL_OUT _cs;
 
 private:
-    Mutex _mutex;
+    int _csAssertValue;
 };

--- a/firmware/common2015/drivers/shared-spi/SharedSPI.hpp
+++ b/firmware/common2015/drivers/shared-spi/SharedSPI.hpp
@@ -28,6 +28,8 @@ public:
     SharedSPIDevice(std::shared_ptr<SharedSPI> spi, DIGITAL_OUT cs,
                     bool csInverted = true)
         : _spi(spi), _cs(cs) {
+        ASSERT(spi != nullptr);
+
         /// The value we set the chip select pin to in order to assert it (it's
         /// often inverted).
         _csAssertValue = csInverted ? 0 : 1;
@@ -38,6 +40,7 @@ public:
 
     void chipSelect() {
         _spi->lock();
+        _spi->frequency(_frequency);
         _cs = _csAssertValue;
     }
 
@@ -46,10 +49,17 @@ public:
         _spi->unlock();
     }
 
+    /// Set the SPI frequency for this device
+    void setSPIFrequency(int hz) { _frequency = hz; }
+
 protected:
     std::shared_ptr<SharedSPI> _spi;
     DIGITAL_OUT _cs;
 
 private:
     int _csAssertValue;
+
+    /// The SPI bus frequency used by this device.
+    /// This default value is the same as the mbed's default (1MHz).
+    int _frequency = 1000000;
 };

--- a/firmware/common2015/drivers/shared-spi/SharedSPI.hpp
+++ b/firmware/common2015/drivers/shared-spi/SharedSPI.hpp
@@ -18,12 +18,11 @@ public:
     SharedSPI(PinName mosi, PinName miso, PinName sck) : SPI(mosi, miso, sck) {}
 };
 
-
 /**
  * Classes that provide an interface to a device on the shared spi bus should
  * inherit from this class.
  */
-template<class DIGITAL_OUT = mbed::DigitalOut>
+template <class DIGITAL_OUT = mbed::DigitalOut>
 class SharedSPIDevice {
 public:
     SharedSPIDevice(std::shared_ptr<SharedSPI> spi, DIGITAL_OUT cs,
@@ -38,12 +37,12 @@ public:
         _cs = !_csAssertValue;
     }
 
-    void chip_select() {
+    void chipSelect() {
         _spi->lock();
         _cs = _csAssertValue;
     }
 
-    void chip_deselect() {
+    void chipDeselect() {
         _cs = _csAssertValue;
         _spi->unlock();
     }

--- a/firmware/common2015/drivers/shared-spi/SharedSPI.hpp
+++ b/firmware/common2015/drivers/shared-spi/SharedSPI.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <mbed.h>
+#include <rtos.h>
+#include "assert.hpp"
+
+/**
+ * A simple wrapper over mbed's SPI class that includes a mutex.
+ *
+ * This makes it easier to correctly use a shared SPI bus (with multiple
+ * devices) in a multi-threaded environment.
+ */
+class SharedSPI : public mbed::SPI {
+public:
+    SharedSPI(PinName mosi, PinName miso, PinName sck) : SPI(mosi, miso, sck) {}
+
+    osStatus lock(uint32_t millisec = osWaitForever) {
+        return _mutex.lock(millisec);
+    }
+
+    bool trylock() { return _mutex.trylock(); }
+
+    osStatus unlock() { return _mutex.unlock(); }
+
+private:
+    Mutex _mutex;
+};

--- a/firmware/common2015/drivers/shared-spi/SharedSPI.hpp
+++ b/firmware/common2015/drivers/shared-spi/SharedSPI.hpp
@@ -28,7 +28,6 @@ public:
     SharedSPIDevice(std::shared_ptr<SharedSPI> spi, DIGITAL_OUT cs,
                     bool csInverted = true)
         : _spi(spi), _cs(cs) {
-
         /// The value we set the chip select pin to in order to assert it (it's
         /// often inverted).
         _csAssertValue = csInverted ? 0 : 1;

--- a/firmware/common2015/modules/CommLink/CommLink.cpp
+++ b/firmware/common2015/modules/CommLink/CommLink.cpp
@@ -14,7 +14,7 @@ CommLink::CommLink(shared_ptr<SharedSPI> sharedSPI, PinName nCs,
       _int_in(int_pin),
       _rxThread(&CommLink::rxThreadHelper, this, osPriorityNormal,
                 DEFAULT_STACK_SIZE / 2) {
-    ASSERT(_spi != nullptr);
+    setSPIFrequency(5000000);
     _int_in.mode(PullUp);
 }
 

--- a/firmware/common2015/modules/CommLink/CommLink.cpp
+++ b/firmware/common2015/modules/CommLink/CommLink.cpp
@@ -10,8 +10,7 @@ const char* COMM_ERR_STRING[] = {FOREACH_COMM_ERR(GENERATE_STRING)};
 
 CommLink::CommLink(shared_ptr<SharedSPI> sharedSPI, PinName nCs,
                    PinName int_pin)
-    : _spi(sharedSPI),
-      _nCs(nCs, 1),
+    : SharedSPIDevice(sharedSPI, nCs, true),
       _int_in(int_pin),
       _rxThread(&CommLink::rxThreadHelper, this, osPriorityNormal,
                 DEFAULT_STACK_SIZE / 2) {
@@ -67,13 +66,3 @@ void CommLink::sendPacket(rtp::packet* p) {
 }
 
 void CommLink::ISR() { _rxThread.signal_set(COMM_LINK_SIGNAL_RX_TRIGGER); }
-
-void CommLink::radio_select() {
-    _spi->lock();
-    _nCs = 0;
-}
-
-void CommLink::radio_deselect() {
-    _nCs = 1;
-    _spi->unlock();
-}

--- a/firmware/common2015/modules/CommLink/CommLink.hpp
+++ b/firmware/common2015/modules/CommLink/CommLink.hpp
@@ -8,6 +8,7 @@
 #include "helper-funcs.hpp"
 #include "rtos-mgmt/mail-helper.hpp"
 #include "CommModule.hpp"
+#include "SharedSPI.hpp"
 
 #define FOREACH_COMM_ERR(ERR) \
     ERR(COMM_SUCCESS)         \
@@ -32,7 +33,7 @@ public:
     CommLink();
 
     /// Constructor
-    CommLink(PinName mosi, PinName miso, PinName sck, PinName nCs = NC,
+    CommLink(std::shared_ptr<SharedSPI> spiBus, PinName nCs = NC,
              PinName int_pin = NC);
 
     /// Virtual deconstructor
@@ -73,7 +74,11 @@ protected:
     /// Interrupt Service Routine - KEEP OPERATIONS TO ABSOLUTE MINIMUM HERE AND
     /// IN ANY OVERRIDDEN BASE CLASS IMPLEMENTATIONS OF THIS CLASS METHOD
     void ISR();
+
+    /// Activate the chip select pin and acquire a lock on the shared spi bus
     void radio_select();
+
+    /// Deactivate the chip select pin and release a lock on the shared spi bus
     void radio_deselect();
 
     /// Used for giving derived classes a standaradized way to inform the base
@@ -87,11 +92,9 @@ protected:
         return ~val + 1;
     }
 
-    SPI _spi;
+    std::shared_ptr<SharedSPI> _spi;
     DigitalOut _nCs;
     InterruptIn _int_in;
-
-    static const int DEFAULT_BAUD = 5000000;
 
 private:
     Thread _rxThread;

--- a/firmware/common2015/modules/CommLink/CommLink.hpp
+++ b/firmware/common2015/modules/CommLink/CommLink.hpp
@@ -27,7 +27,7 @@ enum { FOREACH_COMM_ERR(GENERATE_ENUM) };
  * CommLink Class used as the hal (hardware abstraction layer) module for
  * interfacing communication links to the higher-level firmware
  */
-class CommLink {
+class CommLink : public SharedSPIDevice<> {
 public:
     /// Default Constructor
     CommLink();
@@ -75,12 +75,6 @@ protected:
     /// IN ANY OVERRIDDEN BASE CLASS IMPLEMENTATIONS OF THIS CLASS METHOD
     void ISR();
 
-    /// Activate the chip select pin and acquire a lock on the shared spi bus
-    void radio_select();
-
-    /// Deactivate the chip select pin and release a lock on the shared spi bus
-    void radio_deselect();
-
     /// Used for giving derived classes a standaradized way to inform the base
     /// class that it is ready for communication and to begin the threads
     //
@@ -92,8 +86,6 @@ protected:
         return ~val + 1;
     }
 
-    std::shared_ptr<SharedSPI> _spi;
-    DigitalOut _nCs;
     InterruptIn _int_in;
 
 private:

--- a/firmware/robot2015/src-ctrl/config/pins-ctrl-2015.hpp
+++ b/firmware/robot2015/src-ctrl/config/pins-ctrl-2015.hpp
@@ -54,7 +54,7 @@
 
 // This defines one of the mbed's unused pins. It is not connected to anything
 // on the 2015 Control Board rev. 1.
-#define RJ_SPARE_IO p20
+#define RJ_KICKER_nRESET p20
 
 // This defines the pin used for communicating with the Mechanical Base's ID#.
 #define RJ_BASE_ID p21

--- a/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.cpp
+++ b/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.cpp
@@ -35,8 +35,7 @@
 
 #include "AVR910.hpp"
 
-AVR910::AVR910(PinName mosi, PinName miso, PinName sclk, PinName nReset)
-    : spi_(mosi, miso, sclk), nReset_(nReset) {
+AVR910::AVR910(SPI spi, PinName nReset) : spi_(spi), nReset_(nReset) {
     // Slow frequency as default to ensure no errors from
     // trying to run it too fast. Increase as appropriate.
     spi_.frequency(32000);

--- a/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.cpp
+++ b/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.cpp
@@ -182,43 +182,33 @@ void AVR910::poll() {
     chipDeselect();
 }
 
-int AVR910::readVendorCode() {
-    // Issue read signature byte command.
-    // Address 0x00 is vendor code.
+int AVR910::readRegister(int reg) {
     chipSelect();
     _spi->write(0x30);
     _spi->write(0x00);
-    _spi->write(0x00);
-    int code = _spi->write(0x00);
+    _spi->write(reg);
+    int val = _spi->write(0x00);
     chipDeselect();
 
-    return code;
+    return val;
+}
+
+int AVR910::readVendorCode() {
+    // Issue read signature byte command.
+    // Address 0x00 is vendor code.
+    return readRegister(0x00);
 }
 
 int AVR910::readPartFamilyAndFlashSize() {
     // Issue read signature byte command.
     // Address 0x01 is part family and flash size code.
-    chipSelect();
-    _spi->write(0x30);
-    _spi->write(0x00);
-    _spi->write(0x01);
-    int value = _spi->write(0x00);
-    chipDeselect();
-
-    return value;
+    return readRegister(0x01);
 }
 
 int AVR910::readPartNumber() {
     // Issue read signature byte command.
     // Address 0x02 is part number code.
-    chipSelect();
-    _spi->write(0x30);
-    _spi->write(0x00);
-    _spi->write(0x02);
-    int num = _spi->write(0x00);
-    chipDeselect();
-
-    return num;
+    return readRegister(0x02);
 }
 
 void AVR910::chipErase() {

--- a/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.cpp
+++ b/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.cpp
@@ -37,8 +37,8 @@
 
 using namespace std;
 
-AVR910::AVR910(shared_ptr<SharedSPI> spi, PinName nReset)
-    : SharedSPIDevice(spi, NC), nReset_(nReset) {
+AVR910::AVR910(shared_ptr<SharedSPI> spi, PinName nCs, PinName nReset)
+    : SharedSPIDevice(spi, nCs, true), nReset_(nReset) {
     // Slow frequency as default to ensure no errors from
     // trying to run it too fast. Increase as appropriate.
     setSPIFrequency(32000);

--- a/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.cpp
+++ b/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.cpp
@@ -35,11 +35,13 @@
 
 #include "AVR910.hpp"
 
-AVR910::AVR910(SPI spi, PinName nReset) : spi_(spi), nReset_(nReset) {
+using namespace std;
+
+AVR910::AVR910(shared_ptr<SharedSPI> spi, PinName nReset)
+    : SharedSPIDevice(spi, NC), nReset_(nReset) {
     // Slow frequency as default to ensure no errors from
     // trying to run it too fast. Increase as appropriate.
-    spi_.frequency(32000);
-    spi_.format(8, 0);
+    // _spi->frequency(32000); // TODO(justin): fix this
 
     // Enter serial programming mode by pulling reset line low.
     nReset_ = 0;
@@ -148,15 +150,17 @@ bool AVR910::program(FILE* binary, int pageSize, int numPages) {
     return success;
 }
 
-void AVR910::setFrequency(int frequency) { spi_.frequency(frequency); }
+void AVR910::setFrequency(int frequency) { _spi->frequency(frequency); }
 
 bool AVR910::enableProgramming() {
     // Programming Enable Command: 0xAC, 0x53, 0x00, 0x00
     // Byte two echo'd back in byte three.
-    spi_.write(0xAC);
-    spi_.write(0x53);
-    int response = spi_.write(0x00);
-    spi_.write(0x00);
+    chipSelect();
+    _spi->write(0xAC);
+    _spi->write(0x53);
+    int response = _spi->write(0x00);
+    _spi->write(0x00);
+    chipDeselect();
 
     if (response == 0x53) {
         return true;
@@ -168,47 +172,63 @@ bool AVR910::enableProgramming() {
 void AVR910::poll() {
     // Query the chip until it indicates it's ready by setting the busy bit to 0
     int response = 0;
+    chipSelect();
     do {
-        spi_.write(0xF0);
-        spi_.write(0x00);
-        spi_.write(0x00);
-        response = spi_.write(0x00);
+        _spi->write(0xF0);
+        _spi->write(0x00);
+        _spi->write(0x00);
+        response = _spi->write(0x00);
     } while ((response & 0x01) != 0);
+    chipDeselect();
 }
 
 int AVR910::readVendorCode() {
     // Issue read signature byte command.
     // Address 0x00 is vendor code.
-    spi_.write(0x30);
-    spi_.write(0x00);
-    spi_.write(0x00);
-    return spi_.write(0x00);
+    chipSelect();
+    _spi->write(0x30);
+    _spi->write(0x00);
+    _spi->write(0x00);
+    int code = _spi->write(0x00);
+    chipDeselect();
+
+    return code;
 }
 
 int AVR910::readPartFamilyAndFlashSize() {
     // Issue read signature byte command.
     // Address 0x01 is part family and flash size code.
-    spi_.write(0x30);
-    spi_.write(0x00);
-    spi_.write(0x01);
-    return spi_.write(0x00);
+    chipSelect();
+    _spi->write(0x30);
+    _spi->write(0x00);
+    _spi->write(0x01);
+    int value = _spi->write(0x00);
+    chipDeselect();
+
+    return value;
 }
 
 int AVR910::readPartNumber() {
     // Issue read signature byte command.
     // Address 0x02 is part number code.
-    spi_.write(0x30);
-    spi_.write(0x00);
-    spi_.write(0x02);
-    return spi_.write(0x00);
+    chipSelect();
+    _spi->write(0x30);
+    _spi->write(0x00);
+    _spi->write(0x02);
+    int num = _spi->write(0x00);
+    chipDeselect();
+
+    return num;
 }
 
 void AVR910::chipErase() {
     // Issue chip erase command.
-    spi_.write(0xAC);
-    spi_.write(0x80);
-    spi_.write(0x00);
-    spi_.write(0x00);
+    chipSelect();
+    _spi->write(0xAC);
+    _spi->write(0x80);
+    _spi->write(0x00);
+    _spi->write(0x00);
+    chipDeselect();
 
     poll();
 
@@ -218,35 +238,43 @@ void AVR910::chipErase() {
 }
 
 void AVR910::loadMemoryPage(int highLow, char address, char data) {
-    spi_.write(highLow);
-    spi_.write(0x00);
-    spi_.write(address & 0x3F);
-    spi_.write(data);
+    chipSelect();
+    _spi->write(highLow);
+    _spi->write(0x00);
+    _spi->write(address & 0x3F);
+    _spi->write(data);
+    chipDeselect();
 
     poll();
 }
 
 void AVR910::writeFlashMemoryByte(int highLow, int address, char data) {
-    spi_.write(highLow);
-    spi_.write(address & 0xFF00 >> 8);
-    spi_.write(address & 0x00FF);
-    spi_.write(data);
+    chipSelect();
+    _spi->write(highLow);
+    _spi->write(address & 0xFF00 >> 8);
+    _spi->write(address & 0x00FF);
+    _spi->write(data);
+    chipDeselect();
 }
 
 void AVR910::writeFlashMemoryPage(char pageNumber) {
-    spi_.write(0x4C);
-    spi_.write(pageNumber >> 3);  // top 5 bits stored in bottom of byte
-    spi_.write(pageNumber << 5);  // bottom 3 bits stored in top of byte
-    spi_.write(0x00);
+    chipSelect();
+    _spi->write(0x4C);
+    _spi->write(pageNumber >> 3);  // top 5 bits stored in bottom of byte
+    _spi->write(pageNumber << 5);  // bottom 3 bits stored in top of byte
+    _spi->write(0x00);
+    chipDeselect();
 
     poll();
 }
 
 char AVR910::readProgramMemory(int highLow, char pageNumber, char pageOffset) {
-    spi_.write(highLow);
-    spi_.write(pageNumber >> 3);
-    spi_.write((pageNumber << 5) | (pageOffset & 0x3F));
-    char response = spi_.write(0x00);
+    chipSelect();
+    _spi->write(highLow);
+    _spi->write(pageNumber >> 3);
+    _spi->write((pageNumber << 5) | (pageOffset & 0x3F));
+    char response = _spi->write(0x00);
+    chipDeselect();
 
     poll();
 

--- a/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.cpp
+++ b/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.cpp
@@ -41,7 +41,7 @@ AVR910::AVR910(shared_ptr<SharedSPI> spi, PinName nReset)
     : SharedSPIDevice(spi, NC), nReset_(nReset) {
     // Slow frequency as default to ensure no errors from
     // trying to run it too fast. Increase as appropriate.
-    // _spi->frequency(32000); // TODO(justin): fix this
+    setSPIFrequency(32000);
 
     // Enter serial programming mode by pulling reset line low.
     nReset_ = 0;
@@ -149,8 +149,6 @@ bool AVR910::program(FILE* binary, int pageSize, int numPages) {
 
     return success;
 }
-
-void AVR910::setFrequency(int frequency) { _spi->frequency(frequency); }
 
 bool AVR910::enableProgramming() {
     // Programming Enable Command: 0xAC, 0x53, 0x00, 0x00

--- a/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.hpp
@@ -70,7 +70,7 @@ public:
      * Sends an enable programming command, allowing device registers to be
      * read and commands sent.
      */
-    AVR910(std::shared_ptr<SharedSPI> spi, PinName nReset);
+    AVR910(std::shared_ptr<SharedSPI> spi, PinName nCs, PinName nReset);
 
     /**
      * Program the AVR microcontroller connected to the mbed.

--- a/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.hpp
@@ -127,6 +127,8 @@ public:
     int readPartNumber();
 
 protected:
+    int readRegister(int reg);
+
     /**
      * Check the binary has been written correctly.
      *

--- a/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.hpp
@@ -68,7 +68,7 @@ public:
      * Sends an enable programming command, allowing device registers to be
      * read and commands sent.
      */
-    AVR910(PinName mosi, PinName miso, PinName sclk, PinName nReset);
+    AVR910(SPI spi, PinName nReset);
 
     /**
      * Program the AVR microcontroller connected to the mbed.

--- a/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.hpp
@@ -40,6 +40,8 @@
 
 #include "mbed.h"
 
+#include "SharedSPI.hpp"
+
 // AVR SPI Commands
 #define ATMEL_VENDOR_CODE 0x1E
 #define DEVICE_LOCKED 0x00
@@ -55,7 +57,7 @@
  *
  * This class facilitates loading a program onto an AVR chip's flash memory.
  */
-class AVR910 {
+class AVR910 : public SharedSPIDevice<> {
 public:
     /**
      * Constructor.
@@ -68,7 +70,7 @@ public:
      * Sends an enable programming command, allowing device registers to be
      * read and commands sent.
      */
-    AVR910(SPI spi, PinName nReset);
+    AVR910(std::shared_ptr<SharedSPI> spi, PinName nReset);
 
     /**
      * Program the AVR microcontroller connected to the mbed.
@@ -200,6 +202,5 @@ private:
      */
     char readProgramMemory(int highLow, char pageNumber, char pageOffset);
 
-    SPI spi_;
     DigitalOut nReset_;
 };

--- a/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/avr-isp/AVR910.hpp
@@ -92,15 +92,6 @@ public:
     bool program(FILE* binary, int pageSize, int numPages = 1);
 
     /**
-     * Set the frequency of the SPI communication.
-     *
-     * (Wrapper for SPI::frequency)
-     *
-     * @param frequency Frequency of the SPI communication in hertz.
-     */
-    void setFrequency(int frequency);
-
-    /**
      * Read the vendor code of the device.
      *
      * @return The vendor code - should be 0x1E for Atmel.

--- a/firmware/robot2015/src-ctrl/drivers/fpga/fpga.cpp
+++ b/firmware/robot2015/src-ctrl/drivers/fpga/fpga.cpp
@@ -26,7 +26,9 @@ FPGA::FPGA(std::shared_ptr<SharedSPI> sharedSPI, PinName nCs, PinName initB,
     : SharedSPIDevice(sharedSPI, nCs, true),
       _initB(initB),
       _progB(progB, PIN_OUTPUT, OpenDrain, 1),
-      _done(done) {}
+      _done(done) {
+    setSPIFrequency(1000000);
+}
 
 FPGA* FPGA::Initialize(shared_ptr<SharedSPI> sharedSPI) {
     instance = new FPGA(sharedSPI, RJ_FPGA_nCS, RJ_FPGA_INIT_B, RJ_FPGA_PROG_B,
@@ -96,8 +98,6 @@ bool FPGA::configure(const std::string& filepath) {
             LOG(INF1, "DONE pin state:\t%s", _done ? "HIGH" : "LOW");
 
             _isInit = true;
-
-            // spi->frequency(1000000); // TODO(justin): remove?
 
             return true;
         }

--- a/firmware/robot2015/src-ctrl/drivers/fpga/fpga.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/fpga/fpga.hpp
@@ -43,7 +43,6 @@ private:
     bool _isInit = false;
     static FPGA* instance;
 
-    std::shared_ptr<SharedSPI> _spi;
     DigitalIn _initB;
     DigitalInOut _progB;
     DigitalIn _done;

--- a/firmware/robot2015/src-ctrl/drivers/fpga/fpga.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/fpga/fpga.hpp
@@ -11,7 +11,7 @@
 #include "pins-ctrl-2015.hpp"
 #include "SharedSPI.hpp"
 
-class FPGA {
+class FPGA : public SharedSPIDevice<> {
 public:
     static FPGA* Instance();
 
@@ -36,12 +36,6 @@ public:
     void gate_drivers(std::vector<uint16_t>&);
     bool send_config(const std::string& filepath);
 
-    /// Activate the chip select pin and acquire a lock on the shared spi bus
-    void fpga_select();
-
-    /// Deactivate the chip select pin and release a lock on the shared spi bus
-    void fpga_deselect();
-
 private:
     FPGA(std::shared_ptr<SharedSPI> sharedSPI, PinName nCs, PinName initB,
          PinName progB, PinName done);
@@ -50,7 +44,6 @@ private:
     static FPGA* instance;
 
     std::shared_ptr<SharedSPI> _spi;
-    DigitalOut _nCs;
     DigitalIn _initB;
     DigitalInOut _progB;
     DigitalIn _done;

--- a/firmware/robot2015/src-ctrl/drivers/fpga/fpga.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/fpga/fpga.hpp
@@ -48,7 +48,6 @@ private:
 
     static bool isInit;
     static FPGA* instance;
-    Mutex mutex;
 
     std::shared_ptr<SharedSPI> spi;
     DigitalOut nCs;

--- a/firmware/robot2015/src-ctrl/drivers/fpga/fpga.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/fpga/fpga.hpp
@@ -46,12 +46,12 @@ private:
     FPGA(std::shared_ptr<SharedSPI> sharedSPI, PinName nCs, PinName initB,
          PinName progB, PinName done);
 
-    static bool isInit;
+    bool _isInit = false;
     static FPGA* instance;
 
-    std::shared_ptr<SharedSPI> spi;
-    DigitalOut nCs;
-    DigitalIn initB;
-    DigitalInOut progB;
-    DigitalIn done;
+    std::shared_ptr<SharedSPI> _spi;
+    DigitalOut _nCs;
+    DigitalIn _initB;
+    DigitalInOut _progB;
+    DigitalIn _done;
 };

--- a/firmware/robot2015/src-ctrl/drivers/fpga/fpga.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/fpga/fpga.hpp
@@ -43,15 +43,16 @@ public:
     void fpga_deselect();
 
 private:
-    FPGA(std::shared_ptr<SharedSPI> sharedSPI) : spi(sharedSPI){};
+    FPGA(std::shared_ptr<SharedSPI> sharedSPI, PinName nCs, PinName initB,
+         PinName progB, PinName done);
 
     static bool isInit;
     static FPGA* instance;
     Mutex mutex;
 
     std::shared_ptr<SharedSPI> spi;
-    DigitalOut* nCs;
-    DigitalInOut* progB;
-    DigitalIn* initB;
-    DigitalIn* done;
+    DigitalOut nCs;
+    DigitalIn initB;
+    DigitalInOut progB;
+    DigitalIn done;
 };

--- a/firmware/robot2015/src-ctrl/drivers/kicker-board/KickerBoard.cpp
+++ b/firmware/robot2015/src-ctrl/drivers/kicker-board/KickerBoard.cpp
@@ -3,9 +3,9 @@
 
 using namespace std;
 
-KickerBoard::KickerBoard(PinName mosi, PinName miso, PinName sck,
-                         PinName nReset, const string& progFilename)
-    : AVR910(SPI(mosi, miso, sck), nReset), _filename(progFilename) {}
+KickerBoard::KickerBoard(shared_ptr<SharedSPI> sharedSPI, PinName nReset,
+                         const string& progFilename)
+    : AVR910(sharedSPI, nReset), _filename(progFilename) {}
 
 bool KickerBoard::verify_param(const char* name, char expected,
                                int (AVR910::*paramMethod)(), char mask,

--- a/firmware/robot2015/src-ctrl/drivers/kicker-board/KickerBoard.cpp
+++ b/firmware/robot2015/src-ctrl/drivers/kicker-board/KickerBoard.cpp
@@ -3,9 +3,9 @@
 
 using namespace std;
 
-KickerBoard::KickerBoard(shared_ptr<SharedSPI> sharedSPI, PinName nReset,
-                         const string& progFilename)
-    : AVR910(sharedSPI, nReset), _filename(progFilename) {}
+KickerBoard::KickerBoard(shared_ptr<SharedSPI> sharedSPI, PinName nCs,
+                         PinName nReset, const string& progFilename)
+    : AVR910(sharedSPI, nCs, nReset), _filename(progFilename) {}
 
 bool KickerBoard::verify_param(const char* name, char expected,
                                int (AVR910::*paramMethod)(), char mask,

--- a/firmware/robot2015/src-ctrl/drivers/kicker-board/KickerBoard.cpp
+++ b/firmware/robot2015/src-ctrl/drivers/kicker-board/KickerBoard.cpp
@@ -5,7 +5,7 @@ using namespace std;
 
 KickerBoard::KickerBoard(PinName mosi, PinName miso, PinName sck,
                          PinName nReset, const string& progFilename)
-    : AVR910(mosi, miso, sck, nReset), _filename(progFilename) {}
+    : AVR910(SPI(mosi, miso, sck), nReset), _filename(progFilename) {}
 
 bool KickerBoard::verify_param(const char* name, char expected,
                                int (AVR910::*paramMethod)(), char mask,

--- a/firmware/robot2015/src-ctrl/drivers/kicker-board/KickerBoard.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/kicker-board/KickerBoard.hpp
@@ -20,14 +20,12 @@ public:
     /**
      * @brief Constructor for KickerBoard
      *
-     * @param mosi mbed pin for MOSI SPI line.
-     * @param miso mbed pin for MISO SPI line.
-     * @param sclk mbed pin for SCLK SPI line.
+     * @param sharedSPI A pointer to the shared spi bus
      * @param nReset mbed pin for not reset line on the ISP interface.
      * @param progFilename Path to kicker program binary file that will be
      *     loaded by the flash() method
      */
-    KickerBoard(PinName mosi, PinName miso, PinName sck, PinName nReset,
+    KickerBoard(std::shared_ptr<SharedSPI> sharedSPI, PinName nReset,
                 const std::string& progFilename);
 
     /**

--- a/firmware/robot2015/src-ctrl/drivers/kicker-board/KickerBoard.hpp
+++ b/firmware/robot2015/src-ctrl/drivers/kicker-board/KickerBoard.hpp
@@ -25,8 +25,8 @@ public:
      * @param progFilename Path to kicker program binary file that will be
      *     loaded by the flash() method
      */
-    KickerBoard(std::shared_ptr<SharedSPI> sharedSPI, PinName nReset,
-                const std::string& progFilename);
+    KickerBoard(std::shared_ptr<SharedSPI> sharedSPI, PinName nCs,
+                PinName nReset, const std::string& progFilename);
 
     /**
      * @brief Reflashes the program on the kicker board MCU with the file

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -17,6 +17,7 @@
 #include "io-expander.hpp"
 #include "neostrip.hpp"
 #include "CC1201.cpp"
+#include "SharedSPI.hpp"
 
 using namespace std;
 
@@ -98,6 +99,11 @@ int main() {
     RtosTimer init_leds_off(statusLightsOFF, osTimerOnce);
     init_leds_off.start(RJ_STARTUP_LED_TIMEOUT_MS);
 
+    /// A shared spi bus used for the fpga and cc1201 radio
+    shared_ptr<SharedSPI> sharedSPI = make_shared<SharedSPI>(RJ_SPI_BUS);
+    sharedSPI->format(8, 0);  // 8 bits per transfer
+    sharedSPI->frequency(5000000);
+
     // This is where the FPGA is actually configured with the bitfile's name
     // passed in
     bool fpga_ready = FPGA::Instance()->Init("/local/rj-fpga.nib");
@@ -130,7 +136,7 @@ int main() {
     Thread::signal_wait(MAIN_TASK_CONTINUE, osWaitForever);
 
     // Initialize the CommModule and CC1201 radio
-    InitializeCommModule();
+    InitializeCommModule(sharedSPI);
 
     // Make sure all of the motors are enabled
     motors_Init();

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -18,6 +18,7 @@
 #include "neostrip.hpp"
 #include "CC1201.cpp"
 #include "SharedSPI.hpp"
+#include "KickerBoard.hpp"
 
 using namespace std;
 
@@ -115,6 +116,11 @@ int main() {
     }
 
     DigitalOut rdy_led(RJ_RDY_LED, !fpga_ready);
+
+    // Initialize kicker board
+    // TODO: clarify between kicker nCs and nReset
+    KickerBoard kickerBoard(sharedSPI, RJ_KICKER_nCS, "/local/rj-kickr.nib");
+    bool kickerReady = kickerBoard.flash(true, true);
 
     // Init IO Expander and turn all LEDs on
     MCP23017 ioExpander(RJ_I2C_BUS, 0);

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -104,9 +104,9 @@ int main() {
     sharedSPI->format(8, 0);  // 8 bits per transfer
     sharedSPI->frequency(5000000);
 
-    // This is where the FPGA is actually configured with the bitfile's name
-    // passed in
-    bool fpga_ready = FPGA::Instance()->Init("/local/rj-fpga.nib");
+    // Initialize and configure the fpga with the given bitfile
+    FPGA::Initialize(sharedSPI);
+    bool fpga_ready = FPGA::Instance()->configure("/local/rj-fpga.nib");
 
     if (fpga_ready) {
         LOG(INIT, "FPGA Configuration Successful!");

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -118,7 +118,8 @@ int main() {
 
     // Initialize kicker board
     // TODO: clarify between kicker nCs and nReset
-    KickerBoard kickerBoard(sharedSPI, RJ_KICKER_nCS, "/local/rj-kickr.nib");
+    KickerBoard kickerBoard(sharedSPI, RJ_KICKER_nCS, RJ_KICKER_nRESET,
+                            "/local/rj-kickr.nib");
     bool kickerReady = kickerBoard.flash(true, true);
 
     // Init IO Expander and turn all LEDs on

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -103,7 +103,6 @@ int main() {
     /// A shared spi bus used for the fpga and cc1201 radio
     shared_ptr<SharedSPI> sharedSPI = make_shared<SharedSPI>(RJ_SPI_BUS);
     sharedSPI->format(8, 0);  // 8 bits per transfer
-    sharedSPI->frequency(5000000);
 
     // Initialize and configure the fpga with the given bitfile
     FPGA::Initialize(sharedSPI);

--- a/firmware/robot2015/src-ctrl/modules/CommInitialization.cpp
+++ b/firmware/robot2015/src-ctrl/modules/CommInitialization.cpp
@@ -74,7 +74,7 @@ const DigitalInOut rx_led(RJ_RX_LED, PIN_OUTPUT, OpenDrain, 1);
 shared_ptr<RtosTimer> rx_led_ticker;
 shared_ptr<RtosTimer> tx_led_ticker;
 
-void InitializeCommModule() {
+void InitializeCommModule(shared_ptr<SharedSPI> sharedSPI) {
     // leds that flash if tx/rx have happened recently
     auto rxTimeoutLED =
         make_shared<FlashingTimeoutLED>(DigitalOut(RJ_RX_LED, OpenDrain));
@@ -88,7 +88,7 @@ void InitializeCommModule() {
     // TODO(justin): make this non-global
     // Create a new physical hardware communication link
     global_radio =
-        new CC1201(RJ_SPI_BUS, RJ_RADIO_nCS, RJ_RADIO_INT, preferredSettings,
+        new CC1201(sharedSPI, RJ_RADIO_nCS, RJ_RADIO_INT, preferredSettings,
                    sizeof(preferredSettings) / sizeof(registerSetting_t));
 
     // Open a socket for running tests across the link layer

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.hpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.hpp
@@ -4,13 +4,15 @@
 #include <array>
 #include <vector>
 #include <algorithm>
+#include <memory>
 
 #include "robot-devices.hpp"
 #include "motors.hpp"
+#include "SharedSPI.hpp"
 
 // forward declaration of tasks
 void Task_SerialConsole(void const* args);
-void InitializeCommModule();
+void InitializeCommModule(std::shared_ptr<SharedSPI> sharedSPI);
 
 /**
  * Max number of command aliases.


### PR DESCRIPTION
This PR adds a `SharedSPI` class that bundles a `Mutex` and an `SPI` instance.  The FPGA and CC1201 are now initialized with a shared pointer to a `SharedSPI` instance and lock the mutex when they're using the bus.  This should ensure thread-safety when using the spi bus.

TODO:

- [x] Do we need different spi frequencies for our different devices?  If so, this PR will need to change a good bit.  The fpga was previously using 1000000Hz and the cc1201 was on 5000000.  I currently have them both using 5000000.
- [x] Chip select doesn't look quite right in `FPGA::configure()` (prevously named `FPGA::Init()`)
- [x] Do we need `FPGA.mutex` anymore? (removed in 13d82c3cd7b1a77812c715c9fe09f789ac20ecb6)
- [x] why is chip select toggled in `FPGA.git_hash()`?
- [x] switch `KickerBoard` class to use `SharedSPI`
- [x] verify that fpga configuration still works
- [x] why use `SoftwareSPI` when configuring fpga?  We'll need to lock the shared mutex here.
- [x] kicker nCs vs reset?