### PR TITLE
Removed task-signals

### DIFF
--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -11,7 +11,6 @@
 #include <assert.hpp>
 
 #include "robot-devices.hpp"
-#include "task-signals.hpp"
 #include "commands.hpp"
 #include "fpga.hpp"
 #include "io-expander.hpp"
@@ -155,11 +154,9 @@ int main() {
     // Start the thread task for the on-board control loop
     Thread controller_task(Task_Controller, mainID, osPriorityHigh,
                            DEFAULT_STACK_SIZE / 2);
-    Thread::signal_wait(MAIN_TASK_CONTINUE, osWaitForever);
 
     // Start the thread task for the serial console
     Thread console_task(Task_SerialConsole, mainID, osPriorityBelowNormal);
-    Thread::signal_wait(MAIN_TASK_CONTINUE, osWaitForever);
 
     // Initialize the CommModule and CC1201 radio
     InitializeCommModule(sharedSPI);
@@ -169,10 +166,6 @@ int main() {
 
     // Set the watdog timer's initial config
     Watchdog::Set(RJ_WATCHDOG_TIMER_VALUE);
-
-    // Release each thread into its operations in a structured manner
-    controller_task.signal_set(SUB_TASK_CONTINUE);
-    console_task.signal_set(SUB_TASK_CONTINUE);
 
     osStatus tState = osThreadSetPriority(mainID, osPriorityNormal);
     ASSERT(tState == osOK);

--- a/firmware/robot2015/src-ctrl/modules/CommInitialization.cpp
+++ b/firmware/robot2015/src-ctrl/modules/CommInitialization.cpp
@@ -11,7 +11,6 @@
 #include <assert.hpp>
 
 #include "robot-devices.hpp"
-#include "task-signals.hpp"
 #include "io-expander.hpp"
 #include "fpga.hpp"
 #include "TimeoutLED.hpp"

--- a/firmware/robot2015/src-ctrl/modules/ConsoleTaskThread.cpp
+++ b/firmware/robot2015/src-ctrl/modules/ConsoleTaskThread.cpp
@@ -5,15 +5,12 @@
 #include <logger.hpp>
 #include <assert.hpp>
 
-#include "task-signals.hpp"
 #include "commands.hpp"
 
 /**
  * Initializes the console
  */
 void Task_SerialConsole(void const* args) {
-    const osThreadId mainID = (const osThreadId)args;
-
     // Store the thread's ID
     const osThreadId threadID = Thread::gettid();
     ASSERT(threadID != nullptr);
@@ -32,10 +29,6 @@ void Task_SerialConsole(void const* args) {
         "Serial console ready!\r\n"
         "    Thread ID: %u, Priority: %d",
         threadID, threadPriority);
-
-    // Signal back to main and wait until we're signaled to continue
-    osSignalSet(mainID, MAIN_TASK_CONTINUE);
-    Thread::signal_wait(SUB_TASK_CONTINUE, osWaitForever);
 
     // Display RoboJackets if we're up and running at this point during startup
     console->ShowLogo();

--- a/firmware/robot2015/src-ctrl/modules/ControllerTaskThread.cpp
+++ b/firmware/robot2015/src-ctrl/modules/ControllerTaskThread.cpp
@@ -6,7 +6,6 @@
 #include <assert.hpp>
 
 #include "robot-devices.hpp"
-#include "task-signals.hpp"
 #include "motors.hpp"
 #include "fpga.hpp"
 #include "mpu-6050.hpp"
@@ -83,10 +82,6 @@ void Task_Controller(void const* args) {
         return;
     }
 
-    // signal back to main and wait until we're signaled to continue
-    osSignalSet(mainID, MAIN_TASK_CONTINUE);
-    Thread::signal_wait(SUB_TASK_CONTINUE, osWaitForever);
-
     std::vector<uint16_t> duty_cycles;
     duty_cycles.assign(5, 100);
     for (size_t i = 0; i < duty_cycles.size(); ++i)
@@ -155,10 +150,6 @@ void Task_Controller_Sensorless(const osThreadId mainID) {
     LOG(INIT,
         "Sensorless control loop ready!\r\n    Thread ID: %u, Priority: %d",
         threadID, threadPriority);
-
-    // signal back to main and wait until we're signaled to continue
-    osSignalSet(mainID, MAIN_TASK_CONTINUE);
-    Thread::signal_wait(SUB_TASK_CONTINUE, osWaitForever);
 
     while (true) {
         Thread::wait(CONTROL_LOOP_WAIT_MS);

--- a/firmware/robot2015/src-ctrl/modules/task-signals.hpp
+++ b/firmware/robot2015/src-ctrl/modules/task-signals.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-// This is where the signals for different threads are defined for use across
-// mutliple files
-
-static const uint32_t MAIN_TASK_CONTINUE = 1 << 0;
-static const uint32_t SUB_TASK_CONTINUE = 1 << 1;


### PR DESCRIPTION
@jjones646 I don't think we need the back and forth signaling between the main and task threads.  The initialization they do should be independent so they can initialize in parallel.  Do you see any issues with this?