### PR TITLE
Adding username mappings between commits and GitHub

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,50 @@
+robobuzz                        <robocup@robojackets.org>
+robobuzz                        <robocup@robojackets.org>           <robojackets@rj-robocup>
+robobuzz                        <robocup@robojackets.org>           <robojackets@robojackets>
+robobuzz                        <robocup@robojackets.org>           <robojackets@robojackets.(none)>
+robobuzz                        <robocup@robojackets.org>           <robojackets@rj-robocup>
+robobuzz                        <robocup@robojackets.org>           <robojackets@rj-robocup.(none)>
+robobuzz                        <robocup@robojackets.org>           <robojackets@macbook.(none)>
+robobuzz                        <robocup@robojackets.org>           <george.burdel@gatech.edu>
+comp-pc                         <robocup@robojackets.org>           <robojackets@RJ-FIELD-01.(none)>
+comp-pc                         <robocup@robojackets.org>           <robojackets@RJ-FIELD-02.(none)>
+electrical-pc                   <robocup@robojackets.org>           <robojackets@rj-elec-03.(none)>
+field-pc                        <robocup@robojackets.org>           RJ RoboCup Field Computer <rj-robocup@robojackets.org>
+gitter-badget                   <badger@gitter.im>
+alexgc                          <alexgc@gatech.edu>
+alexgc                          <alexgc@gatech.edu>                 <alexgc@crenshaw-travel.(none)>
+ashaw596                        <ashaw596@gmail.com>
+ashaw596                        <ashaw596@gmail.com>                <ashaw@medallia.com>
+barulicm                        <matthew.barulic@gmail.com>
+barulicm                        <matthew.barulic@gmail.com>         <matthew@mbUbuntu.(none)>
+barulicm                        <matthew.barulic@gmail.com>         <matt@matt-G55VW.(none)>
+blueintegral                    <hunter.scott@gatech.edu>           <hunter@x.(none)>
+blueintegral                    <hunter.scott@gatech.edu>           <hunter@hunter-ubuntu-vm.(none)>
+bstrong1218                     <bstrong1218@gmail.com>
+bstrong1218                     <bstrong1218@gmail.com>             <barmstrong@lawn-143-215-53-125.lawn.gatech.edu>
+ChrisDoho                       <ChrisDoho@gmail.com>
+circuitben                      <circuitben@gmail.com>
+circuitben                      <circuitben@gmail.com>              <circuitben@7ccbd594-6f30-0410-bcae-e071bb1c4cdc>
+ehuang3                         <ehuang3@gatech.edu>
+ehuang3                         <ehuang3@gatech.edu>                <eric@eric-VirtualBox.(none)>
+winterfroststrom                <dzhang61@gatech.edu>               <sparky@ubuntu.(none)>
+guyfleeman                      <guyfleeman@gmail.com>
+jgkamat                         <jaygkamat@gmail.com>
+jgkamat                         <jaygkamat@gmail.com>               <github@jgkamat.33mail.com>
+jgkamat                         <jaygkamat@gmail.com>               <jgkamat@users.noreply.github.com>
+jjones646                       <jjones646@gmail.com>
+jjones646                       <jjones646@gmail.com>               <jonathan.jones@gatech.edu>
+jjones646                       <jjones646@gmail.com>               <jjones646@users.noreply.github.com>
+jjones646                       <jjones646@gmail.com>               <jonathan@lawn-128-61-122-214.lawn.gatech.edu>
+JNeiger                         <fcdneiger@gmail.com>
+joshhting                       <joshting25@gmail.com>
+joshhting                       <joshting25@gmail.com>              <KingTing25@users.noreply.github.com>
+jpfeltracco                     <jpfeltracco@gatech.edu>
+justbuchanan                    <justbuchanan@gmail.com>
+justbuchanan                    <justbuchanan@gmail.com>            <justinbuchanan@google.com>
+Offboss                         <JohnGMCarnahan@gmail.com>
+ra4king                         <ra4king@gmail.com>
+ra4king                         <ra4king@gmail.com>                 <roi@roiatalla.com>
+xxia34                          <xxia34@gatech.edu>
+xxia34                          <xxia34@gatech.edu>                 <xiaojing@xiaojing-VirtualBox.(none)>
+yousifd                         <yad999@gmail.com>


### PR DESCRIPTION
I've went through and tried matching up the repo's commit authors to a GitHub username. Just something to make it slightly easier for running `git log --use-mailmap --author=<username>`.

Or set this so you don't need the `--use-mailmap` flag:
```
git config log.mailmap true
```