### PR TITLE
FPGA configuration fixes and updated error LED states

### DIFF
--- a/firmware/common2015/drivers/fpga/fpga.cpp
+++ b/firmware/common2015/drivers/fpga/fpga.cpp
@@ -72,82 +72,88 @@ bool FPGA::configure(const std::string& filepath) {
         return false;
     }
 
-    // Configure the FPGA with the bitstream file
+    // Configure the FPGA with the bitstream file, this returns false if file
+    // can't be opened
     if (send_config(filepath)) {
-        LOG(FATAL, "FPGA bitstream write error");
-
-        chipDeselect();
-        return false;
-    } else {
         // Wait some extra time in case the _done pin needs time to be asserted
-        bool configureDone = false;
+        bool configSuccess = false;
         for (int i = 0; i < 1000; i++) {
             Thread::wait(1);
             if (_done == true) {
-                configureDone = true;
+                configSuccess = true;
                 break;
             }
         }
 
-        if (configureDone) {
-            LOG(FATAL, "DONE pin timed out\t(POST CONFIGURATION ERROR)");
-
-            chipDeselect();
-            return false;
-        } else {
+        if (configSuccess) {
             // everything worked are we're good to go!
-            LOG(INF1, "DONE pin state:\t%s", _done ? "HIGH" : "LOW");
-
             _isInit = true;
+            LOG(INF1, "DONE pin state:\t%s", _done ? "HIGH" : "LOW");
 
             chipDeselect();
             return true;
         }
+
+        LOG(FATAL, "DONE pin timed out\t(POST CONFIGURATION ERROR)");
     }
+
+    LOG(FATAL, "FPGA bitstream write error");
+
+    chipDeselect();
+    return false;
 }
 
 // TODO(justin): remove this hack once GitHub issue #590 is fixed
 #include "../../robot2015/src-ctrl/config/pins-ctrl-2015.hpp"
 
 bool FPGA::send_config(const std::string& filepath) {
-    char buf[10];
+    const uint8_t bufSize = 50;
 
     // open the bitstream file
     FILE* fp = fopen(filepath.c_str(), "r");
 
     // send it out if successfully opened
     if (fp != nullptr) {
+        size_t filesize;
+        char buf[bufSize];
+
         // MISO & MOSI are intentionally switched here
         // defaults to 8 bit field size with CPOL = 0 & CPHA = 0
-        SoftwareSPI spi(RJ_SPI_MISO, RJ_SPI_MOSI, RJ_SPI_SCK);
-
-        size_t read_byte;
+        SoftwareSPI softSpi(RJ_SPI_MISO, RJ_SPI_MOSI, RJ_SPI_SCK);
 
         fseek(fp, 0, SEEK_END);
-        size_t filesize = ftell(fp);
+        filesize = ftell(fp);
         fseek(fp, 0, SEEK_SET);
 
         LOG(INF1, "Sending %s (%u bytes) out to the FPGA", filepath.c_str(),
             filesize);
 
-        for(size_t i = 0; i < filesize; i++) {
-            read_byte = fread(buf, 1, 1, fp);
+        for (size_t i = 0; i < filesize; i++) {
+            bool breakOut = false;
+            size_t readSize = fread(buf, 1, bufSize, fp);
 
-            if ( !read_byte || !_done || _initB ) break;
+            if(!readSize) break;
 
-            spi.write(buf[0]);
+            for (size_t j = 0; j < bufSize; j++) {
+                if (!_initB || _done) {
+                    breakOut = true; break;
+                }
+
+                softSpi.write(buf[j]);
+            }
+
+            if (breakOut) break;
         }
 
         fclose(fp);
 
-        return false;
-
-    } else {
-        LOG(INIT, "FPGA configuration failed\r\n    Unable to open %s",
-            filepath.c_str());
-
         return true;
     }
+
+    LOG(INIT, "FPGA configuration failed\r\n    Unable to open %s",
+        filepath.c_str());
+
+    return false;
 }
 
 uint8_t FPGA::read_halls(uint8_t* halls, size_t size) {

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -111,15 +111,23 @@ int main() {
     // Initialize and configure the fpga with the given bitfile
     FPGA::Instance = new FPGA(sharedSPI, RJ_FPGA_nCS, RJ_FPGA_INIT_B,
                               RJ_FPGA_PROG_B, RJ_FPGA_DONE);
-    bool fpga_ready = FPGA::Instance->configure("/local/rj-fpga.nib");
+    bool fpgaReady = FPGA::Instance->configure("/local/rj-fpga.nib");
 
-    if (fpga_ready) {
+    if (fpgaReady) {
+        rgbLED.brightness(3 * defaultBrightness);
+        rgbLED.setPixel(1, NeoColorGreen);
+
         LOG(INIT, "FPGA Configuration Successful!");
+
     } else {
+        rgbLED.brightness(4 * defaultBrightness);
+        rgbLED.setPixel(1, NeoColorOrange);
+
         LOG(FATAL, "FPGA Configuration Failed!");
     }
+    rgbLED.write();
 
-    DigitalOut rdy_led(RJ_RDY_LED, !fpga_ready);
+    DigitalOut rdy_led(RJ_RDY_LED, !fpgaReady);
 
     // Initialize kicker board
     // TODO: clarify between kicker nCs and nReset
@@ -178,6 +186,17 @@ int main() {
     ASSERT(tState == osOK);
 
     unsigned int ll = 0;
+    uint16_t errorBitmask = 0;
+    bool errorFlash = false;
+
+    if (!fpgaReady) {
+        // assume all motors have errors if FPGA does not work
+        errorBitmask |= (1 << RJ_ERR_LED_M1);
+        errorBitmask |= (1 << RJ_ERR_LED_M2);
+        errorBitmask |= (1 << RJ_ERR_LED_M3);
+        errorBitmask |= (1 << RJ_ERR_LED_M4);
+        errorBitmask |= (1 << RJ_ERR_LED_DRIB);
+    }
 
     while (true) {
         // make sure we can always reach back to main by
@@ -197,8 +216,7 @@ int main() {
         ballSenseStatusLED = !ballSense.have_ball();
 
         // Pack errors into bitmask
-        uint16_t errorBitmask = !global_radio->isConnected()
-                                << RJ_ERR_LED_RADIO;
+        errorBitmask |= !global_radio->isConnected() << RJ_ERR_LED_RADIO;
 
         // add motor errors to bitmask
         static const auto motorErrLedMapping = {
@@ -213,34 +231,24 @@ int main() {
         // Set error-indicating leds on the control board
         ioExpander.writeMask(~errorBitmask, IOExpanderErrorLEDMask);
 
-        // Set error indicators
-        if (!fpga_ready) {
+        if (errorBitmask || !fpgaReady) {
             // orange - error
-            rgbLED.brightness(4 * defaultBrightness);
+            rgbLED.brightness(6 * defaultBrightness);
             rgbLED.setPixel(0, NeoColorOrange);
+
+            if (!fpgaReady) {
+                errorFlash = !errorFlash;
+                // bright as hell to make sure they know
+                rgbLED.brightness(10 * defaultBrightness * errorFlash);
+                // well, damn. everything is broke as hell
+                rgbLED.setPixel(0, NeoColorRed);
+            }
         } else {
-            // green - no error...yet
-            rgbLED.brightness(defaultBrightness);
+            // no errors, yay!
+            rgbLED.brightness(3 * defaultBrightness);
             rgbLED.setPixel(0, NeoColorGreen);
         }
-
-        if (errorBitmask & RJ_ERR_LED_RADIO) {
-            // orange - error
-            rgbLED.brightness(6 * defaultBrightness);
-            rgbLED.setPixel(1, NeoColorOrange);
-        } else {
-            // green - no error...yet
-            rgbLED.brightness(6 * defaultBrightness);
-            rgbLED.setPixel(1, NeoColorGreen);
-        }
-
-        if ((errorBitmask & RJ_ERR_LED_RADIO) && !fpga_ready) {
-            // bright as hell to make sure they know
-            rgbLED.brightness(10 * defaultBrightness);
-            // well, damn. everything is broke as hell
-            rgbLED.setPixel(0, NeoColorRed);
-            rgbLED.setPixel(1, NeoColorRed);
-        }
+        rgbLED.write();
     }
 }
 


### PR DESCRIPTION
These fixes have been confirmed in hardware. Renamed a few things to make it more clear as to what's going on in `FPGA::configure()`. Also rolled out the proper error led states for all of it now that the io expander is able to be tested on.

I've also tested the ls command with the control board connected or not connected with all of this. So, that's apparently fixed now I believe. Tested 3 different mbeds with a combination of files on them, and it all checks out.

fixes #653 
fixes #623 
fixes #639