### PR TITLE
Updated initial value of fieldEdgeInset to reflect 2016 rules

### DIFF
--- a/soccer/gameplay/GameplayModule.cpp
+++ b/soccer/gameplay/GameplayModule.cpp
@@ -31,7 +31,7 @@ void GameplayModule::createConfiguration(Configuration* cfg) {
 +     * The value is given in meters. As of April 20, 2016 the inner 300mm
 +     * is free space for the robots.
 +     */
-+     fieldEdgeInset = new ConfigDouble(cfg, "Pathplanner/Field Edge Obstacle", .33);
++     fieldEdgeInset = new ConfigDouble(cfg, "PathPlanner/Field Edge Obstacle", .33);
 }
 
 bool GameplayModule::hasFieldEdgeInsetChanged() const {

--- a/soccer/gameplay/GameplayModule.cpp
+++ b/soccer/gameplay/GameplayModule.cpp
@@ -31,7 +31,7 @@ void GameplayModule::createConfiguration(Configuration* cfg) {
 +     * The value is given in meters. As of April 20, 2016 the inner 300mm
 +     * is free space for the robots.
 +     */
-    +fieldEdgeInset =
+    _fieldEdgeInset =
         new ConfigDouble(cfg, "PathPlanner/Field Edge Obstacle", .33);
 }
 

--- a/soccer/gameplay/GameplayModule.cpp
+++ b/soccer/gameplay/GameplayModule.cpp
@@ -26,12 +26,13 @@ using namespace Geometry2d;
 ConfigDouble* GameplayModule::_fieldEdgeInset;
 
 void GameplayModule::createConfiguration(Configuration* cfg) {
-     /*  This sets the disance from the field boundries to the edge of the global
+    /*  This sets the disance from the field boundries to the edge of the global
 +     * obstacles, which the robots will not move through or into.
 +     * The value is given in meters. As of April 20, 2016 the inner 300mm
 +     * is free space for the robots.
 +     */
-+     fieldEdgeInset = new ConfigDouble(cfg, "PathPlanner/Field Edge Obstacle", .33);
+    +fieldEdgeInset =
+        new ConfigDouble(cfg, "PathPlanner/Field Edge Obstacle", .33);
 }
 
 bool GameplayModule::hasFieldEdgeInsetChanged() const {

--- a/soccer/gameplay/GameplayModule.cpp
+++ b/soccer/gameplay/GameplayModule.cpp
@@ -26,10 +26,12 @@ using namespace Geometry2d;
 ConfigDouble* GameplayModule::_fieldEdgeInset;
 
 void GameplayModule::createConfiguration(Configuration* cfg) {
-    // this sets the disance from the field boundries to the edge of the global
-    // obstacles, which the
-    // robots will not move through or into
-    _fieldEdgeInset = new ConfigDouble(cfg, "Field Edge Obstacle", .3);
+     /*  This sets the disance from the field boundries to the edge of the global
++     * obstacles, which the robots will not move through or into.
++     * The value is given in meters. As of April 20, 2016 the inner 300mm
++     * is free space for the robots.
++     */
++     fieldEdgeInset = new ConfigDouble(cfg, "Pathplanner/Field Edge Obstacle", .33);
 }
 
 bool GameplayModule::hasFieldEdgeInsetChanged() const {


### PR DESCRIPTION
In past years the inner 250mm has been free space for the robots to move, with the outer 450mm being reserved for referee walking. This year, they are placing a small wall around the field, and have changed the border so that we now have the inner 300mm to work with. I have changed the value of the configurable fieldEdgeInset variable (which controls how far the robots venture from the painted border of the field) to reflect this change. Closes #638 