### PR TITLE
use MBED_INDEX env var for `make robot-prog`

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -12,7 +12,12 @@ remove_cxx_flag("-Werror=return-stack-address")
 include(${CMAKE_CURRENT_LIST_DIR}/mbed/arm_mbed.cmake)
 
 # set the path to a script for moving files to the mbed's USB storage
-set(MBED_COPY_SCRIPT sudo ${PROJECT_SOURCE_DIR}/util/mbed/mbed-copy.py)
+# passes the MBED_INDEX environment variable as a parameter if it is set
+if(DEFINED ENV{MBED_INDEX})
+    set(MBED_COPY_SCRIPT sudo ${PROJECT_SOURCE_DIR}/util/mbed/mbed-copy.py --mbed_index=$ENV{MBED_INDEX})
+else()
+    set(MBED_COPY_SCRIPT sudo ${PROJECT_SOURCE_DIR}/util/mbed/mbed-copy.py)
+endif()
 
 # Note: the arm_mbed.cmake script exports flags that need to be set in each CMake
 # file used to build MBED code like so:

--- a/util/mbed/mbed-copy.py
+++ b/util/mbed/mbed-copy.py
@@ -70,7 +70,7 @@ mbeds.sort(key=lambda m: m['serial_port'])
 # if args.mbed_index is set, copy only to that one
 if args.mbed_index != None:
     index = args.mbed_index
-    if  index < len(mbeds):
+    if index < len(mbeds):
         mbeds = [mbeds[index]]
     else:
         print("Unable to find mbed at index '%'" % index, file=sys.stderr)

--- a/util/mbed/mbed-copy.py
+++ b/util/mbed/mbed-copy.py
@@ -73,7 +73,7 @@ if args.mbed_index != None:
     if index < len(mbeds):
         mbeds = [mbeds[index]]
     else:
-        print("Unable to find mbed at index '%'" % index, file=sys.stderr)
+        print("Unable to find mbed at index '%d'" % index, file=sys.stderr)
         sys.exit(1)
 
 # iterate copying all files to all mbeds

--- a/util/mbed/mbed-copy.py
+++ b/util/mbed/mbed-copy.py
@@ -19,6 +19,11 @@ parser = argparse.ArgumentParser(
 parser.add_argument('files',
                     nargs='+',
                     help='files to move to all connected mbeds')
+parser.add_argument(
+    '--mbed_index',
+    '-i',
+    type=int,
+    help='Index of mbed to copy to.  If unset, copies to all mbeds.')
 args = parser.parse_args()
 
 
@@ -59,10 +64,24 @@ def find_mbed_disk(mbed):
             return os.path.join(dirpath, path)
     return None
 
+# sort alphabetically by serial port
+mbeds.sort(key=lambda m: m['serial_port'])
+
+# if args.mbed_index is set, copy only to that one
+if args.mbed_index:
+    index = args.mbed_index
+    if  index < len(mbeds):
+        mbeds = [mbeds[index]]
+    else:
+        print("Unable to find mbed at index '%'" % index, file=sys.stderr)
+        sys.exit(1)
+
 # iterate copying all files to all mbeds
 for i in range(len(mbeds)):
     mbed = mbeds[i]
     mount_point = mbed['mount_point']
+
+    print("Using mbed at '%s'" % mbed['serial_port'])
 
     already_mounted = mount_point != None
 

--- a/util/mbed/mbed-copy.py
+++ b/util/mbed/mbed-copy.py
@@ -68,7 +68,7 @@ def find_mbed_disk(mbed):
 mbeds.sort(key=lambda m: m['serial_port'])
 
 # if args.mbed_index is set, copy only to that one
-if args.mbed_index:
+if args.mbed_index != None:
     index = args.mbed_index
     if  index < len(mbeds):
         mbeds = [mbeds[index]]


### PR DESCRIPTION
If the `MBED_INDEX` environment variable is set, the mbed copy script will only copy to that mbed, otherwise it will copy to all mbeds.  Use it like:

~~~{.sh}
MBED_INDEX=1 make robot-prog
~~~