### PR TITLE
Start to fix touchpass

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,7 @@ trim_trailing_whitespace = true
 # Use 4 spaces for most files
 indent_style = space
 indent_size = 4
+max_line_length = 80
 
 
 # Use 2 spaces for travis files

--- a/makefile
+++ b/makefile
@@ -22,6 +22,7 @@ all:
 
 run: all
 	cd run; ./soccer
+rs: run-sim
 run-sim: all
 	-pkill -f './simulator --headless'
 	cd run; ./simulator --headless &
@@ -132,7 +133,7 @@ fpga2015:
 	$(call cmake_build_target_fw, fpga2015)
 fpga2015-prog:
 	$(call cmake_build_target_fw, fpga2015-prog)
-	
+
 # Base station 2015 firmware
 base2015:
 	$(call cmake_build_target_fw, base2015)

--- a/soccer/gameplay/root_play.py
+++ b/soccer/gameplay/root_play.py
@@ -72,22 +72,19 @@ class RootPlay(Play, QtCore.QObject):
             if self.play != None:
                 if self.play.__class__ not in map(lambda tup: tup[0],
                                                   enabled_plays_and_scores):
-                    logging.info("Current play '" +
-                                 self.play.__class__.__name__ +
-                                 "' no longer enabled, aborting")
+                    logging.info("Current play '" + self.play.__class__.
+                                 __name__ + "' no longer enabled, aborting")
                     self.play.terminate()
                     self.play = None
                 elif self.play.is_done_running():
-                    logging.info("Current play '" +
-                                 self.play.__class__.__name__ +
-                                 "' finished running")
+                    logging.info("Current play '" + self.play.__class__.
+                                 __name__ + "' finished running")
                     if self.play.is_restart:
                         self._currently_restarting = False
                     self.play = None
                 elif self.play.__class__.score() == float("inf"):
-                    logging.info("Current play '" +
-                                 self.play.__class__.__name__ +
-                                 "' no longer applicable, ending")
+                    logging.info("Current play '" + self.play.__class__.
+                                 __name__ + "' no longer applicable, ending")
                     self.play.terminate()
                     self.play = None
 

--- a/soccer/gameplay/skills/angle_receive.py
+++ b/soccer/gameplay/skills/angle_receive.py
@@ -6,7 +6,7 @@ import main
 import math
 import enum
 import time
-import skills.touchball
+import skills.touch_ball
 import skills._kick
 import skills.pass_receive
 
@@ -143,7 +143,7 @@ class AngleReceive(skills.pass_receive.PassReceive):
 
         self.remove_subbehavior('capture')
 
-        capture = skills.touchball.TouchBall()
+        capture = skills.touch_ball.TouchBall()
         capture.dribbler_power = skills.pass_receive.PassReceive.DribbleSpeed
         self.add_subbehavior(capture, 'capture', required=True)
 

--- a/soccer/gameplay/skills/angle_receive.py
+++ b/soccer/gameplay/skills/angle_receive.py
@@ -19,7 +19,7 @@ import skills.pass_receive
 # Kick is a single_robot_behavior, so no need to import both
 class AngleReceive(skills.pass_receive.PassReceive):
     def __init__(self):
-        super().__init__()
+        super().__init__(captureFunction=(lambda: skills.touch_ball.TouchBall()))
         self._target_point = None
         self.kick_power = 1
         self.target_point = constants.Field.TheirGoalSegment.center()
@@ -135,17 +135,6 @@ class AngleReceive(skills.pass_receive.PassReceive):
         if self._kick_line != None:
             main.system_state().draw_line(self._kick_line,
                                           constants.Colors.Red, "Shot")
-
-    # This depends on the superclasse's implementation somewhat
-    # If we stop using capture in pass_receive, this needs to be modified.
-    def on_enter_receiving(self):
-        super().on_enter_receiving()
-
-        self.remove_subbehavior('capture')
-
-        capture = skills.touch_ball.TouchBall()
-        capture.dribbler_power = skills.pass_receive.PassReceive.DribbleSpeed
-        self.add_subbehavior(capture, 'capture', required=True)
 
     def execute_receiving(self):
         super().execute_receiving()

--- a/soccer/gameplay/skills/angle_receive.py
+++ b/soccer/gameplay/skills/angle_receive.py
@@ -6,6 +6,7 @@ import main
 import math
 import enum
 import time
+import skills.touchball
 import skills._kick
 import skills.pass_receive
 
@@ -142,7 +143,7 @@ class AngleReceive(skills.pass_receive.PassReceive):
 
         self.remove_subbehavior('capture')
 
-        capture = skills.capture.Capture(onlyApproach=True)
+        capture = skills.touchball.TouchBall()
         capture.dribbler_power = skills.pass_receive.PassReceive.DribbleSpeed
         self.add_subbehavior(capture, 'capture', required=True)
 

--- a/soccer/gameplay/skills/angle_receive.py
+++ b/soccer/gameplay/skills/angle_receive.py
@@ -135,6 +135,17 @@ class AngleReceive(skills.pass_receive.PassReceive):
             main.system_state().draw_line(self._kick_line,
                                           constants.Colors.Red, "Shot")
 
+    # This depends on the superclasse's implementation somewhat
+    # If we stop using capture in pass_receive, this needs to be modified.
+    def on_enter_receiving(self):
+        super().on_enter_receiving()
+
+        self.remove_subbehavior('capture')
+
+        capture = skills.capture.Capture(onlyApproach=True)
+        capture.dribbler_power = skills.pass_receive.PassReceive.DribbleSpeed
+        self.add_subbehavior(capture, 'capture', required=True)
+
     def execute_receiving(self):
         super().execute_receiving()
 

--- a/soccer/gameplay/skills/angle_receive.py
+++ b/soccer/gameplay/skills/angle_receive.py
@@ -19,7 +19,8 @@ import skills.pass_receive
 # Kick is a single_robot_behavior, so no need to import both
 class AngleReceive(skills.pass_receive.PassReceive):
     def __init__(self):
-        super().__init__(captureFunction=(lambda: skills.touch_ball.TouchBall()))
+        super().__init__(
+            captureFunction=(lambda: skills.touch_ball.TouchBall()))
         self._target_point = None
         self.kick_power = 1
         self.target_point = constants.Field.TheirGoalSegment.center()

--- a/soccer/gameplay/skills/capture.py
+++ b/soccer/gameplay/skills/capture.py
@@ -24,9 +24,9 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
         fine_approach = 2
 
     ## Capture Constructor
-    # onlyApproach - If true, any turning functions are turned off,
+    # faceBall - If false, any turning functions are turned off,
     # useful for using capture to reflect/bounce moving ballls.
-    def __init__(self, onlyApproach=False):
+    def __init__(self, faceBall=True):
         super().__init__(continuous=False)
 
         self.add_state(Capture.State.course_approach,
@@ -54,7 +54,7 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
 
         self.lastApproachTarget = None
 
-        self.onlyApproach = onlyApproach
+        self.faceBall = faceBall
 
     def bot_to_ball(self):
         return main.ball().pos - self.robot.pos
@@ -107,7 +107,7 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
         self.robot.set_avoid_ball_radius(Capture.CourseApproachAvoidBall)
         pos = self.find_intercept_point()
 
-        if (not self.onlyApproach):
+        if (self.faceBall):
             self.robot.face(main.ball().pos)
 
         if (self.lastApproachTarget != None and
@@ -129,7 +129,7 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
         self.robot.disable_avoid_ball()
         self.robot.set_dribble_speed(Capture.DribbleSpeed)
 
-        if (not self.onlyApproach):
+        if (self.faceBall):
             self.robot.face(main.ball().pos)
 
         # TODO(ashaw596): explain this math a bit

--- a/soccer/gameplay/skills/capture.py
+++ b/soccer/gameplay/skills/capture.py
@@ -69,8 +69,8 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
 
     # normalized vector pointing from the ball to the point the robot should get to in course_aproach
     def approach_vector(self):
-        if main.ball().vel.mag() > 0.25 and self.robot.pos.dist_to(main.ball(
-        ).pos) > 0.2:
+        if (main.ball().vel.mag() > 0.25
+            and self.robot.pos.dist_to(main.ball().pos) > 0.2):
             # ball's moving, get on the side it's moving towards
             return main.ball().vel.normalized()
         else:
@@ -113,6 +113,9 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
         if (self.lastApproachTarget != None and
             (pos - self.lastApproachTarget).mag() < 0.1):
             self.robot.move_to(self.lastApproachTarget)
+            main.system_state().draw_circle(self.lastApproachTarget,
+                                            constants.Ball.Radius,
+                                            constants.Colors.White, "Capture")
         else:
             main.system_state().draw_circle(pos, constants.Ball.Radius,
                                             constants.Colors.White, "Capture")

--- a/soccer/gameplay/skills/capture.py
+++ b/soccer/gameplay/skills/capture.py
@@ -106,6 +106,7 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
         # don't hit the ball on accident
         self.robot.set_avoid_ball_radius(Capture.CourseApproachAvoidBall)
         pos = self.find_intercept_point()
+
         if (not self.onlyApproach):
             self.robot.face(main.ball().pos)
 

--- a/soccer/gameplay/skills/capture.py
+++ b/soccer/gameplay/skills/capture.py
@@ -53,7 +53,6 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
             'ball went into goal')
 
         self.lastApproachTarget = None
-
         self.faceBall = faceBall
 
     def bot_to_ball(self):

--- a/soccer/gameplay/skills/capture.py
+++ b/soccer/gameplay/skills/capture.py
@@ -69,8 +69,8 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
 
     # normalized vector pointing from the ball to the point the robot should get to in course_aproach
     def approach_vector(self):
-        if (main.ball().vel.mag() > 0.25
-            and self.robot.pos.dist_to(main.ball().pos) > 0.2):
+        if main.ball().vel.mag() > 0.25 \
+            and self.robot.pos.dist_to(main.ball().pos) > 0.2:
             # ball's moving, get on the side it's moving towards
             return main.ball().vel.normalized()
         else:

--- a/soccer/gameplay/skills/capture.py
+++ b/soccer/gameplay/skills/capture.py
@@ -23,7 +23,10 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
         course_approach = 1
         fine_approach = 2
 
-    def __init__(self):
+    ## Capture Constructor
+    # onlyApproach - If true, any turning functions are turned off,
+    # useful for using capture to reflect/bounce moving ballls.
+    def __init__(self, onlyApproach=False):
         super().__init__(continuous=False)
 
         self.add_state(Capture.State.course_approach,
@@ -50,6 +53,8 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
             'ball went into goal')
 
         self.lastApproachTarget = None
+
+        self.onlyApproach = onlyApproach
 
     def bot_to_ball(self):
         return main.ball().pos - self.robot.pos
@@ -101,7 +106,8 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
         # don't hit the ball on accident
         self.robot.set_avoid_ball_radius(Capture.CourseApproachAvoidBall)
         pos = self.find_intercept_point()
-        self.robot.face(main.ball().pos)
+        if (not self.onlyApproach):
+            self.robot.face(main.ball().pos)
 
         if (self.lastApproachTarget != None and
             (pos - self.lastApproachTarget).mag() < 0.1):
@@ -118,7 +124,9 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
     def execute_fine_approach(self):
         self.robot.disable_avoid_ball()
         self.robot.set_dribble_speed(Capture.DribbleSpeed)
-        self.robot.face(main.ball().pos)
+
+        if (not self.onlyApproach):
+            self.robot.face(main.ball().pos)
 
         # TODO(ashaw596): explain this math a bit
         bot2ball = (main.ball().pos - self.robot.pos).normalized()

--- a/soccer/gameplay/skills/capture.py
+++ b/soccer/gameplay/skills/capture.py
@@ -98,6 +98,9 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
         # make sure teammates don't bump into us
         self.robot.shield_from_teammates(constants.Robot.Radius * 2.0)
 
+        if (self.faceBall):
+            self.robot.face(main.ball().pos)
+
     def on_enter_course_approach(self):
         self.lastApproachTarget == None
 
@@ -105,9 +108,6 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
         # don't hit the ball on accident
         self.robot.set_avoid_ball_radius(Capture.CourseApproachAvoidBall)
         pos = self.find_intercept_point()
-
-        if (self.faceBall):
-            self.robot.face(main.ball().pos)
 
         if (self.lastApproachTarget != None and
             (pos - self.lastApproachTarget).mag() < 0.1):
@@ -127,9 +127,6 @@ class Capture(single_robot_behavior.SingleRobotBehavior):
     def execute_fine_approach(self):
         self.robot.disable_avoid_ball()
         self.robot.set_dribble_speed(Capture.DribbleSpeed)
-
-        if (self.faceBall):
-            self.robot.face(main.ball().pos)
 
         # TODO(ashaw596): explain this math a bit
         bot2ball = (main.ball().pos - self.robot.pos).normalized()

--- a/soccer/gameplay/skills/pass_receive.py
+++ b/soccer/gameplay/skills/pass_receive.py
@@ -60,7 +60,6 @@ class PassReceive(
         self.kicked_time = 0
         self.captureFunction = captureFunction
 
-
         for state in PassReceive.State:
             self.add_state(state, behavior.Behavior.State.running)
 

--- a/soccer/gameplay/skills/pass_receive.py
+++ b/soccer/gameplay/skills/pass_receive.py
@@ -47,7 +47,7 @@ class PassReceive(
         ## the ball's been kicked and we're adjusting based on where the ball's moving
         receiving = 3
 
-    def __init__(self):
+    def __init__(self, captureFunction=(lambda: skills.capture.Capture())):
         super().__init__(continuous=False)
 
         self.ball_kicked = False
@@ -58,6 +58,8 @@ class PassReceive(
         self.kicked_vel = None
         self.stable_frame = 0
         self.kicked_time = 0
+        self.captureFunction = captureFunction
+
 
         for state in PassReceive.State:
             self.add_state(state, behavior.Behavior.State.running)
@@ -196,7 +198,7 @@ class PassReceive(
         self.kicked_vel = main.ball().vel
 
     def on_enter_receiving(self):
-        capture = skills.capture.Capture()
+        capture = self.captureFunction()
         capture.dribbler_power = PassReceive.DribbleSpeed
         self.add_subbehavior(capture, 'capture', required=True)
 

--- a/soccer/gameplay/skills/touch_ball.py
+++ b/soccer/gameplay/skills/touch_ball.py
@@ -29,7 +29,7 @@ class TouchBall(single_robot_behavior.SingleRobotBehavior):
 
     ## TouchBall Constructor
     # useful for reflecting/bouncing moving ballls.
-    def __init__(self ):
+    def __init__(self):
         super().__init__(continuous=False)
 
         self.add_state(TouchBall.State.course_approach,
@@ -57,7 +57,6 @@ class TouchBall(single_robot_behavior.SingleRobotBehavior):
 
         self.lastApproachTarget = None
 
-
     ## Override this to detect if the ball is directly in front of us
     def ball_in_front_of_bot(self):
         adjFactor = robocup.Point.direction(self.robot.angle) \
@@ -74,7 +73,6 @@ class TouchBall(single_robot_behavior.SingleRobotBehavior):
         else:
             return (self.robot.pos - main.ball().pos).normalized()
 
-
     ## A touch is different from a capture in that we should try to keep our
     # distance from the ball if possible, and move forward to hit the ball at
     # the last minute.
@@ -90,15 +88,15 @@ class TouchBall(single_robot_behavior.SingleRobotBehavior):
         robotPos = self.robot.pos - adjFactor
 
         # multiply by a large enough value to cover the field.
-        approach_line = robocup.Line(main.ball().pos, main.ball().pos +
-                                     approach_vec * constants.Field.Length)
+        approach_line = robocup.Line(
+            main.ball().pos,
+            main.ball().pos + approach_vec * constants.Field.Length)
         pos = approach_line.nearest_point(robotPos)
 
         if adjusted:
             pos += adjFactor
 
         return pos
-
 
     def execute_running(self):
         # make sure teammates don't bump into us
@@ -111,16 +109,16 @@ class TouchBall(single_robot_behavior.SingleRobotBehavior):
         # don't hit the ball on accident
         pos = self.find_intercept_point()
 
-
         if (self.lastApproachTarget != None and
             (pos - self.lastApproachTarget).mag() < 0.1):
             self.robot.move_to(self.lastApproachTarget)
-            main.system_state().draw_circle(self.lastApproachTarget,
-                                            constants.Ball.Radius,
-                                            constants.Colors.White, "TouchBall")
+            main.system_state().draw_circle(
+                self.lastApproachTarget, constants.Ball.Radius,
+                constants.Colors.White, "TouchBall")
         else:
             main.system_state().draw_circle(pos, constants.Ball.Radius,
-                                            constants.Colors.White, "TouchBall")
+                                            constants.Colors.White,
+                                            "TouchBall")
             self.robot.move_to(pos)
             self.lastApproachTarget = pos
 
@@ -130,8 +128,8 @@ class TouchBall(single_robot_behavior.SingleRobotBehavior):
     def execute_hit_ball(self):
         self.robot.disable_avoid_ball()
         self.robot.set_dribble_speed(TouchBall.DribbleSpeed)
-        self.robot.move_to_direct(main.ball().pos +
-                                  (main.ball().vel * (1 / TouchBall.HitAdjust)))
+        self.robot.move_to_direct(main.ball().pos + (main.ball().vel * (
+            1 / TouchBall.HitAdjust)))
 
     def role_requirements(self):
         reqs = super().role_requirements()

--- a/soccer/gameplay/skills/touch_ball.py
+++ b/soccer/gameplay/skills/touch_ball.py
@@ -49,7 +49,7 @@ class TouchBall(single_robot_behavior.SingleRobotBehavior):
                             lambda: self.robot.has_ball(), 'has ball')
 
         self.add_transition(
-            TouchBall.State.fine_approach, TouchBall.State.course_approach,
+            TouchBall.State.fine_approach, behavior.Behavior.State.failed,
             lambda: not (self.bot_in_front_of_ball() or self.bot_near_ball(TouchBall.CourseApproachDist)) and (not self.bot_near_ball(TouchBall.CourseApproachDist * 1.5) or not main.ball().pos),
             'ball went into goal')
 

--- a/soccer/gameplay/skills/touch_ball.py
+++ b/soccer/gameplay/skills/touch_ball.py
@@ -123,7 +123,7 @@ class TouchBall(single_robot_behavior.SingleRobotBehavior):
             self.lastApproachTarget = pos
 
     def on_exit_course_approach(self):
-        self.lastApproachTarget == None
+        self.lastApproachTarget = None
 
     def execute_hit_ball(self):
         self.robot.disable_avoid_ball()

--- a/soccer/gameplay/skills/touch_ball.py
+++ b/soccer/gameplay/skills/touch_ball.py
@@ -12,18 +12,18 @@ import math
 
 class TouchBall(skills.capture.Capture):
     def __init__(self):
-        super().__init__(onlyApproach=True)
+        super().__init__(faceBall=False)
 
     # Move back so we hit the mouth, not the side
-    adjDist = constants.Robot.Radius * 2
+    AdjDist = constants.Robot.Radius * 2
 
-    ## Override so this so we only transition when the ball is in front
+    ## Override this to detect if the ball is directly in front of us
     def bot_in_front_of_ball(self):
         adjFactor = robocup.Point(
-            math.cos(self.robot.angle) * -TouchBall.adjDist,
-            math.sin(self.robot.angle) * -TouchBall.adjDist)
+            math.cos(self.robot.angle) * -TouchBall.AdjDist,
+            math.sin(self.robot.angle) * -TouchBall.AdjDist)
         return (self.robot.pos - adjFactor).dist_to(main.ball().pos) \
-            < TouchBall.adjDist + constants.Robot.Radius
+            < TouchBall.AdjDist + constants.Robot.Radius
 
     ## A touch is different from a capture in that we should try to keep our
     # distance from the ball if possible, and move forward to hit the ball at
@@ -35,9 +35,8 @@ class TouchBall(skills.capture.Capture):
     def find_intercept_point(self):
         approach_vec = self.approach_vector()
 
-        adjFactor = robocup.Point(
-            math.cos(self.robot.angle) * -TouchBall.adjDist,
-            math.sin(self.robot.angle) * -TouchBall.adjDist)
+        adjFactor = robocup.Point.direction(self.robot.angle) \
+                    *  -TouchBall.AdjDist
         robotPos = self.robot.pos - adjFactor
 
         # multiply by a large enough value to cover the field.

--- a/soccer/gameplay/skills/touch_ball.py
+++ b/soccer/gameplay/skills/touch_ball.py
@@ -14,9 +14,7 @@ class TouchBall(single_robot_behavior.SingleRobotBehavior):
 
     # tunable config values
     CourseApproachDist = 0.4
-    CourseApproachAvoidBall = 0.10
     DribbleSpeed = 0
-    FineApproachSpeed = 0.2
     # The amount of seconds to look in the future when
     # trying to actualy hit the eball. TODO: use maxaccel to find this.
     HitAdjust = 1
@@ -25,7 +23,8 @@ class TouchBall(single_robot_behavior.SingleRobotBehavior):
         course_approach = 1
         hit_ball = 2
 
-    # Move back so we hit the mouth, not the side
+    # Move back so we hit the mouth, not the side. This is needed
+    # as the robot will oscilate a bit, giving a 50% chance of failure.
     AdjDist = constants.Robot.Radius * 2
 
     ## TouchBall Constructor
@@ -110,7 +109,6 @@ class TouchBall(single_robot_behavior.SingleRobotBehavior):
 
     def execute_course_approach(self):
         # don't hit the ball on accident
-        self.robot.set_avoid_ball_radius(TouchBall.CourseApproachAvoidBall)
         pos = self.find_intercept_point()
 
 

--- a/soccer/gameplay/skills/touch_ball.py
+++ b/soccer/gameplay/skills/touch_ball.py
@@ -10,12 +10,58 @@ import skills.capture
 import math
 
 
-class TouchBall(skills.capture.Capture):
-    def __init__(self):
-        super().__init__(faceBall=False)
+class TouchBall(single_robot_behavior.SingleRobotBehavior):
+
+    # tunable config values
+    CourseApproachDist = 0.4
+    CourseApproachAvoidBall = 0.10
+    DribbleSpeed = 100
+    FineApproachSpeed = 0.2
+
+    class State(Enum):
+        course_approach = 1
+        fine_approach = 2
 
     # Move back so we hit the mouth, not the side
     AdjDist = constants.Robot.Radius * 2
+
+    ## TouchBall Constructor
+    # useful for reflecting/bouncing moving ballls.
+    def __init__(self ):
+        super().__init__(continuous=False)
+
+        self.add_state(TouchBall.State.course_approach,
+                       behavior.Behavior.State.running)
+        self.add_state(TouchBall.State.fine_approach,
+                       behavior.Behavior.State.running)
+
+        self.add_transition(behavior.Behavior.State.start,
+                            TouchBall.State.course_approach, lambda: True,
+                            'immediately')
+
+        self.add_transition(
+            TouchBall.State.course_approach, TouchBall.State.fine_approach,
+            lambda: (self.bot_in_front_of_ball() or self.bot_near_ball(TouchBall.CourseApproachDist)) and main.ball().valid,
+            'dist to ball < threshold')
+
+        self.add_transition(TouchBall.State.fine_approach,
+                            behavior.Behavior.State.completed,
+                            lambda: self.robot.has_ball(), 'has ball')
+
+        self.add_transition(
+            TouchBall.State.fine_approach, TouchBall.State.course_approach,
+            lambda: not (self.bot_in_front_of_ball() or self.bot_near_ball(TouchBall.CourseApproachDist)) and (not self.bot_near_ball(TouchBall.CourseApproachDist * 1.5) or not main.ball().pos),
+            'ball went into goal')
+
+        self.lastApproachTarget = None
+
+
+    def bot_to_ball(self):
+        return main.ball().pos - self.robot.pos
+
+    def bot_near_ball(self, distance):
+        return (self.bot_to_ball().mag() < distance)
+
 
     ## Override this to detect if the ball is directly in front of us
     def bot_in_front_of_ball(self):
@@ -24,6 +70,16 @@ class TouchBall(skills.capture.Capture):
             math.sin(self.robot.angle) * -TouchBall.AdjDist)
         return (self.robot.pos - adjFactor).dist_to(main.ball().pos) \
             < TouchBall.AdjDist + constants.Robot.Radius
+
+    # normalized vector pointing from the ball to the point the robot should get to in course_aproach
+    def approach_vector(self):
+        if main.ball().vel.mag() > 0.25 \
+            and self.robot.pos.dist_to(main.ball().pos) > 0.2:
+            # ball's moving, get on the side it's moving towards
+            return main.ball().vel.normalized()
+        else:
+            return (self.robot.pos - main.ball().pos).normalized()
+
 
     ## A touch is different from a capture in that we should try to keep our
     # distance from the ball if possible, and move forward to hit the ball at
@@ -46,3 +102,54 @@ class TouchBall(skills.capture.Capture):
 
         pos += adjFactor
         return pos
+
+
+    def execute_running(self):
+        # make sure teammates don't bump into us
+        self.robot.shield_from_teammates(constants.Robot.Radius * 2.0)
+
+    def on_enter_course_approach(self):
+        self.lastApproachTarget == None
+
+    def execute_course_approach(self):
+        # don't hit the ball on accident
+        self.robot.set_avoid_ball_radius(TouchBall.CourseApproachAvoidBall)
+        pos = self.find_intercept_point()
+
+
+        if (self.lastApproachTarget != None and
+            (pos - self.lastApproachTarget).mag() < 0.1):
+            self.robot.move_to(self.lastApproachTarget)
+            main.system_state().draw_circle(self.lastApproachTarget,
+                                            constants.Ball.Radius,
+                                            constants.Colors.White, "TouchBall")
+        else:
+            main.system_state().draw_circle(pos, constants.Ball.Radius,
+                                            constants.Colors.White, "TouchBall")
+            self.robot.move_to(pos)
+            self.lastApproachTarget = pos
+
+    def on_exit_course_approach(self):
+        self.lastApproachTarget == None
+
+    def execute_fine_approach(self):
+        self.robot.disable_avoid_ball()
+        self.robot.set_dribble_speed(TouchBall.DribbleSpeed)
+
+        # TODO(ashaw596): explain this math a bit
+        bot2ball = (main.ball().pos - self.robot.pos).normalized()
+        multiplier = 1.5
+        aproach = self.bot_to_ball(
+        ) * multiplier + bot2ball * TouchBall.FineApproachSpeed / 4 + main.ball(
+        ).vel
+        if (aproach.mag() > 1):
+            aproach = aproach.normalized() * 1
+        self.robot.set_world_vel(aproach)
+
+    def role_requirements(self):
+        reqs = super().role_requirements()
+        reqs.require_kicking = True
+        # try to be near the ball
+        if main.ball().valid:
+            reqs.destination_shape = main.ball().pos
+        return reqs

--- a/soccer/gameplay/skills/touchball.py
+++ b/soccer/gameplay/skills/touchball.py
@@ -16,9 +16,11 @@ class TouchBall(skills.capture.Capture):
     # Move back so we hit the mouth, not the side
     adjDist = constants.Robot.Radius * 2
 
-    ## Override so this has no impact on state transitions
+    ## Override so this so we only transition when the ball is in front
     def bot_in_front_of_ball(self):
-        return False
+        adjFactor = robocup.Point(math.cos(self.robot.angle) * -TouchBall.adjDist, math.sin(self.robot.angle) * -TouchBall.adjDist)
+        return (self.robot.pos - adjFactor).dist_to(main.ball().pos) \
+            < TouchBall.adjDist + constants.Robot.Radius
 
 
     ## A touch is different from a capture in that we should try to keep our

--- a/soccer/gameplay/skills/touchball.py
+++ b/soccer/gameplay/skills/touchball.py
@@ -1,0 +1,27 @@
+import single_robot_behavior
+import behavior
+from enum import Enum
+import main
+import evaluation
+import constants
+import role_assignment
+import robocup
+import skills.capture
+import math
+
+class TouchBall(skills.capture.Capture):
+    def __init__(self):
+        super().__init__(onlyApproach=True)
+
+    AdjustDistance = 0.25
+
+    ## A touch is different from a capture in that we should try to keep our
+    # distance from the ball if possible, and move forward to hit the ball at
+    # the last minute.
+    # To do this, let's move the intercept point capture found back a bit.
+    def find_intercept_point(self):
+        # Capture's interception point.
+        pos = super().find_intercept_point()
+
+        pos += robocup.Point(math.cos(self.robot.angle) * -TouchBall.AdjustDistance, math.sin(self.robot.angle) * -TouchBall.AdjustDistance)
+        return pos

--- a/soccer/gameplay/skills/touchball.py
+++ b/soccer/gameplay/skills/touchball.py
@@ -9,6 +9,7 @@ import robocup
 import skills.capture
 import math
 
+
 class TouchBall(skills.capture.Capture):
     def __init__(self):
         super().__init__(onlyApproach=True)
@@ -18,10 +19,11 @@ class TouchBall(skills.capture.Capture):
 
     ## Override so this so we only transition when the ball is in front
     def bot_in_front_of_ball(self):
-        adjFactor = robocup.Point(math.cos(self.robot.angle) * -TouchBall.adjDist, math.sin(self.robot.angle) * -TouchBall.adjDist)
+        adjFactor = robocup.Point(
+            math.cos(self.robot.angle) * -TouchBall.adjDist,
+            math.sin(self.robot.angle) * -TouchBall.adjDist)
         return (self.robot.pos - adjFactor).dist_to(main.ball().pos) \
             < TouchBall.adjDist + constants.Robot.Radius
-
 
     ## A touch is different from a capture in that we should try to keep our
     # distance from the ball if possible, and move forward to hit the ball at
@@ -33,11 +35,14 @@ class TouchBall(skills.capture.Capture):
     def find_intercept_point(self):
         approach_vec = self.approach_vector()
 
-        adjFactor = robocup.Point(math.cos(self.robot.angle) * -TouchBall.adjDist, math.sin(self.robot.angle) * -TouchBall.adjDist)
+        adjFactor = robocup.Point(
+            math.cos(self.robot.angle) * -TouchBall.adjDist,
+            math.sin(self.robot.angle) * -TouchBall.adjDist)
         robotPos = self.robot.pos - adjFactor
 
         # multiply by a large enough value to cover the field.
-        approach_line = robocup.Line(main.ball().pos, main.ball().pos + approach_vec * constants.Field.Length)
+        approach_line = robocup.Line(main.ball().pos, main.ball().pos +
+                                     approach_vec * constants.Field.Length)
         pos = approach_line.nearest_point(robotPos)
 
         pos += adjFactor

--- a/soccer/gameplay/skills/touchball.py
+++ b/soccer/gameplay/skills/touchball.py
@@ -13,15 +13,46 @@ class TouchBall(skills.capture.Capture):
     def __init__(self):
         super().__init__(onlyApproach=True)
 
-    AdjustDistance = 0.25
+    adjDist = constants.Robot.Radius * 2 # Move back so the
+
+    ## Override so this has no impact on state transitions
+    def bot_in_front_of_ball(self):
+        return False
+
 
     ## A touch is different from a capture in that we should try to keep our
     # distance from the ball if possible, and move forward to hit the ball at
     # the last minute.
     # To do this, let's move the intercept point capture found back a bit.
+    #
+    # In addition, lets try to keep this point stable by choosing the closest
+    # point, instead of the point that we can reach in time closest to the ball
     def find_intercept_point(self):
-        # Capture's interception point.
-        pos = super().find_intercept_point()
+        approach_vec = self.approach_vector()
 
-        pos += robocup.Point(math.cos(self.robot.angle) * -TouchBall.AdjustDistance, math.sin(self.robot.angle) * -TouchBall.AdjustDistance)
-        return pos
+        adjFactor = robocup.Point(math.cos(self.robot.angle) * -TouchBall.adjDist, math.sin(self.robot.angle) * -TouchBall.adjDist)
+
+        # sample every 5 cm in the -approach_vector direction from the ball
+        pos = None
+        # Adjust where this algorithm thinks we are by the adjust factor.
+        robotPos = self.robot.pos - adjFactor
+        finalPos = None
+        minBotTime = float('inf')
+        for i in range(50):
+            dist = i * 0.05
+            pos = main.ball().pos + approach_vec * dist
+            # how long will it take the ball to get there
+            ball_time = evaluation.ball.rev_predict(main.ball().vel, dist)
+            robotDist = (pos - (robotPos)).mag() * 0.6
+            bot_time = robocup.get_trapezoidal_time(robotDist, robotDist, 2.2,
+                                                    1, self.robot.vel.mag(), 0)
+
+            if bot_time < minBotTime or finalPos == None:
+                minBotTime = bot_time
+                finalPos = pos
+
+        # Push found point back a bit to have the ball hit our mouth,
+        # instead of our side.
+        finalPos += adjFactor
+
+        return finalPos


### PR DESCRIPTION
Touchpass was broken from some point during last year in china, but I think I've fixed it (at least in the simulator for now). The cause of this was using capture in the receiving play, which I made some modificiations to fix. This is still a work in progress, but it's mostly done.

The main improvement I was thinking about was hijacking the 'fine-approach' state in capture to lunge towards the ball, as well as improve detecting when a touchpass fails earlier if possible. I've already modified course approach to suggest points to intercept on that allow for a touchpass.

Right now, only style is complaning, but I'll fix that once we have everything else wrapped up.

See #408