### PR TITLE
Fixed KickerBoard memory checking and programming.

### DIFF
--- a/firmware/common2015/drivers/avr-isp/AVR910.cpp
+++ b/firmware/common2015/drivers/avr-isp/AVR910.cpp
@@ -80,6 +80,7 @@ bool AVR910::program(FILE* binary, int pageSize, int numPages) {
     int c = 0;
     int highLow = 0;
 
+    fseek(binary, 0, SEEK_SET);
     // We're dealing with paged memory.
     if (numPages > 1) {
         while ((c = getc(binary)) != EOF) {
@@ -269,7 +270,7 @@ char AVR910::readProgramMemory(int highLow, char pageNumber, char pageOffset) {
     return response;
 }
 
-bool AVR910::checkMemory(int numPages, int pageSize, FILE* binary,
+bool AVR910::checkMemory(int pageSize, int numPages, FILE* binary,
                          bool verbose) {
     bool success = true;
 
@@ -282,6 +283,7 @@ bool AVR910::checkMemory(int numPages, int pageSize, FILE* binary,
             char c = getc(binary);
             // Read program memory low byte.
             response = readProgramMemory(READ_LOW_BYTE, page, offset);
+
             if (c != response) {
                 if (verbose) {
                     printf("Page %i low byte %i: 0x%02x\r\n", page, offset,


### PR DESCRIPTION
The AVR910::program(...) didn't fseek to the beginning of the file before writing. This led to issues when checkMemory was called before programming which advances our seek position to the end of the file.

Also, in KickerBoard::flash(...) we were calling checkMemory with page size first and num pages second. This was consistent with AVR910::program(File* fp, int pageSize, int numPages), but in AVR910::checkMemory the arguments were actually flipped. I changed AVR910::checkMemory to maintain consistency.

This will hopefully resolve #584