### PR TITLE
Know battery levels from a robot in Soccer

### DIFF
--- a/firmware/common2015/utils/rtp.hpp
+++ b/firmware/common2015/utils/rtp.hpp
@@ -70,9 +70,12 @@ struct ControlMessage {
 struct RobotStatusMessage {
     uint8_t uid;  // robot id
 
-    /// @battVoltage is a direct reading from the mbed's ADC and is sent over
-    /// the air as-is.  Soccer must convert this reading into an actual voltage
-    /// value by multiplying it by the scale factor.
+    /** @battVoltage is a direct reading from the mbed's ADC and is sent over
+     * the air as-is.  Soccer must convert this reading into an actual voltage
+     * value by multiplying it by the scale factor. The theoretical scale factor
+     * is 0.100546875, but this has been adjusted after testing to the value
+     * below.
+     */
     const float BATTERY_READING_SCALE_FACTOR = 0.09884;
     uint8_t battVoltage;
 

--- a/firmware/common2015/utils/rtp.hpp
+++ b/firmware/common2015/utils/rtp.hpp
@@ -76,7 +76,7 @@ struct RobotStatusMessage {
      * is 0.100546875, but this has been adjusted after testing to the value
      * below.
      */
-    const float BATTERY_READING_SCALE_FACTOR = 0.09884;
+    static constexpr float BATTERY_READING_SCALE_FACTOR = 0.09884;
     uint8_t battVoltage;
 
     uint8_t ballSenseStatus : 2;

--- a/firmware/common2015/utils/rtp.hpp
+++ b/firmware/common2015/utils/rtp.hpp
@@ -69,7 +69,13 @@ struct ControlMessage {
 
 struct RobotStatusMessage {
     uint8_t uid;  // robot id
+
+    /// @battVoltage is a direct reading from the mbed's ADC and is sent over
+    /// the air as-is.  Soccer must convert this reading into an actual voltage
+    /// value by multiplying it by the scale factor.
+    const float BATTERY_READING_SCALE_FACTOR = 0.09884;
     uint8_t battVoltage;
+
     uint8_t ballSenseStatus : 2;
 };
 

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -176,6 +176,11 @@ int main() {
     // Make sure all of the motors are enabled
     motors_Init();
 
+    // setup analog in on battery sense pin
+    // the value is updated in the main loop below
+    AnalogIn batt(RJ_BATT_SENSE);
+    uint8_t battVoltage = 0;
+
     // Setup radio protocol handling
     const uint8_t robotID = 2;  // TODO: remove
     RadioProtocol radioProtocol(CommModule::Instance, global_radio);
@@ -184,7 +189,7 @@ int main() {
     radioProtocol.rxCallback = [&](const rtp::ControlMessage* msg) {
         rtp::RobotStatusMessage reply;
         reply.uid = robotID;
-        reply.battVoltage = 5;  // TODO
+        reply.battVoltage = battVoltage;
         reply.ballSenseStatus = ballSense.have_ball() ? 1 : 0;
 
         vector<uint8_t> replyBuf;
@@ -246,12 +251,7 @@ int main() {
         }
 
         // get the battery voltage
-        AnalogIn batt(RJ_BATT_SENSE);
-
-        uint8_t batt_vol = (batt.read_u16() >> 8);
-
-        const float batt_vol_in_soccer = batt_vol * 0.09884f;
-        printf("battery voltage: %.5fV\r\n", batt_vol_in_soccer);
+        battVoltage = (batt.read_u16() >> 8);
 
         // Set error-indicating leds on the control board
         ioExpander.writeMask(~errorBitmask, IOExpanderErrorLEDMask);

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -245,6 +245,14 @@ int main() {
             errorBitmask |= !status.hallOK << pair.second;
         }
 
+        // get the battery voltage
+        AnalogIn batt(RJ_BATT_SENSE);
+
+        uint8_t batt_vol = (batt.read_u16() >> 8);
+
+        const float batt_vol_in_soccer = batt_vol * 0.09884f;
+        printf("battery voltage: %.5fV\r\n", batt_vol_in_soccer);
+
         // Set error-indicating leds on the control board
         ioExpander.writeMask(~errorBitmask, IOExpanderErrorLEDMask);
 

--- a/soccer/BatteryProfile.cpp
+++ b/soccer/BatteryProfile.cpp
@@ -14,7 +14,6 @@ const BatteryProfile RJ2008BatteryProfile({{14.20, 0.20},
                                            {15.10, 0.50},
                                            {16.00, 1.00}});
 
-#warning Battery profile for 2015 robot is untested, actual battery charge may be different than what is seen in soccer
 const BatteryProfile RJ2015BatteryProfile({{17.75, 0.20},
                                            {18.87, 0.50},
                                            {20.00, 1.00}});

--- a/soccer/BatteryProfile.cpp
+++ b/soccer/BatteryProfile.cpp
@@ -14,8 +14,10 @@ const BatteryProfile RJ2008BatteryProfile({{14.20, 0.20},
                                            {15.10, 0.50},
                                            {16.00, 1.00}});
 
-#warning Battery profile for 2015 robot isnt calibrated yet - it always reports 0% charged
-const BatteryProfile RJ2015BatteryProfile({{0, 0.00}, {100, 0.00}});
+#warning Battery profile for 2015 robot is untested, actual battery charge may be different than what is seen in soccer
+const BatteryProfile RJ2015BatteryProfile({{17.75, 0.20},
+                                           {18.87, 0.50},
+                                           {20.00, 1.00}});
 
 BatteryProfile::BatteryProfile(std::vector<BatteryProfile::Entry> dataPoints) {
     _dataPoints = std::move(dataPoints);

--- a/soccer/radio/USBRadio.cpp
+++ b/soccer/radio/USBRadio.cpp
@@ -285,7 +285,7 @@ void USBRadio::handleRxData(uint8_t* buf) {
     packet.set_hardware_version(RJ2015);
 
     // battery voltage
-    packet.set_battery(msg->battVoltage * rtp::BATTERY_READING_SCALE_FACTOR);
+    packet.set_battery(msg->battVoltage * rtp::RobotStatusMessage::BATTERY_READING_SCALE_FACTOR);
 
     // ball sense
     packet.set_ball_sense_status(BallSenseStatus(msg->ballSenseStatus));

--- a/soccer/radio/USBRadio.cpp
+++ b/soccer/radio/USBRadio.cpp
@@ -274,16 +274,26 @@ void USBRadio::handleRxData(uint8_t* buf) {
 
     RadioRx packet = RadioRx();
 
+    // Unit conversions
+    //
+    // theoretical
+    //static const float Batt_VConv_2015 = 0.100546875f;
+    //
+    // real world tested
+    static const float Batt_VConv_2015 = 0.09884f;
+
     rtp::header_data* header = (rtp::header_data*)buf;
     rtp::RobotStatusMessage* msg =
         (rtp::RobotStatusMessage*)(buf + sizeof(rtp::header_data));
 
     packet.set_timestamp(rx_time);
     packet.set_robot_id(msg->uid);
-    packet.set_battery(msg->battVoltage);
 
     // Hardware version
     packet.set_hardware_version(RJ2015);
+
+    // battery voltage
+    packet.set_battery(msg->battVoltage * Batt_VConv_2015);
 
     // ball sense
     packet.set_ball_sense_status(BallSenseStatus(msg->ballSenseStatus));

--- a/soccer/radio/USBRadio.cpp
+++ b/soccer/radio/USBRadio.cpp
@@ -274,14 +274,6 @@ void USBRadio::handleRxData(uint8_t* buf) {
 
     RadioRx packet = RadioRx();
 
-    // Unit conversions
-    //
-    // theoretical
-    // static const float Batt_VConv_2015 = 0.100546875f;
-    //
-    // real world tested
-    static const float Batt_VConv_2015 = 0.09884f;
-
     rtp::header_data* header = (rtp::header_data*)buf;
     rtp::RobotStatusMessage* msg =
         (rtp::RobotStatusMessage*)(buf + sizeof(rtp::header_data));

--- a/soccer/radio/USBRadio.cpp
+++ b/soccer/radio/USBRadio.cpp
@@ -277,7 +277,7 @@ void USBRadio::handleRxData(uint8_t* buf) {
     // Unit conversions
     //
     // theoretical
-    //static const float Batt_VConv_2015 = 0.100546875f;
+    // static const float Batt_VConv_2015 = 0.100546875f;
     //
     // real world tested
     static const float Batt_VConv_2015 = 0.09884f;

--- a/soccer/radio/USBRadio.cpp
+++ b/soccer/radio/USBRadio.cpp
@@ -293,7 +293,7 @@ void USBRadio::handleRxData(uint8_t* buf) {
     packet.set_hardware_version(RJ2015);
 
     // battery voltage
-    packet.set_battery(msg->battVoltage * Batt_VConv_2015);
+    packet.set_battery(msg->battVoltage * rtp::BATTERY_READING_SCALE_FACTOR);
 
     // ball sense
     packet.set_ball_sense_status(BallSenseStatus(msg->ballSenseStatus));


### PR DESCRIPTION
The firmware side of everything is in place with this. The conversion constant was computed, then tweaked slightly after testing in hardware. Also estimated a set of 20%, 50%, and 100% levels for the battery profile. It should be accurate enough for what we're using it for - at least for now.

The motors shouldn't be spun if the battery is critically low, but that's somewhat of a separate issue. And it'd be much easier to do that after most of the motor/radio things are merged into master.

cc @justbuchanan
