### PR TITLE
Fix ball sense issue

### DIFF
--- a/firmware/common2015/drivers/ball_sense/BallSense.cpp
+++ b/firmware/common2015/drivers/ball_sense/BallSense.cpp
@@ -17,11 +17,13 @@ void BallSense::update_ball_sensor() {
         emitter_pin.write(0);
 
         // Possible break in beam
-        if (sense_light - sense_dark > sense_threshold) {
+        if (std::abs(sense_light - sense_dark) < sense_threshold) {
             consec_ctr++;
         } else {
             consec_ctr = 0;
         }
+        // printf("{'light': %d, 'dark': %d, 'ball': %s},\r\n", sense_light,
+        // sense_dark, have_ball() ? "True" : "False");
     } else  // Emitter off
     {
         // Update value

--- a/firmware/common2015/drivers/ball_sense/BallSense.hpp
+++ b/firmware/common2015/drivers/ball_sense/BallSense.hpp
@@ -29,15 +29,14 @@ private:
     // Holds the light sensed when
     //  emitter is lit (sense_light) and
     //  dark (sense_dark)
-    int sense_dark = 0;
+    uint16_t sense_dark = 0;
 
     // Emitter state (Light or dark)
     bool emitter_on = false;
 
-    // Difference between the light and dark
-    //  values before the sensor is considered
-    //  broken
-    const int sense_threshold = 8000;
+    // If the light reading and dark reading are closer than this value, the
+    // beam is considered broken
+    const int sense_threshold = 5;
 
     // Number of consecative "broken" senses
     //  before we are confident the beam is broken

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -80,7 +80,7 @@ int main() {
 
     // Initialize and start ball sensor
     BallSense ballSense(RJ_BALL_EMIT, RJ_BALL_DETECTOR);
-    ballSense.start(100);  // TODO(justin): choose smarter update frequency
+    ballSense.start(10);
     DigitalOut ballSenseStatusLED(RJ_BALL_LED, 1);
 
     // Force off since the neopixel's hardware is stateless from previous


### PR DESCRIPTION
The logic for detecting a break in the beam was somewhat circular because it updated the "dark" reading every other update and compared it to the "light" reading.  For the first break in the beam, this would trigger a break, but after that, the dark and light readings would always be the same because of the ball being in the way.

This changes it to consider the beam broken if the light and dark readings are the same.

fixes #658 

TODO:

- [x] tune `BallSense.sense_threshold` - I set it to `20` for now, but that's pretty arbitrary

cc @JNeiger 