### PR TITLE
better number format for fpga values

### DIFF
--- a/firmware/common2015/drivers/fpga/fpga.cpp
+++ b/firmware/common2015/drivers/fpga/fpga.cpp
@@ -189,9 +189,9 @@ uint8_t FPGA::read_encs(int16_t* enc_counts, size_t size) {
     status = _spi->write(CMD_READ_ENC);
 
     for (size_t i = 0; i < size; i++) {
-        int16_t enc = (_spi->write(0x00) << 8);
+        uint16_t enc = _spi->write(0x00) << 8;
         enc |= _spi->write(0x00);
-        enc_counts[i] = fromSignMag<15>(enc);
+        enc_counts[i] = static_cast<int16_t>(enc);
     }
 
     chipDeselect();
@@ -262,7 +262,7 @@ uint8_t FPGA::set_duty_get_enc(int16_t* duty_cycles, size_t size_dut,
 
         uint16_t enc = _spi->write(dc & 0xFF) << 8;
         enc |= _spi->write(dc >> 8);
-        enc_deltas[i] = fromSignMag<15>(enc);
+        enc_deltas[i] = static_cast<int16_t>(enc);
     }
 
     chipDeselect();

--- a/firmware/common2015/drivers/fpga/fpga.cpp
+++ b/firmware/common2015/drivers/fpga/fpga.cpp
@@ -221,7 +221,7 @@ uint8_t FPGA::set_duty_cycles(int16_t* duty_cycles, size_t size) {
 
     // Check for valid duty cycles values
     for (size_t i = 0; i < size; i++)
-        if (abs(duty_cycles[i]) > 255) return 0x7F;
+        if (abs(duty_cycles[i]) > MAX_DUTY_CYCLE) return 0x7F;
 
     chipSelect();
     status = _spi->write(CMD_R_ENC_W_VEL);
@@ -243,7 +243,7 @@ uint8_t FPGA::set_duty_get_enc(int16_t* duty_cycles, size_t size_dut,
 
     // Check for valid duty cycles values
     for (size_t i = 0; i < size_dut; i++)
-        if (abs(duty_cycles[i]) > 255) return 0x7F;
+        if (abs(duty_cycles[i]) > MAX_DUTY_CYCLE) return 0x7F;
 
     chipSelect();
     status = _spi->write(CMD_R_ENC_W_VEL);

--- a/firmware/common2015/drivers/fpga/fpga.cpp
+++ b/firmware/common2015/drivers/fpga/fpga.cpp
@@ -219,6 +219,10 @@ uint8_t FPGA::read_duty_cycles(int16_t* duty_cycles, size_t size) {
 uint8_t FPGA::set_duty_cycles(int16_t* duty_cycles, size_t size) {
     uint8_t status;
 
+    if (size != 5) {
+        LOG(WARN, "set_duty_cycles() requires input buffer to be of size 5");
+    }
+
     // Check for valid duty cycles values
     for (size_t i = 0; i < size; i++)
         if (abs(duty_cycles[i]) > MAX_DUTY_CYCLE) return 0x7F;
@@ -240,6 +244,10 @@ uint8_t FPGA::set_duty_cycles(int16_t* duty_cycles, size_t size) {
 uint8_t FPGA::set_duty_get_enc(int16_t* duty_cycles, size_t size_dut,
                                int16_t* enc_deltas, size_t size_enc) {
     uint8_t status;
+
+    if (size_dut != 5 || size_enc != 5) {
+        LOG(WARN, "set_duty_get_enc() requires input buffers to be of size 5");
+    }
 
     // Check for valid duty cycles values
     for (size_t i = 0; i < size_dut; i++)

--- a/firmware/common2015/drivers/fpga/fpga.cpp
+++ b/firmware/common2015/drivers/fpga/fpga.cpp
@@ -250,13 +250,14 @@ uint8_t FPGA::set_duty_get_enc(int16_t* duty_cycles, size_t size_dut,
     }
 
     // Check for valid duty cycles values
-    for (size_t i = 0; i < size_dut; i++)
+    for (size_t i = 0; i < size_dut; i++) {
         if (abs(duty_cycles[i]) > MAX_DUTY_CYCLE) return 0x7F;
+    }
 
     chipSelect();
     status = _spi->write(CMD_R_ENC_W_VEL);
 
-    for (size_t i = 0; i < size_enc; i++) {
+    for (size_t i = 0; i < 5; i++) {
         uint16_t dc = toSignMag<9>(duty_cycles[i]);
 
         uint16_t enc = _spi->write(dc & 0xFF) << 8;

--- a/firmware/common2015/drivers/fpga/fpga.cpp
+++ b/firmware/common2015/drivers/fpga/fpga.cpp
@@ -9,8 +9,8 @@
 #include "software-spi.hpp"
 
 template <size_t SIGN_INDEX>
-int16_t toSignMag(int16_t val) {
-    return (val < 0) ? ((-val) | 1 << SIGN_INDEX) : val;
+uint16_t toSignMag(int16_t val) {
+    return static_cast<uint16_t>((val < 0) ? ((-val) | 1 << SIGN_INDEX) : val);
 }
 
 template <size_t SIGN_INDEX>
@@ -227,7 +227,7 @@ uint8_t FPGA::set_duty_cycles(int16_t* duty_cycles, size_t size) {
     status = _spi->write(CMD_R_ENC_W_VEL);
 
     for (size_t i = 0; i < size; i++) {
-        int16_t dc = toSignMag<9>(duty_cycles[i]);
+        uint16_t dc = toSignMag<9>(duty_cycles[i]);
         _spi->write(dc & 0xFF);
         _spi->write(dc >> 8);
     }
@@ -249,7 +249,7 @@ uint8_t FPGA::set_duty_get_enc(int16_t* duty_cycles, size_t size_dut,
     status = _spi->write(CMD_R_ENC_W_VEL);
 
     for (size_t i = 0; i < size_enc; i++) {
-        int16_t dc = toSignMag<9>(duty_cycles[i]);
+        uint16_t dc = toSignMag<9>(duty_cycles[i]);
 
         int16_t enc = (_spi->write(dc & 0xFF) << 8);
         enc |= _spi->write(dc >> 8);

--- a/firmware/common2015/drivers/fpga/fpga.cpp
+++ b/firmware/common2015/drivers/fpga/fpga.cpp
@@ -14,7 +14,7 @@ uint16_t toSignMag(int16_t val) {
 }
 
 template <size_t SIGN_INDEX>
-int16_t fromSignMag(int16_t val) {
+int16_t fromSignMag(uint16_t val) {
     if (val & 1 << SIGN_INDEX) {
         val ^= 1 << SIGN_INDEX;  // unset sign bit
         val *= -1;               // negate
@@ -206,7 +206,7 @@ uint8_t FPGA::read_duty_cycles(int16_t* duty_cycles, size_t size) {
     status = _spi->write(CMD_READ_DUTY);
 
     for (size_t i = 0; i < size; i++) {
-        int16_t dc = (_spi->write(0x00) << 8);
+        uint16_t dc = _spi->write(0x00) << 8;
         dc |= _spi->write(0x00);
         duty_cycles[i] = fromSignMag<9>(dc);
     }
@@ -251,7 +251,7 @@ uint8_t FPGA::set_duty_get_enc(int16_t* duty_cycles, size_t size_dut,
     for (size_t i = 0; i < size_enc; i++) {
         uint16_t dc = toSignMag<9>(duty_cycles[i]);
 
-        int16_t enc = (_spi->write(dc & 0xFF) << 8);
+        uint16_t enc = _spi->write(dc & 0xFF) << 8;
         enc |= _spi->write(dc >> 8);
         enc_deltas[i] = fromSignMag<15>(enc);
     }

--- a/firmware/common2015/drivers/fpga/fpga.hpp
+++ b/firmware/common2015/drivers/fpga/fpga.hpp
@@ -3,10 +3,10 @@
 #include <mbed.h>
 #include <rtos.h>
 
-#include <string>
 #include <array>
-#include <vector>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "SharedSPI.hpp"
 
@@ -23,11 +23,11 @@ public:
     bool configure(const std::string& filepath);
 
     bool isReady();
-    uint8_t set_duty_get_enc(uint16_t* duty_cycles, size_t size_dut,
-                             uint16_t* enc_deltas, size_t size_enc);
-    uint8_t set_duty_cycles(uint16_t* duty_cycles, size_t size);
-    uint8_t read_duty_cycles(uint16_t* duty_cycles, size_t size);
-    uint8_t read_encs(uint16_t* enc_counts, size_t size);
+    uint8_t set_duty_get_enc(int16_t* duty_cycles, size_t size_dut,
+                             int16_t* enc_deltas, size_t size_enc);
+    uint8_t set_duty_cycles(int16_t* duty_cycles, size_t size);
+    uint8_t read_duty_cycles(int16_t* duty_cycles, size_t size);
+    uint8_t read_encs(int16_t* enc_counts, size_t size);
     uint8_t read_halls(uint8_t* halls, size_t size);
     uint8_t motors_en(bool state);
     uint8_t watchdog_reset();

--- a/firmware/common2015/drivers/fpga/fpga.hpp
+++ b/firmware/common2015/drivers/fpga/fpga.hpp
@@ -35,6 +35,8 @@ public:
     void gate_drivers(std::vector<uint16_t>&);
     bool send_config(const std::string& filepath);
 
+    static const int16_t MAX_DUTY_CYCLE = 511;
+
 private:
     bool _isInit = false;
 

--- a/firmware/robot2015/src-ctrl/modules/ControllerTaskThread.cpp
+++ b/firmware/robot2015/src-ctrl/modules/ControllerTaskThread.cpp
@@ -1,17 +1,17 @@
-#include <rtos.h>
 #include <RPCVariable.h>
+#include <rtos.h>
 
 #include <Console.hpp>
-#include <logger.hpp>
 #include <assert.hpp>
+#include <logger.hpp>
 
+#include "Pid.hpp"
+#include "fpga.hpp"
+#include "io-expander.hpp"
+#include "motors.hpp"
+#include "mpu-6050.hpp"
 #include "robot-devices.hpp"
 #include "task-signals.hpp"
-#include "motors.hpp"
-#include "fpga.hpp"
-#include "mpu-6050.hpp"
-#include "io-expander.hpp"
-#include "Pid.hpp"
 
 const float kpi = 3.14159265358979f;
 
@@ -94,7 +94,7 @@ void Task_Controller(void const* args) {
 
     Pid motor2pid(0.0, 0.0, 0.0);
 
-    std::vector<uint16_t> duty_cycles;
+    std::vector<int16_t> duty_cycles;
 
     const uint16_t kduty_cycle = 0;
     duty_cycles.assign(5, kduty_cycle);
@@ -102,13 +102,13 @@ void Task_Controller(void const* args) {
     size_t ii = 0;
     bool spin_rev = true;
 
-    uint16_t duty_cycle_all = kduty_cycle;
+    int16_t duty_cycle_all = kduty_cycle;
 
     while (true) {
         imu.getGyro(gyroVals);
         imu.getAccelero(accelVals);
 
-        std::vector<uint16_t> enc_deltas(5);
+        std::vector<int16_t> enc_deltas(5);
 
         FPGA::Instance->set_duty_get_enc(duty_cycles.data(), duty_cycles.size(),
                                          enc_deltas.data(),
@@ -152,10 +152,10 @@ void Task_Controller(void const* args) {
 
         const float vel_err = ktarget_vel - kvel;
 
-        uint16_t dc = ktarget_vel * kmultiplier + motor2pid.run(vel_err);
+        int16_t dc = ktarget_vel * kmultiplier + motor2pid.run(vel_err);
 
         // duty cycle values range: 0 -> 511, the 9th bit is direction
-        dc = std::min(dc, static_cast<uint16_t>(511));
+        dc = std::min(dc, static_cast<int16_t>(511));
 
         ii++;
         // if (ii < 20) {
@@ -169,7 +169,7 @@ void Task_Controller(void const* args) {
         // if ((ii % 100) == 0) printf("dc: %u, dt: %f\r\n", dc, kdt);
 
         // set the direction
-        duty_cycle_all |= (spin_rev << 9);
+        if (spin_rev) duty_cycle_all *= -1;
 
         std::fill(duty_cycles.begin(), duty_cycles.end(), duty_cycle_all);
 

--- a/firmware/robot2015/src-ctrl/modules/motors/motors.cpp
+++ b/firmware/robot2015/src-ctrl/modules/motors/motors.cpp
@@ -65,12 +65,11 @@ void motors_show() {
         status_byte & 0x40 ? "[EXPIRED]" : "[OK]     ");
     printf("\033[K    ID\t\tVEL\tHALL\tENC\tDIR\tSTATUS\t\tFAULTS\033E");
     for (size_t i = 0; i < duty_cycles.size() - 1; i++) {
-        printf("\033[K    %s\t%-3u\t%-3u\t%-5u\t%s\t%s\t0x%03X\033E",
-               global_motors.at(i).desc.c_str(), duty_cycles.at(i) & 0x1FF,
-               halls.at(i), enc_deltas.at(i),
-               duty_cycles.at(i) < 0 ? "CW" : "CCW",
+        printf("\033[K    %s\t%-3d\t%-3u\t%-5d\t%s\t%s\t0x%03X\033E",
+               global_motors[i].desc.c_str(), duty_cycles[i], halls[i],
+               enc_deltas[i], duty_cycles[i] < 0 ? "CW" : "CCW",
                (status_byte & (1 << i)) ? "[OK]    " : "[UNCONN]",
-               driver_regs.at(i));
+               driver_regs[i]);
     }
     printf("\033[K    %s\t%-3u\t%-3u\tN/A\t%s\t%s\t0x%03X\033E",
            global_motors.back().desc.c_str(), duty_cycles.back() & 0x1FF,

--- a/firmware/robot2015/src-ctrl/modules/motors/motors.cpp
+++ b/firmware/robot2015/src-ctrl/modules/motors/motors.cpp
@@ -5,8 +5,8 @@
 #include <Console.hpp>
 #include <numparser.hpp>
 
-#include "fpga.hpp"
 #include "commands.hpp"
+#include "fpga.hpp"
 
 namespace {
 const int NUM_MOTORS = 5;
@@ -32,7 +32,7 @@ void motors_Init() {
 }
 
 void motors_refresh() {
-    std::array<uint16_t, NUM_MOTORS> enc_deltas = {0};
+    std::array<int16_t, NUM_MOTORS> enc_deltas = {0};
     uint8_t status_byte =
         FPGA::Instance->read_encs(enc_deltas.data(), enc_deltas.size());
 
@@ -41,9 +41,9 @@ void motors_refresh() {
 }
 
 void motors_show() {
-    std::array<uint16_t, NUM_MOTORS> duty_cycles = {0};
+    std::array<int16_t, NUM_MOTORS> duty_cycles = {0};
     std::array<uint8_t, NUM_MOTORS> halls = {0};
-    std::array<uint16_t, NUM_MOTORS> enc_deltas = {0};
+    std::array<int16_t, NUM_MOTORS> enc_deltas = {0};
 
     FPGA::Instance->read_duty_cycles(duty_cycles.data(), duty_cycles.size());
     FPGA::Instance->read_halls(halls.data(), halls.size());
@@ -68,13 +68,13 @@ void motors_show() {
         printf("\033[K    %s\t%-3u\t%-3u\t%-5u\t%s\t%s\t0x%03X\033E",
                global_motors.at(i).desc.c_str(), duty_cycles.at(i) & 0x1FF,
                halls.at(i), enc_deltas.at(i),
-               duty_cycles.at(i) & (1 << 9) ? "CW" : "CCW",
+               duty_cycles.at(i) < 0 ? "CW" : "CCW",
                (status_byte & (1 << i)) ? "[OK]    " : "[UNCONN]",
                driver_regs.at(i));
     }
     printf("\033[K    %s\t%-3u\t%-3u\tN/A\t%s\t%s\t0x%03X\033E",
            global_motors.back().desc.c_str(), duty_cycles.back() & 0x1FF,
-           halls.back(), duty_cycles.back() & (1 << 9) ? "CW" : "CCW",
+           halls.back(), duty_cycles.back() < 0 ? "CW" : "CCW",
            (status_byte & (1 << (enc_deltas.size() - 1))) ? "[OK]    "
                                                           : "[UNCONN]",
            driver_regs.back());
@@ -114,9 +114,9 @@ int cmd_motors(const std::vector<std::string>& args) {
 
     else if (strcmp(args.front().c_str(), "set") == 0) {
         if (args.size() == 3) {
-            std::array<uint16_t, NUM_MOTORS> duty_cycles;
+            std::array<int16_t, NUM_MOTORS> duty_cycles;
             uint8_t motor_id = static_cast<uint8_t>(atoi(args.at(1).c_str()));
-            uint16_t new_vel = static_cast<uint16_t>(atoi(args.at(2).c_str()));
+            int16_t new_vel = static_cast<int16_t>(atoi(args.at(2).c_str()));
             // return error if motor id doesn't exist
             if (motor_id > 4) return 2;
             // get the current duty cycles for all motors
@@ -130,7 +130,7 @@ int cmd_motors(const std::vector<std::string>& args) {
                                                 duty_cycles.size());
                 printf("%s velocity set to %u (%s)\r\n",
                        global_motors.at(motor_id).desc.c_str(), new_vel & 0x1FF,
-                       new_vel & (1 << 9) ? "CW" : "CCW");
+                       new_vel < 0 ? "CW" : "CCW");
             } else {
                 // return an error if an invalid duty cycle was given
                 printf("Motor %u does not exist", motor_id);

--- a/firmware/robot2015/src-fpga/src/BLDC/BLDC_Encoder_Counter.v
+++ b/firmware/robot2015/src-fpga/src/BLDC/BLDC_Encoder_Counter.v
@@ -58,7 +58,7 @@ always @( posedge clk ) begin : ENCODER_COUNTER
         if ( count_up == 1 ) begin
             count <= count + 1;
         end else if ( count_down == 1 ) begin
-            count <= count + 1;
+            count <= count - 1;
         end
     end
 


### PR DESCRIPTION
Instead of having to do bit shifting and or-ing to pass negative values to the FPGA class, you can now just pass negative numbers.

The fpga expects numbers to be in sign-magnitude format, which is why we had the bitwise ops before for negative values.  This is now handled in the FPGA C++ class, making code using the fpga cleaner.

TODO:

- [x] test on hardware
- [x] double-check formatting of encoder values read from fpga
- [ ] hall sensor formatting?
- [x] fix duty cycle range-checking in FPGA.cpp - allowed range is [-511,511]?