### PR TITLE
Reduce stack sizes for main and timer threads

### DIFF
--- a/firmware/common2015/CMakeLists.txt
+++ b/firmware/common2015/CMakeLists.txt
@@ -84,11 +84,11 @@ endforeach()
 list(APPEND common2015_INCLUDE_DIRS ${MBED_ASSEC_LIBS_INCLUDES})
 
 # tell cmake that all of the source files aren't here yet
-set_source_files_properties(
-    ${MBED_ASSEC_LIBS_SRCS} PROPERTIES
-    GENERATED               TRUE
-    DEPENDS                 ${MBED_ASSEC_LIBS_DEPENDS}
-)
+# set_source_files_properties(
+#     ${MBED_ASSEC_LIBS_SRCS} PROPERTIES
+#     GENERATED               TRUE
+#     DEPENDS                 ${MBED_ASSEC_LIBS_DEPENDS}
+# )
 
 # build the 'common2015' library that contains all the MBED stuff needed for
 # both the base station and robot firmware

--- a/firmware/common2015/drivers/cc1201/CC1201.cpp
+++ b/firmware/common2015/drivers/cc1201/CC1201.cpp
@@ -122,7 +122,7 @@ int32_t CC1201::getData(std::vector<uint8_t>* buf) {
             strobe(CC1201_STROBE_SRX);
             return COMM_DEV_BUF_ERR;
         }
-        for (int i = 0; i < size_byte; i++) {
+        for (uint8_t i = 0; i < size_byte; i++) {
             buf->push_back(_spi->write(CC1201_STROBE_SNOP));
         }
         chipDeselect();

--- a/firmware/mbed/CMakeLists.txt
+++ b/firmware/mbed/CMakeLists.txt
@@ -4,9 +4,9 @@ set(ARM_TOOLCHAIN_FILE ${ARM_TOOLCHAIN_FILE} PARENT_SCOPE)
 
 # create a list of which accessory libraries we want to download and add to the common2015 library
 set(MBED_ASSEC_LIBS
-    "${CMAKE_CURRENT_LIST_DIR}/burst-spi.cmake"
-    "${CMAKE_CURRENT_LIST_DIR}/modserial.cmake"
-    "${CMAKE_CURRENT_LIST_DIR}/moddma.cmake"
+    # "${CMAKE_CURRENT_LIST_DIR}/burst-spi.cmake"
+    # "${CMAKE_CURRENT_LIST_DIR}/modserial.cmake"
+    # "${CMAKE_CURRENT_LIST_DIR}/moddma.cmake"
     # "${CMAKE_CURRENT_LIST_DIR}/software-spi.cmake"
     # "${CMAKE_CURRENT_LIST_DIR}/software-i2c.cmake"
     # "${CMAKE_CURRENT_LIST_DIR}/pixelarray.cmake"

--- a/firmware/mbed/arm_mbed.cmake
+++ b/firmware/mbed/arm_mbed.cmake
@@ -177,8 +177,9 @@ ExternalProject_Add(mbed_libraries
     BUILD_COMMAND       ${MBED_REPO_DIR}/workspace_tools/build.py
                                 --mcu=${MBED_PLATFORM_UPPERC}
                                 --tool=${MBED_TOOLCHAIN}
+                                # smaller stacks for main and timer threads
                                 -DOS_MAINSTKSIZE=1500 # default is 2048
-                                -DOS_TIMERSTKSZ=400 # default is 512
+                                -DOS_TIMERSTKSZ=300 # default is 512
                                 ${MBED_OPT_LIBS}
     INSTALL_COMMAND     ""
     UPDATE_COMMAND      ""

--- a/firmware/mbed/arm_mbed.cmake
+++ b/firmware/mbed/arm_mbed.cmake
@@ -177,6 +177,8 @@ ExternalProject_Add(mbed_libraries
     BUILD_COMMAND       ${MBED_REPO_DIR}/workspace_tools/build.py
                                 --mcu=${MBED_PLATFORM_UPPERC}
                                 --tool=${MBED_TOOLCHAIN}
+                                -DOS_MAINSTKSIZE=1500 # default is 2048
+                                -DOS_TIMERSTKSZ=400 # default is 512
                                 ${MBED_OPT_LIBS}
     INSTALL_COMMAND     ""
     UPDATE_COMMAND      ""

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -236,7 +236,8 @@ int main() {
         ballSenseStatusLED = !ballSense.have_ball();
 
         // Pack errors into bitmask
-        errorBitmask |= (!global_radio || !global_radio->isConnected()) << RJ_ERR_LED_RADIO;
+        errorBitmask |= (!global_radio || !global_radio->isConnected())
+                        << RJ_ERR_LED_RADIO;
 
         motors_refresh();
 

--- a/firmware/robot2015/src-ctrl/main.cpp
+++ b/firmware/robot2015/src-ctrl/main.cpp
@@ -236,7 +236,7 @@ int main() {
         ballSenseStatusLED = !ballSense.have_ball();
 
         // Pack errors into bitmask
-        errorBitmask |= !global_radio->isConnected() << RJ_ERR_LED_RADIO;
+        errorBitmask |= (!global_radio || !global_radio->isConnected()) << RJ_ERR_LED_RADIO;
 
         motors_refresh();
 

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
@@ -144,7 +144,11 @@ static const vector<command_t> commands = {
 
     {{"ps"}, false, cmd_ps, "list the active threads.", "ps"},
 
-    {{"heapfill"}, false, cmd_heapfill, "Check how large of a block is available on the heap", "heapfill"},
+    {{"heapfill"},
+     false,
+     cmd_heapfill,
+     "Check how large of a block is available on the heap",
+     "heapfill"},
 
     {{"radio"},
      false,
@@ -885,7 +889,7 @@ int cmd_heapfill(cmd_args_t& args) {
     int count = 1;
     while (true) {
         void* buf = malloc(count);
-        if (!buf){
+        if (!buf) {
             printf("failed to allocate %d bytes\r\n", count);
             break;
         } else {

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.cpp
@@ -144,6 +144,8 @@ static const vector<command_t> commands = {
 
     {{"ps"}, false, cmd_ps, "list the active threads.", "ps"},
 
+    {{"heapfill"}, false, cmd_heapfill, "Check how large of a block is available on the heap", "heapfill"},
+
     {{"radio"},
      false,
      cmd_radio,
@@ -868,6 +870,29 @@ int cmd_ps(cmd_args_t& args) {
         }
 
         printf("==============\r\nTotal Threads:\t%u\r\n", num_threads);
+    }
+
+    return 0;
+}
+
+int cmd_heapfill(cmd_args_t& args) {
+    if (!args.empty()) {
+        show_invalid_args(args);
+        return 1;
+    }
+
+    printf("Testing heap size...\r\n");
+    int count = 1;
+    while (true) {
+        void* buf = malloc(count);
+        if (!buf){
+            printf("failed to allocate %d bytes\r\n", count);
+            break;
+        } else {
+            printf("allocated %d bytes\r\n", count);
+        }
+        count++;
+        free(buf);
     }
 
     return 0;

--- a/firmware/robot2015/src-ctrl/modules/commands/commands.hpp
+++ b/firmware/robot2015/src-ctrl/modules/commands/commands.hpp
@@ -93,6 +93,7 @@ int cmd_log_level(cmd_args_t&);
 int cmd_ls(cmd_args_t&);
 int cmd_ping(cmd_args_t&);
 int cmd_ps(cmd_args_t&);
+int cmd_heapfill(cmd_args_t& args);
 int cmd_radio(cmd_args_t&);
 int cmd_ping(cmd_args_t&);
 int cmd_pong(cmd_args_t&);


### PR DESCRIPTION
This doesn't fix the crash/reboot problem entirely, but it seems to make it happen less often.  The mbed build script allows you to pass macro definitions on the command line, so I added entries for OS_MAINSTKSIZE and TIMERSTKSZ in arm_mbed.cmake.  I'm not sure how small we can get away with for these because the `ps` command shows that those threads use 100% of their stack.  I'm sure this isn't correct, but I don't know how to get better numbers.

I also added a "heapfill" command that lets you get a rough idea of how much space is available on the heap.

Related to #686 

cc @JNeiger 