### PR TITLE
Add logging on Referee data protobuf

### DIFF
--- a/common/protobuf/LogFrame.proto
+++ b/common/protobuf/LogFrame.proto
@@ -1,5 +1,6 @@
 package Packet;
 
+import "referee.proto";
 import "Point.proto";
 import "messages_robocup_ssl_wrapper.proto";
 import "RadioTx.proto";
@@ -88,8 +89,11 @@ message LogFrame
 	
 	// Network packets received since the last iteration
 	repeated SSL_WrapperPacket raw_vision = 1;
-	repeated bytes raw_referee = 2;
+	repeated SSL_Referee raw_refbox = 27;
 	repeated RadioRx radio_rx = 3;
+
+	// Deprecated field kept for compatability with old logs
+	repeated bytes raw_referee = 2;
 
 	// Which team are we playing as?
 	optional bool blue_team = 4;

--- a/soccer/LogViewer.cpp
+++ b/soccer/LogViewer.cpp
@@ -182,7 +182,7 @@ bool LogViewer::exportBSV(char* logFilename, char* bsvFilename) {
         SSL_Referee_Stage stage;
         SSL_Referee_Command command;
 
-        if (currentFrame->raw_referee_size() > 0) {
+        if (currentFrame->raw_refbox_size() > 0) {
             SSL_Referee referee = currentFrame->raw_refbox(0);
 
             stage = referee.stage();

--- a/soccer/LogViewer.cpp
+++ b/soccer/LogViewer.cpp
@@ -12,8 +12,6 @@
 #include <algorithm>
 #include <fcntl.h>
 
-#include <iostream>
-
 using namespace std;
 using namespace boost;
 using namespace Packet;

--- a/soccer/LogViewer.cpp
+++ b/soccer/LogViewer.cpp
@@ -1,5 +1,4 @@
 #include <LogViewer.hpp>
-#include <ProtobufTree.hpp>
 
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <protobuf/LogFrame.pb.h>

--- a/soccer/LogViewer.cpp
+++ b/soccer/LogViewer.cpp
@@ -183,10 +183,7 @@ bool LogViewer::exportBSV(char* logFilename, char* bsvFilename) {
         SSL_Referee_Command command;
 
         if (currentFrame->raw_referee_size() > 0) {
-            const string raw_referee = currentFrame->raw_referee(0);
-
-            SSL_Referee referee;
-            referee.ParsePartialFromString(raw_referee);
+            SSL_Referee referee = currentFrame->raw_refbox(0);
 
             stage = referee.stage();
             command = referee.command();

--- a/soccer/LogViewer.cpp
+++ b/soccer/LogViewer.cpp
@@ -187,6 +187,8 @@ bool LogViewer::exportBSV(char* logFilename, char* bsvFilename) {
 
             stage = referee.stage();
             command = referee.command();
+        } else {
+            fprintf(stderr, "No Ref Data\n");
         }
 
         outFrame << matchID << BAR << timestamp << BAR << stage << BAR

--- a/soccer/LogViewer.hpp
+++ b/soccer/LogViewer.hpp
@@ -7,6 +7,9 @@
 #include <QTimer>
 #include <vector>
 
+#define BAR "|"
+#define MATCH_ID_LENGTH 32
+
 class LogViewer : public QMainWindow {
     Q_OBJECT;
 
@@ -17,6 +20,8 @@ public:
 
     void frameNumber(int value) { _doubleFrameNumber = value; }
 
+    bool exportBSV(char* logFilename, char* bsvFilename);
+    bool launchGUI(const char* logFilename);
     // This is called when
     bool readFrames(const char* filename);
 
@@ -57,4 +62,6 @@ private:
     // Tree items that are not in LogFrame
     QTreeWidgetItem* _frameNumberItem;
     QTreeWidgetItem* _elapsedTimeItem;
+
+    void generateMatchID(char* id);
 };

--- a/soccer/NewRefereeModule.cpp
+++ b/soccer/NewRefereeModule.cpp
@@ -165,9 +165,6 @@ void NewRefereeModule::run() {
         _mutex.lock();
         _packets.push_back(packet);
 
-        // SSL_Referee* ref = _state.logFrame->add_raw_refbox();
-        // ref->CopyFrom(packet->wrapper);
-
         stage = (Stage)packet->wrapper.stage();
         command = (Command)packet->wrapper.command();
         sent_time = packet->wrapper.packet_timestamp();

--- a/soccer/NewRefereeModule.cpp
+++ b/soccer/NewRefereeModule.cpp
@@ -165,6 +165,9 @@ void NewRefereeModule::run() {
         _mutex.lock();
         _packets.push_back(packet);
 
+        // SSL_Referee* ref = _state.logFrame->add_raw_refbox();
+        // ref->CopyFrom(packet->wrapper);
+
         stage = (Stage)packet->wrapper.stage();
         command = (Command)packet->wrapper.command();
         sent_time = packet->wrapper.packet_timestamp();

--- a/soccer/NewRefereeModule.hpp
+++ b/soccer/NewRefereeModule.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <protobuf/referee.pb.h>
+#include <protobuf/LogFrame.pb.h>
 #include "TeamInfo.hpp"
 #include "GameState.hpp"
 #include "SystemState.hpp"

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -386,11 +386,11 @@ void Processor::run() {
             delete packet;
         }
 
-
         // Log referee data
         vector<NewRefereePacket*> refereePackets;
         _refereeModule.get()->getPackets(refereePackets);
-        fprintf(stderr, "Ref packets received this loop:%lu\n", refereePackets.size());
+        fprintf(stderr, "Ref packets received this loop:%lu\n",
+                refereePackets.size());
         for (NewRefereePacket* packet : refereePackets) {
             SSL_Referee* log = _state.logFrame->add_raw_refbox();
             log->CopyFrom(packet->wrapper);
@@ -399,8 +399,6 @@ void Processor::run() {
         // Update gamestate w/ referee data
         _refereeModule->updateGameState(blueTeam());
         _refereeModule->spinKickWatcher();
-
-
 
         string yellowname, bluename;
 

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -386,9 +386,21 @@ void Processor::run() {
             delete packet;
         }
 
+
+        // Log referee data
+        vector<NewRefereePacket*> refereePackets;
+        _refereeModule.get()->getPackets(refereePackets);
+        fprintf(stderr, "Ref packets received this loop:%lu\n", refereePackets.size());
+        for (NewRefereePacket* packet : refereePackets) {
+            SSL_Referee* log = _state.logFrame->add_raw_refbox();
+            log->CopyFrom(packet->wrapper);
+        }
+
         // Update gamestate w/ referee data
         _refereeModule->updateGameState(blueTeam());
         _refereeModule->spinKickWatcher();
+
+
 
         string yellowname, bluename;
 

--- a/soccer/gameplay/skills/pass_receive.py
+++ b/soccer/gameplay/skills/pass_receive.py
@@ -15,8 +15,8 @@ import skills
 # Set its 'ball_kicked' property to True to tell it to dynamically update its position based on where
 # the ball is moving and attempt to catch it.
 # It will move to the 'completed' state if it catches the ball, otherwise it will go to 'failed'.
-class PassReceive(
-        single_robot_composite_behavior.SingleRobotCompositeBehavior):
+class PassReceive(single_robot_composite_behavior.SingleRobotCompositeBehavior
+                  ):
 
     ## max difference between where we should be facing and where we are facing (in radians)
     FaceAngleErrorThreshold = 8 * constants.DegreesToRadians
@@ -189,8 +189,7 @@ class PassReceive(
 
     def reset_correct_location(self):
         # Extrapolate center of robot location from kick velocity
-        self.kicked_from = main.ball(
-        ).pos  #- (main.ball().vel / main.ball().vel.mag()) * constants.Robot.Radius * 4
+        self.kicked_from = main.ball().pos  #- (main.ball().vel / main.ball().vel.mag()) * constants.Robot.Radius * 4
         self.kicked_vel = main.ball().vel
 
     def on_enter_receiving(self):


### PR DESCRIPTION
Fixes #710 

Data from the refbox is now stored in a new raw_refbox field in a LogFrame Protobuf.

I derived this branch off of my bsv-export branch because I needed my in-progress BSV exporter to view the referee data, since we don't currently display it in any other place. I'm still adding export fields to the output on the ryan/bsv-export branch, which is why this is a separate pull request.
