### PR TITLE
Fix 14.04 support

### DIFF
--- a/config.docif
+++ b/config.docif
@@ -74,7 +74,7 @@ CACHE_DIRECTORIES+=("${CIRCLE_ARTIFACTS}")
 
 # The script to set up the environment, by default ubuntu.
 # YOU WILL NEED TO USE SUDO TO GET ROOT PRIVLEGES HERE
-SETUP_COMMAND="sudo ./util/ubuntu-setup --yes --firmware && sudo ccache -M 3G"
+SETUP_COMMAND="sudo ./util/ubuntu-setup --yes && sudo ccache -M 3G"
 # SETUP_COMMAND="./ubuntu-setup-script"
 
 # DOCIF can cache baseimages, if you give it files that will force a rebuild if changed.

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -7,7 +7,7 @@ HELP_STR="Usage: ./ubuntu-setup [-y | --yes] [-n | --noclobber] [-c | --clobber]
 \tclobber:\t\tInstall 3rd party repositories
 \tfirmware:\t\tInstall firmware repository
 \tnofirmware:\t\tPrevents installation of firmware deps firmware repository
-\toverwrite-sources-list:\tOverwrites the sources.list with gatech mirrors for faster ubuntu-setup at gatech. Works only on Ubuntu 14.04
+\toverwrite-sources-list:\tOverwrites the sources.list with gatech mirrors for faster ubuntu-setup. Only works on ubuntu > precise.
 \thelp:\t\t\tprint this message!
 
 This script will need root privileges"
@@ -96,7 +96,7 @@ if [ $UID -ne 0 ]; then
 fi
 
 if $OVERWRITE_SOURCES; then
-    read -p "Do you really want to overwrite your sources.list? THIS SHOULD ONLY BE DONE ON UBUNTU 14.04 [yN]: " yn
+    read -p "Do you really want to overwrite your sources.list? THIS SHOULD ONLY BE DONE ON STOCK UBUNTU [yN]: " yn
     case $yn in
         [Yy]* ) ;;
         [Nn]* ) exit;;
@@ -105,20 +105,14 @@ if $OVERWRITE_SOURCES; then
 
     # Copy sources.list to sources.list.old if sources.list.old is empty
     if [ -f "/etc/apt/sources.list" ]; then
-        mv -n /etc/apt/sources.list /etc/apt/sources.list.old
+        cp -n /etc/apt/sources.list /etc/apt/sources.list.old
     else
         echo "A prior /etc/apt/sources.list was not found! This probably means you are on a non-debian based system! To force override, run: touch /etc/apt/sources.list" 1>&2
         exit 1
     fi
 
-    # BE CAREFUL HERE...
-    cat <<EOF >/etc/apt/sources.list
-deb http://www.gtlib.gatech.edu/pub/ubuntu/ trusty main restricted universe
-deb-src http://www.gtlib.gatech.edu/pub/ubuntu/ trusty main restricted universe
-deb http://www.gtlib.gatech.edu/pub/ubuntu/ trusty-security main restricted universe
-deb-src http://www.gtlib.gatech.edu/pub/ubuntu/ trusty-security main restricted universe
-deb http://www.gtlib.gatech.edu/pub/ubuntu/ trusty-updates main restricted universe
-deb-src http://www.gtlib.gatech.edu/pub/ubuntu/ trusty-updates main restricted universe
+    # Cross our fingers...
+    sed -i 's%^\s*\([^#]\S\+\)\s\+\S\+%\1 mirror://mirrors.ubuntu.com/mirrors.txt%' /etc/apt/sources.list
 EOF
 
 fi

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -123,6 +123,10 @@ EOF
 
 fi
 
+if $FIRMWARE; then
+    sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
+fi
+
 if $ADD_REPOS; then
     # add repo for backport of cmake3 from debian testing
     # TODO remove this once ubuntu ships cmake3
@@ -151,14 +155,17 @@ if $YES; then
     ARGS="-y"
 fi
 
+PACKAGES="$(sed 's/#.*//;/^$/d' $BASE/util/ubuntu-packages.txt)"
+
 if $FIRMWARE; then
     # This is kind of hacky and could produce unwanted side effects
     # If the firmware switch does more things, it may be better to make a firmware-deps file!
-    ARGS="$ARGS gcc-arm-none-eabi"
+    PACKAGES="$PACKAGES gcc-arm-embedded"
+    PACKAGES="$(sed 's/gcc-arm-none-eabi//' <<< "$PACKAGES")"
 fi
 
 # install all of the packages listed in required_packages.txt
-apt-get install $ARGS $(sed 's/#.*//;/^$/d' $BASE/util/ubuntu-packages.txt)
+apt-get install $ARGS $PACKAGES
 
 # Use ubuntu's 'update-alternatives' to select the newer compiler as the default
 # See issue #468 on GitHub


### PR DESCRIPTION
Closes #696

@ryanstrat could you check out the jay/14.04 branch on your computer and rerun ubuntu setup, and see if that works? 

If you've prevously run ubuntu-setup (on an older commit) could you run `sudo apt-get remove gcc-arm-none-eabi` before trying again?

I _think_ this works on a fresh install of 14.04, according to docker. I'm not going to change the CI because I'm too lazy, and this is way less hacky.

It dosen't seem to be working on the firmware build due to missing `strtok_r`? @justbuchanan do you know anything about this?

`#include <string.h>` dosen't fix it.

```
/home/developer/project/firmware/robot2015/src-ctrl/modules/ControllerTaskThread.cpp: In function 'void Task_Controller(const void*)':
/home/developer/project/firmware/robot2015/src-ctrl/modules/ControllerTaskThread.cpp:150:90: note: #pragma message: TODO: remeasure the duty cycle and rad / s relationship of the motor
/home/developer/project/firmware/robot2015/src-ctrl/modules/commands/commands.cpp: In function 'void execute_line(char*)':
/home/developer/project/firmware/robot2015/src-ctrl/modules/commands/commands.cpp:1125:51: error: 'strtok_r' was not declared in this scope
     char* cmds = strtok_r(rawCommand, ";", &endCmd);
                                                   ^
firmware/robot2015/src-ctrl/CMakeFiles/robot2015_elf.dir/build.make:158: recipe for target 'firmware/robot2015/src-ctrl/CMakeFiles/robot2015_elf.dir/modules/commands/commands.cpp.o' failed
make[4]: *** [firmware/robot2015/src-ctrl/CMakeFiles/robot2015_elf.dir/modules/commands/commands.cpp.o] Error 1
make[4]: *** Waiting for unfinished jobs....
/home/developer/project/firmware/robot2015/src-ctrl/main.cpp: In function 'int main()':
/home/developer/project/firmware/robot2015/src-ctrl/main.cpp:138:10: warning: unused variable 'kickerReady' [-Wunused-variable]
     bool kickerReady = kickerBoard.flash(true, true);
          ^
CMakeFiles/Makefile2:1124: recipe for target 'firmware/robot2015/src-ctrl/CMakeFiles/robot2015_elf.dir/all' failed
make[3]: *** [firmware/robot2015/src-ctrl/CMakeFiles/robot2015_elf.dir/all] Error 2
CMakeFiles/Makefile2:1067: recipe for target 'firmware/robot2015/src-ctrl/CMakeFiles/robot2015.dir/rule' failed
make[2]: *** [firmware/robot2015/src-ctrl/CMakeFiles/robot2015.dir/rule] Error 2
Makefile:415: recipe for target 'robot2015' failed
make[1]: *** [robot2015] Error 2
makefile:104: recipe for target 'robot2015' failed
make: *** [robot2015] Error 2
```