### PR TITLE
Simple_logger now logs protobuf ref packets

### DIFF
--- a/logging/simple_logger.cpp
+++ b/logging/simple_logger.cpp
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]) {
         logFrame.Clear();
         logFrame.set_command_time(startTime);
         logFrame.set_timestamp(startTime);
-        logFrame.set_blue_team(false); //Always assume self is Yellow for logs
+        logFrame.set_blue_team(false);  // Always assume self is Yellow for logs
 
         // Check for user input (to exit)
         struct pollfd pfd;
@@ -123,8 +123,7 @@ int main(int argc, char* argv[]) {
                 continue;
             }
 
-            //LogFrame_Robot* robot = logFrame
-
+            // LogFrame_Robot* robot = logFrame
         }
 
         // Read referee data

--- a/logging/simple_logger.cpp
+++ b/logging/simple_logger.cpp
@@ -122,8 +122,6 @@ int main(int argc, char* argv[]) {
                 printf("Bad vision packet of %d bytes\n", n);
                 continue;
             }
-
-            // LogFrame_Robot* robot = logFrame
         }
 
         // Read referee data

--- a/soccer/gameplay/tactics/defense.py
+++ b/soccer/gameplay/tactics/defense.py
@@ -188,8 +188,7 @@ class Defense(composite_behavior.CompositeBehavior):
 
             # start on one edge of our available angle coverage and work counter-clockwise,
             # assigning block lines to the bots as we go
-            spacing = 0.01 if len(
-                threat.assigned_handlers) < 3 else 0.0  # spacing between each bot in radians
+            spacing = 0.01 if len(threat.assigned_handlers) < 3 else 0.0  # spacing between each bot in radians
             total_angle_coverage = sum(angle_widths) + (len(angle_widths) -
                                                         1) * spacing
             start_vec = center_line.delta().normalized()
@@ -453,7 +452,7 @@ class Defense(composite_behavior.CompositeBehavior):
             if subbehavior_name in reqs:
                 subbehavior_req_tree = reqs[subbehavior_name]
                 for r in role_assignment.iterate_role_requirements_tree_leaves(
-                        subbehavior_req_tree):
+                    subbehavior_req_tree):
                     r.previous_shell_id = None
 
         return reqs

--- a/soccer/gameplay/tactics/positions/submissive_defender.py
+++ b/soccer/gameplay/tactics/positions/submissive_defender.py
@@ -13,7 +13,7 @@ import planning_priority
 # The regular defender does a lot of calculations and figures out where it should be
 # This defender lets someone else (the Defense tactic) handle calculations and blocks things based on that
 class SubmissiveDefender(
-        single_robot_composite_behavior.SingleRobotCompositeBehavior):
+    single_robot_composite_behavior.SingleRobotCompositeBehavior):
     class State(Enum):
         ## gets between a particular opponent and the goal.  stays closer to the goal
         marking = 1


### PR DESCRIPTION
There are still further discussions regarding how to properly include filtered vision data, but as far as updating the existing simple logger for compatibility, the work has been completed.

It is also now capable of taking vision data in from the simulator with the -sim flag 