### PR TITLE
Added address filtering for cc1201 in firmware

### DIFF
--- a/firmware/base2015/main.cpp
+++ b/firmware/base2015/main.cpp
@@ -125,8 +125,8 @@ int main() {
             rtp::packet pkt;
             pkt.recv(buf, bufSize);
 
-            // send to the broadcast address so all robots receive it.
-            pkt.header.address = rtp::BROADCAST_ADDRESS;
+            // send to all robots
+            pkt.header.address = rtp::ROBOT_ADDRESS;
 
             // transmit!
             CommModule::Instance->send(pkt);

--- a/firmware/common2015/drivers/cc1201/CC1201.cpp
+++ b/firmware/common2015/drivers/cc1201/CC1201.cpp
@@ -147,6 +147,10 @@ int32_t CC1201::getData(std::vector<uint8_t>* buf) {
     return COMM_SUCCESS;
 }
 
+uint8_t CC1201::setAddress(uint8_t addr) {
+    return writeReg(CC1201_DEV_ADDR, addr);
+}
+
 uint8_t CC1201::readReg(uint16_t addr) {
     ASSERT_IS_ADDR(addr);
 

--- a/firmware/common2015/drivers/cc1201/CC1201.hpp
+++ b/firmware/common2015/drivers/cc1201/CC1201.hpp
@@ -61,6 +61,15 @@ public:
      */
     int32_t getData(std::vector<uint8_t>* buf);
 
+    /**
+     * Sets the address of the device. Any packet not addressed to this address
+     * is filtered out. Packets addressed to the broadcast address 0x00 are
+     * always received.
+     *
+     * @return status byte (same as writeReg())
+     */
+    uint8_t setAddress(uint8_t addr);
+
     void reset();
 
     int32_t selfTest();

--- a/firmware/common2015/drivers/cc1201/cfg/cc1101-compatible.xml
+++ b/firmware/common2015/drivers/cc1201/cfg/cc1101-compatible.xml
@@ -149,6 +149,10 @@
             <Value>0x20</Value>
         </Register>
         <Register>
+            <Name>PKT_CFG1</Name>
+            <Value>0x13</Value>
+        </Register>
+        <Register>
             <Name>PKT_CFG2</Name>
             <Value>0x00</Value>
         </Register>

--- a/firmware/common2015/utils/rtp.hpp
+++ b/firmware/common2015/utils/rtp.hpp
@@ -9,8 +9,8 @@ namespace rtp {
 /// Max packet size.  This is limited by the CC1201 buffer size.
 static const unsigned int MAX_DATA_SZ = 120;
 
-const uint8_t BROADCAST_ADDRESS = 0;
-const uint8_t BASE_STATION_ADDRESS = 1;
+const uint8_t BROADCAST_ADDRESS = 0x00;  // configured by the PKT_CFG1 register
+const uint8_t BASE_STATION_ADDRESS = 0xFF - 1;
 const uint8_t LOOPBACK_ADDRESS = 2;
 
 // The value 0 is a valid robot id, so we have to choose something else to
@@ -97,8 +97,7 @@ public:
     }
 
     template <class T>
-    packet(const std::vector<T>& v, Port p = SINK)
-        : header(p) {
+    packet(const std::vector<T>& v, Port p = SINK) : header(p) {
         for (T val : v) payload.push_back(val);
     }
 

--- a/firmware/common2015/utils/rtp.hpp
+++ b/firmware/common2015/utils/rtp.hpp
@@ -11,6 +11,7 @@ static const unsigned int MAX_DATA_SZ = 120;
 
 const uint8_t BROADCAST_ADDRESS = 0x00;  // configured by the PKT_CFG1 register
 const uint8_t BASE_STATION_ADDRESS = 0xFF - 1;
+const uint8_t ROBOT_ADDRESS = 0x01;  // All robots have the same address
 const uint8_t LOOPBACK_ADDRESS = 2;
 
 // The value 0 is a valid robot id, so we have to choose something else to

--- a/firmware/robot2015/src-ctrl/modules/RadioProtocol.hpp
+++ b/firmware/robot2015/src-ctrl/modules/RadioProtocol.hpp
@@ -31,8 +31,18 @@ public:
 
     ~RadioProtocol() { stop(); }
 
-    /// robot unique id
-    void setUID(uint8_t uid) { _uid = uid; }
+    /** The value 0x00 is a valid uid, but we can't use it as an address because
+     * it's the broadcast address.  Adding 1 to uids to get addresses solves the
+     * problem.
+     */
+    static uint8_t addr2uid(uint8_t addr) { return addr - 1; }
+    static uint8_t uid2addr(uint8_t uid) { return uid + 1; }
+
+    /// Set robot unique id.  Also update address.
+    void setUID(uint8_t uid) {
+        _uid = uid;
+        _radio->setAddress(uid2addr(uid));
+    }
 
     /**
      * Callback that is called whenever a packet is received.  Set this in

--- a/firmware/robot2015/src-ctrl/modules/RadioProtocol.hpp
+++ b/firmware/robot2015/src-ctrl/modules/RadioProtocol.hpp
@@ -27,22 +27,13 @@ public:
           _timeoutTimer(this, &RadioProtocol::_timeout, osTimerOnce) {
         ASSERT(commModule != nullptr);
         ASSERT(radio != nullptr);
+        _radio->setAddress(rtp::ROBOT_ADDRESS);
     }
 
     ~RadioProtocol() { stop(); }
 
-    /** The value 0x00 is a valid uid, but we can't use it as an address because
-     * it's the broadcast address.  Adding 1 to uids to get addresses solves the
-     * problem.
-     */
-    static uint8_t addr2uid(uint8_t addr) { return addr - 1; }
-    static uint8_t uid2addr(uint8_t uid) { return uid + 1; }
-
     /// Set robot unique id.  Also update address.
-    void setUID(uint8_t uid) {
-        _uid = uid;
-        _radio->setAddress(uid2addr(uid));
-    }
+    void setUID(uint8_t uid) { _uid = uid; }
 
     /**
      * Callback that is called whenever a packet is received.  Set this in


### PR DESCRIPTION
Robots now only receive packets from the base station (not from other robots). closes #578

cc @jjones646 