### PR TITLE
updated stylize to 0.3.0

### DIFF
--- a/util/requirements3.txt
+++ b/util/requirements3.txt
@@ -6,4 +6,4 @@ munkres	# provides the 'hungarian algorithm', which we use for robot role assign
 pylint #static checker for python
 pyserial
 
-stylize>=0.2.1 # code reformatting and checkstyling
+stylize>=0.3.0 # code reformatting and checkstyling


### PR DESCRIPTION
The new version changes the way the `--diffbase` option works.  This should fix most of the formatting conflicts we see on pull requests.  See https://github.com/justbuchanan/stylize/pull/19 for more info.