### PR TITLE
Fixed up Arch build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.0.0)
 project("GT RoboJackets RoboCup")
 
-
 # include cmake files in the 'cmake folder'
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -14,7 +13,8 @@ enable_testing()
 include(SetupGTest)
 
 # C++ version
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Because we use ninja, we have to explicitly turn on color output for the compiler
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,16 @@ enable_testing()
 include(SetupGTest)
 
 # C++ version
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if ("${CMAKE_VERSION}" LESS "3.1")
+    # This is to support the CMake version backported to Ubuntu 14.04
+    message("CMAKE_VERSION < 3.1, specifying c++14 flag.")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+else()
+    # This is the more modern way of setting our c++ version
+    message("CMAKE_VERSION >= 3.1, setting CMAKE_CXX_STANDARD to 14.")
+    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON) # Don't fall back to older versions
+endif()
 
 # Because we use ninja, we have to explicitly turn on color output for the compiler
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")

--- a/util/arch-packages.txt
+++ b/util/arch-packages.txt
@@ -49,6 +49,7 @@ libspnav
 
 # joystick library
 sdl
+sdl2
 
 # debugger for MBED code
 arm-none-eabi-gdb


### PR DESCRIPTION
Added a missing sdl2 package and changed our method of specifying C++14.

I grabbed the CMakeLists snippet from [this website](https://crascit.com/2015/03/28/enabling-cxx11-in-cmake) which describes a few different approaches if you want to check those out.

closes  #787