### PR TITLE
Updated label size to make numbers on field more legible.

### DIFF
--- a/soccer/FieldView.cpp
+++ b/soccer/FieldView.cpp
@@ -513,7 +513,7 @@ void FieldView::drawText(QPainter& p, QPointF pos, QString text, bool center) {
     p.save();
     p.translate(pos);
     p.rotate(_textRotation);
-    p.scale(0.016, -0.016);
+    p.scale(0.0131, -0.0131);
 
     if (center) {
         int flags = Qt::AlignHCenter | Qt::AlignVCenter;


### PR DESCRIPTION
Closes #757. Changed label size in the relevant snippet of code from (0.016,-0.016) to (0.0131,-0.0131) to make sure the numbers didn't clip out of the balls while also keeping them large enough to be read comfortably.