### PR TITLE
Fixes a few edge cases in the reloading logic

### DIFF
--- a/soccer/gameplay/main.py
+++ b/soccer/gameplay/main.py
@@ -63,7 +63,7 @@ def init():
                     try:
                         module = importlib.import_module('.'.join(module_path))
                     except:
-                        logging.error("Error reloading module '" + '.'.join(
+                        logging.error("Error creating module '" + '.'.join(
                             module_path) + "': e")
                         traceback.print_exc()
                         return
@@ -85,17 +85,21 @@ def init():
                     containing_dict = sys.modules
                     for modname in module_path[:-1]:
                         containing_dict = containing_dict[modname].__dict__
+                    if module_path[-1] not in containing_dict:
+                        logging.error("failed reloading module '"
+                                    + '.'.join(module_path) + "'")
+                        return
                     module = containing_dict[module_path[-1]]
                     try:
                         module = imp.reload(module)
                     except:
                         logging.error("Error reloading module '" + '.'.join(
-                            module_path) + "': e")
+                            module_path) + "'")
                         traceback.print_exc()
                         return
 
-                    logging.info("reloaded module '" + '.'.join(module_path) +
-                                 "'")
+                    logging.info("reloaded module '"
+                                 + '.'.join(module_path) + "'")
 
                     if is_play:
                         # re-register the new play class
@@ -121,6 +125,10 @@ def init():
             elif event_type == 'deleted':
                 if is_play:
                     node = _play_registry.node_for_module_path(module_path[1:])
+                    if node is None:
+                        logging.error("Error removing module '"
+                                      + '.'.join(module_path) + "'")
+                        return
                     if _root_play.play != None and _root_play.play.__class__.__name__ == node.play_class.__name__:
                         _root_play.drop_current_play()
 

--- a/soccer/gameplay/main.py
+++ b/soccer/gameplay/main.py
@@ -72,9 +72,7 @@ def init():
                     try:
                         play_class = class_import.find_subclasses(module,
                                                                   play.Play)[0]
-                        _play_registry.insert(
-                            module_path[1:], play_class
-                        )  # note: skipping index zero of module_path cuts off the 'plays' part
+                        _play_registry.insert(module_path[1:], play_class)  # note: skipping index zero of module_path cuts off the 'plays' part
                     except IndexError as e:
                         # we'll get an IndexError exception if the module didn't contain any Plays
                         # FIXME: instead, we should unload the module and just log a warning
@@ -87,8 +85,8 @@ def init():
                     for modname in module_path[:-1]:
                         containing_dict = containing_dict[modname].__dict__
                     if module_path[-1] not in containing_dict:
-                        logging.error("failed reloading module '"
-                                    + '.'.join(module_path) + "'")
+                        logging.error("failed reloading module '" + '.'.join(
+                            module_path) + "'")
                         return
                     module = containing_dict[module_path[-1]]
                     try:
@@ -99,8 +97,8 @@ def init():
                         traceback.print_exc()
                         return
 
-                    logging.info("reloaded module '"
-                                 + '.'.join(module_path) + "'")
+                    logging.info("reloaded module '" + '.'.join(module_path) +
+                                 "'")
 
                     if is_play:
                         # re-register the new play class
@@ -119,16 +117,16 @@ def init():
                         _root_play.drop_current_play()
 
                 except Exception as e:
-                    logging.error("EXCEPTION in file modified event: "
-                                  + repr(e))
+                    logging.error("EXCEPTION in file modified event: " + repr(
+                        e))
                     traceback.print_exc()
                     raise e
             elif event_type == 'deleted':
                 if is_play:
                     node = _play_registry.node_for_module_path(module_path[1:])
                     if node is None:
-                        logging.error("Error removing module '"
-                                      + '.'.join(module_path) + "'")
+                        logging.error("Error removing module '" + '.'.join(
+                            module_path) + "'")
                         return
                     if _root_play.play != None and _root_play.play.__class__.__name__ == node.play_class.__name__:
                         _root_play.drop_current_play()

--- a/soccer/gameplay/main.py
+++ b/soccer/gameplay/main.py
@@ -51,7 +51,8 @@ def init():
         # the top-level folders we care about watching
         autoloadables = ['plays', 'skills', 'tactics', 'evaluation']
 
-        if module_path[0] in autoloadables:
+        # Don't load if we aren't a special module or if the filename is hidden
+        if module_path[0] in autoloadables and module_path[-1][0] != '.':
             logging.info('.'.join(module_path) + " " + event_type)
 
             is_play = module_path[0] == 'plays'

--- a/soccer/gameplay/main.py
+++ b/soccer/gameplay/main.py
@@ -65,7 +65,7 @@ def init():
                         module = importlib.import_module('.'.join(module_path))
                     except:
                         logging.error("Error creating module '" + '.'.join(
-                            module_path) + "': e")
+                            module_path) + "':")
                         traceback.print_exc()
                         return
 
@@ -95,7 +95,7 @@ def init():
                         module = imp.reload(module)
                     except:
                         logging.error("Error reloading module '" + '.'.join(
-                            module_path) + "'")
+                            module_path) + "':")
                         traceback.print_exc()
                         return
 
@@ -119,8 +119,8 @@ def init():
                         _root_play.drop_current_play()
 
                 except Exception as e:
-                    logging.error("EXCEPTION in file modified event: " + repr(
-                        e))
+                    logging.error("EXCEPTION in file modified event: "
+                                  + repr(e))
                     traceback.print_exc()
                     raise e
             elif event_type == 'deleted':

--- a/soccer/gameplay/tactics/one_touch_pass.py
+++ b/soccer/gameplay/tactics/one_touch_pass.py
@@ -10,7 +10,6 @@ import evaluation.touchpass_positioning
 import enum
 
 
-
 ## A tactic that causes a robot to pass to another one,
 # who scores on the goal as fast as possible.
 #

--- a/soccer/gameplay/tactics/one_touch_pass.py
+++ b/soccer/gameplay/tactics/one_touch_pass.py
@@ -10,6 +10,7 @@ import evaluation.touchpass_positioning
 import enum
 
 
+
 ## A tactic that causes a robot to pass to another one,
 # who scores on the goal as fast as possible.
 #


### PR DESCRIPTION
See [this](https://github.com/RoboJackets/robocup-software/tree/master/soccer/gameplay#important) for more information

This PR solves a few issues with garbage files causing the play reloading system to crash (I'm affected by this because my editor creates tmp files in the same directory, I could change this, but I would rather fix this in RC since it might affect others too). 

Things fixed:
1. Deleting python (maybe others) files that aren't plays caused a crash
2. Fixed garbage python code in play files from crashing reload (I think)
3. Fixed stray files changed from crashing the reload system
4. Prevent all hidden files from being affected by the play reloading system

Errors I saw before patch:
```
INFO:root:plays.testing..#test_one_touch_pass created
ERROR:root:Error reloading module 'plays.testing..#test_one_touch_pass': e
Traceback (most recent call last):
  File "/home/jay/Code/robocup-software/soccer/gameplay/main.py", line 64, in fswatch_callback
    module = importlib.import_module('.'.join(module_path))
  File "/usr/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 944, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 956, in _find_and_load_unlocked
ImportError: No module named 'plays.testing.'
INFO:root:plays.testing.test_one_touch_pass modified
INFO:root:reloaded module 'plays.testing.test_one_touch_pass'
INFO:root:plays.testing..#test_one_touch_pass deleted
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.5/dist-packages/watchdog/observers/api.py", line 199, in run
    self.dispatch_events(self.event_queue, self.timeout)
  File "/usr/local/lib/python3.5/dist-packages/watchdog/observers/api.py", line 368, in dispatch_events
    handler.dispatch(event)
  File "/usr/local/lib/python3.5/dist-packages/watchdog/events.py", line 330, in dispatch
    _method_map[event_type](event)
  File "/home/jay/Code/robocup-software/soccer/gameplay/fs_watcher.py", line 83, in on_deleted
    self._watcher._notify('deleted', event.src_path)
  File "/home/jay/Code/robocup-software/soccer/gameplay/fs_watcher.py", line 66, in _notify
    subscriber(event_type, modpath)
  File "/home/jay/Code/robocup-software/soccer/gameplay/main.py", line 127, in fswatch_callback
    _play_registry.delete(module_path[1:])
  File "/home/jay/Code/robocup-software/soccer/gameplay/play_registry.py", line 60, in delete
    del node.parent[node.name]
AttributeError: 'NoneType' object has no attribute 'parent'
```

Fixed log:
```
INFO:root:plays.testing.test_one_touch_pass modified
INFO:root:reloaded module 'plays.testing.test_one_touch_pass'
INFO:root:plays.testing.test_one_touch_pass_flymake created
ERROR:root:Error creating module 'plays.testing.test_one_touch_pass_flymake': e
Traceback (most recent call last):
  File "/home/jay/Code/robocup-software/soccer/gameplay/main.py", line 65, in fswatch_callback
    module = importlib.import_module('.'.join(module_path))
  File "/usr/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 956, in _find_and_load_unlocked
ImportError: No module named 'plays.testing.test_one_touch_pass_flymake'
INFO:root:plays.testing.test_one_touch_pass_flymake modified
ERROR:root:failed reloading module 'plays.testing.test_one_touch_pass_flymake'
INFO:root:plays.testing.test_one_touch_pass_flymake deleted
ERROR:root:Error removing module 'plays.testing.test_one_touch_pass_flymake'
INFO:root:tactics.one_touch_pass modified
INFO:root:reloaded module 'tactics.one_touch_pass'
INFO:root:tactics.one_touch_pass_flymake created
INFO:root:tactics.one_touch_pass_flymake modified
ERROR:root:failed reloading module 'tactics.one_touch_pass_flymake'
INFO:root:tactics.one_touch_pass_flymake deleted
```

I think this still needs work though, but this is a good first step.