### PR TITLE
Format Team Labels in Soccer

### DIFF
--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -209,8 +209,7 @@ void MainWindow::addLayer(int i, QString name, bool checked) {
     on_debugLayers_itemChanged(item);
 }
 
-enum Side { Yellow, Blue };
-string formatLabelBold(Side side, string label) {
+string MainWindow::formatLabelBold(Side side, string label) {
     string color;
     // Colors match up with those statically defined in MainWindow.ui
     if (side == Side::Yellow) {

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <ctime>
+#include <string>
 
 #include <google/protobuf/descriptor.h>
 
@@ -206,6 +207,20 @@ void MainWindow::addLayer(int i, QString name, bool checked) {
     item->setData(Qt::UserRole, i);
     _ui.debugLayers->addItem(item);
     on_debugLayers_itemChanged(item);
+}
+
+enum Side { Yellow, Blue };
+string formatLabelBold(Side side, string label) {
+    string color;
+    // Colors match up with those statically defined in MainWindow.ui
+    if (side == Side::Yellow) {
+        color = "#ac9f2d";
+    }
+    else if (side == Side::Blue) {
+        color = "#000064";
+    }
+    //return "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:" + color + "; font-weight: bold;&quot;&gt;" + string + "&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;";
+    return "<html><head/><body><p><span style=\"color:" + color + "; font-weight: bold;\">" + label + "</span></p></body></html>";
 }
 
 void MainWindow::updateViews() {
@@ -415,7 +430,9 @@ void MainWindow::updateViews() {
         _processor->refereeModule()->stage_time_left / 1000.0f, 'f', 2)));
 
     const char* blueName = _processor->refereeModule()->blue_info.name.c_str();
-    _ui.refBlueName->setText(strlen(blueName) == 0 ? "<Blue Team>" : blueName);
+    string blueFormatted = strlen(blueName) == 0 ? "Blue Team" : blueName;
+    blueFormatted = formatLabelBold(Side::Blue, blueFormatted);
+    _ui.refBlueName->setText(QString::fromStdString(blueFormatted));
     _ui.refBlueScore->setText(
         tr("%1").arg(_processor->refereeModule()->blue_info.score));
     _ui.refBlueRedCards->setText(
@@ -429,8 +446,9 @@ void MainWindow::updateViews() {
 
     const char* yellowName =
         _processor->refereeModule()->yellow_info.name.c_str();
-    _ui.refYellowName->setText(strlen(yellowName) == 0 ? "<Yellow Team>"
-                                                       : yellowName);
+    string yellowFormatted = strlen(yellowName) == 0 ? "Yellow Team" : yellowName;
+    yellowFormatted = formatLabelBold(Side::Yellow, yellowFormatted);
+    _ui.refYellowName->setText(QString::fromStdString(yellowFormatted));
     _ui.refYellowScore->setText(
         tr("%1").arg(_processor->refereeModule()->yellow_info.score));
     _ui.refYellowRedCards->setText(

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -215,12 +215,11 @@ string formatLabelBold(Side side, string label) {
     // Colors match up with those statically defined in MainWindow.ui
     if (side == Side::Yellow) {
         color = "#ac9f2d";
-    }
-    else if (side == Side::Blue) {
+    } else if (side == Side::Blue) {
         color = "#000064";
     }
-    //return "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:" + color + "; font-weight: bold;&quot;&gt;" + string + "&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;";
-    return "<html><head/><body><p><span style=\"color:" + color + "; font-weight: bold;\">" + label + "</span></p></body></html>";
+    return "<html><head/><body><p><span style=\"color:" + color +
+           "; font-weight: bold;\">" + label + "</span></p></body></html>";
 }
 
 void MainWindow::updateViews() {
@@ -446,7 +445,8 @@ void MainWindow::updateViews() {
 
     const char* yellowName =
         _processor->refereeModule()->yellow_info.name.c_str();
-    string yellowFormatted = strlen(yellowName) == 0 ? "Yellow Team" : yellowName;
+    string yellowFormatted =
+        strlen(yellowName) == 0 ? "Yellow Team" : yellowName;
     yellowFormatted = formatLabelBold(Side::Yellow, yellowFormatted);
     _ui.refYellowName->setText(QString::fromStdString(yellowFormatted));
     _ui.refYellowScore->setText(

--- a/soccer/MainWindow.hpp
+++ b/soccer/MainWindow.hpp
@@ -17,6 +17,7 @@ class StripChart;
 class ConfigBool;
 
 enum RadioChannels { MHz_916, MHz_918 };
+enum Side { Yellow, Blue };
 /**
  * main gui thread class
  */
@@ -150,6 +151,7 @@ signals:
 
 private:
     void updateStatus();
+    static std::string formatLabelBold(Side side, std::string label);
 
     typedef enum { Status_OK, Status_Warning, Status_Fail } StatusType;
 


### PR DESCRIPTION
Fixes #824 by changing team labels to bold and setting their color to the color of the team that they represent.