### PR TITLE
Changing check for logs directory, playbook default location, and corresponding makefile changes

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,16 +13,16 @@ all:
 	$(call cmake_build_target, all)
 
 run: all
-	cd run; ./soccer
+	./run/soccer
 rs: run-sim
 run-sim: all
 	-pkill -f './simulator --headless'
-	cd run; ./simulator --headless &
-	cd run; ./soccer -sim -pbk example.pbk
+	./run/simulator --headless &
+	./run/soccer -sim -pbk example.pbk
 run-sim2play: all
 	-pkill -f './simulator --headless'
-	cd run; ./simulator --headless &
-	cd run; ./soccer -sim -y & ./soccer -sim -b
+	./run/simulator --headless &
+	./run/soccer -sim -y & ./soccer -sim -b
 
 debug: all
 ifeq ($(shell uname), Linux)
@@ -33,7 +33,7 @@ endif
 
 debug-sim: all
 	-pkill -f './simulator --headless'
-	cd run; ./simulator --headless &
+	./run/simulator --headless &
 ifeq ($(shell uname), Linux)
 	gdb --args ./run/soccer -sim
 else

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -1200,7 +1200,7 @@ void MainWindow::on_saveConfig_clicked() {
 
 void MainWindow::on_loadPlaybook_clicked() {
     QString filename = QFileDialog::getOpenFileName(
-        this, "Load Playbook", "../soccer/gameplay/playbooks/");
+        this, "Load Playbook", "./soccer/gameplay/playbooks/");
     if (!filename.isNull()) {
         try {
             _processor->gameplayModule()->loadPlaybook(filename.toStdString(),
@@ -1214,7 +1214,7 @@ void MainWindow::on_loadPlaybook_clicked() {
 
 void MainWindow::on_savePlaybook_clicked() {
     QString filename = QFileDialog::getSaveFileName(
-        this, "Save Playbook", "../soccer/gameplay/playbooks/");
+        this, "Save Playbook", "./soccer/gameplay/playbooks/");
     if (!filename.isNull()) {
         try {
             _processor->gameplayModule()->savePlaybook(filename.toStdString(),

--- a/soccer/main.cpp
+++ b/soccer/main.cpp
@@ -154,13 +154,13 @@ int main(int argc, char* argv[]) {
 
     win->setUseRefChecked(!noref);
 
-    if (!QDir("logs").exists()) {
+    if (!QDir("./run/logs").exists()) {
         fprintf(stderr, "No logs/ directory - not writing log file\n");
     } else if (!log) {
         fprintf(stderr, "Not writing log file\n");
     } else {
         QString logFile =
-            QString("logs/") +
+            QString("./run/logs/") +
             QDateTime::currentDateTime().toString("yyyyMMdd-hhmmss.log");
         if (!processor->openLog(logFile)) {
             printf("Failed to open %s: %m\n", (const char*)logFile.toLatin1());


### PR DESCRIPTION
Makes the change that was requested in #754. More changes will need to be made to makefile as this breaks logging when using `make run`. Logging will work properly when using `./run/soccer` with this change.