### PR TITLE
Fixed ball velocity bug.

### DIFF
--- a/simulator/physics/Environment.cpp
+++ b/simulator/physics/Environment.cpp
@@ -118,6 +118,10 @@ void Environment::step() {
 void Environment::handleSimCommand(const Packet::SimCommand& cmd) {
     if (!_balls.empty()) {
         if (cmd.has_ball_vel()) {
+            // added because physics engine was maintaining some state
+            // related to velocity causing the ball to keep going even
+            // when we send a command to set velocity to 0.
+            _balls[0]->resetScene();
             _balls[0]->velocity(cmd.ball_vel().x(), cmd.ball_vel().y());
         }
         if (cmd.has_ball_pos()) {


### PR DESCRIPTION
The ball's velocity should have been set to 0 when clicking on a new position for the ball, instead the ball kept rolling in the same direction after moving it with a mouse click. Resetting the ball scene in the simulator when changing velocity seems to work.