### PR TITLE
Refactor refrences to be relative to soccer (in the run directory)

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,16 +13,16 @@ all:
 	$(call cmake_build_target, all)
 
 run: all
-	cd run; ./soccer
+	./run/soccer
 rs: run-sim
 run-sim: all
 	-pkill -f './simulator --headless'
-	cd run; ./simulator --headless &
-	cd run; ./soccer -sim -pbk example.pbk
+	./run/simulator --headless &
+	./run/soccer -sim -pbk example.pbk
 run-sim2play: all
 	-pkill -f './simulator --headless'
-	cd run; ./simulator --headless &
-	cd run; ./soccer -sim -y & ./soccer -sim -b
+	./run/simulator --headless &
+	./run/soccer -sim -y & ./soccer -sim -b
 
 debug: all
 ifeq ($(shell uname), Linux)
@@ -33,7 +33,7 @@ endif
 
 debug-sim: all
 	-pkill -f './simulator --headless'
-	cd run; ./simulator --headless &
+	./run/simulator --headless &
 ifeq ($(shell uname), Linux)
 	gdb --args ./run/soccer -sim
 else

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -1208,7 +1208,7 @@ void MainWindow::on_saveConfig_clicked() {
 
 void MainWindow::on_loadPlaybook_clicked() {
     QString filename = QFileDialog::getOpenFileName(
-        this, "Load Playbook", "../soccer/gameplay/playbooks/");
+        this, "Load Playbook", "./soccer/gameplay/playbooks/");
     if (!filename.isNull()) {
         try {
             _processor->gameplayModule()->loadPlaybook(filename.toStdString(),
@@ -1222,7 +1222,7 @@ void MainWindow::on_loadPlaybook_clicked() {
 
 void MainWindow::on_savePlaybook_clicked() {
     QString filename = QFileDialog::getSaveFileName(
-        this, "Save Playbook", "../soccer/gameplay/playbooks/");
+        this, "Save Playbook", "./soccer/gameplay/playbooks/");
     if (!filename.isNull()) {
         try {
             _processor->gameplayModule()->savePlaybook(filename.toStdString(),

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -1208,7 +1208,8 @@ void MainWindow::on_saveConfig_clicked() {
 
 void MainWindow::on_loadPlaybook_clicked() {
     QString filename = QFileDialog::getOpenFileName(
-        this, "Load Playbook", ApplicationRunDirectory().filePath("../soccer/gameplay/playbooks/"));
+        this, "Load Playbook",
+        ApplicationRunDirectory().filePath("../soccer/gameplay/playbooks/"));
     if (!filename.isNull()) {
         try {
             _processor->gameplayModule()->loadPlaybook(filename.toStdString(),
@@ -1222,7 +1223,8 @@ void MainWindow::on_loadPlaybook_clicked() {
 
 void MainWindow::on_savePlaybook_clicked() {
     QString filename = QFileDialog::getSaveFileName(
-        this, "Save Playbook", ApplicationRunDirectory().filePath("../soccer/gameplay/playbooks/"));
+        this, "Save Playbook",
+        ApplicationRunDirectory().filePath("../soccer/gameplay/playbooks/"));
     if (!filename.isNull()) {
         try {
             _processor->gameplayModule()->savePlaybook(filename.toStdString(),

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -1208,7 +1208,7 @@ void MainWindow::on_saveConfig_clicked() {
 
 void MainWindow::on_loadPlaybook_clicked() {
     QString filename = QFileDialog::getOpenFileName(
-        this, "Load Playbook", "./soccer/gameplay/playbooks/");
+        this, "Load Playbook", ApplicationRunDirectory().filePath("../soccer/gameplay/playbooks/"));
     if (!filename.isNull()) {
         try {
             _processor->gameplayModule()->loadPlaybook(filename.toStdString(),
@@ -1222,7 +1222,7 @@ void MainWindow::on_loadPlaybook_clicked() {
 
 void MainWindow::on_savePlaybook_clicked() {
     QString filename = QFileDialog::getSaveFileName(
-        this, "Save Playbook", "./soccer/gameplay/playbooks/");
+        this, "Save Playbook", ApplicationRunDirectory().filePath("../soccer/gameplay/playbooks/"));
     if (!filename.isNull()) {
         try {
             _processor->gameplayModule()->savePlaybook(filename.toStdString(),

--- a/soccer/joystick/GamepadController.cpp
+++ b/soccer/joystick/GamepadController.cpp
@@ -27,8 +27,11 @@ dpdown:h0.4,dpright:h0.0,dpright:h0.2,dpup:h0.0,dpup:h0.1,leftshoulder:h0.0,\
 dpup:h0.1,leftshoulder:h0.0,leftshoulder:b4,lefttrigger:b6,rightshoulder:b5,\
 righttrigger:b7,leftstick:b10,rightstick:b11,leftx:a0,lefty:a1,rightx:a2,righty:a3,");
     // Attempt to add additional mappings (relative to run)
+    ApplicationRunDirectory();
     if (SDL_GameControllerAddMappingsFromFile(
-            "../external/sdlcontrollerdb/gamecontrollerdb.txt") == -1) {
+            ApplicationRunDirectory()
+            .filePath("../external/sdlcontrollerdb/gamecontrollerdb.txt")
+            .toStdString().c_str()) == -1) {
         cout << "Failed adding additional SDL Gamecontroller Mappings: "
              << SDL_GetError() << endl;
     }

--- a/soccer/joystick/GamepadController.cpp
+++ b/soccer/joystick/GamepadController.cpp
@@ -27,7 +27,6 @@ dpdown:h0.4,dpright:h0.0,dpright:h0.2,dpup:h0.0,dpup:h0.1,leftshoulder:h0.0,\
 dpup:h0.1,leftshoulder:h0.0,leftshoulder:b4,lefttrigger:b6,rightshoulder:b5,\
 righttrigger:b7,leftstick:b10,rightstick:b11,leftx:a0,lefty:a1,rightx:a2,righty:a3,");
     // Attempt to add additional mappings (relative to run)
-    ApplicationRunDirectory();
     if (SDL_GameControllerAddMappingsFromFile(
             ApplicationRunDirectory()
                 .filePath("../external/sdlcontrollerdb/gamecontrollerdb.txt")

--- a/soccer/joystick/GamepadController.cpp
+++ b/soccer/joystick/GamepadController.cpp
@@ -30,8 +30,9 @@ righttrigger:b7,leftstick:b10,rightstick:b11,leftx:a0,lefty:a1,rightx:a2,righty:
     ApplicationRunDirectory();
     if (SDL_GameControllerAddMappingsFromFile(
             ApplicationRunDirectory()
-            .filePath("../external/sdlcontrollerdb/gamecontrollerdb.txt")
-            .toStdString().c_str()) == -1) {
+                .filePath("../external/sdlcontrollerdb/gamecontrollerdb.txt")
+                .toStdString()
+                .c_str()) == -1) {
         cout << "Failed adding additional SDL Gamecontroller Mappings: "
              << SDL_GetError() << endl;
     }

--- a/soccer/main.cpp
+++ b/soccer/main.cpp
@@ -1,4 +1,3 @@
-
 #include <gameplay/GameplayModule.hpp>
 
 #include <stdio.h>
@@ -154,13 +153,13 @@ int main(int argc, char* argv[]) {
 
     win->setUseRefChecked(!noref);
 
-    if (!QDir("./run/logs").exists()) {
-        fprintf(stderr, "No logs/ directory - not writing log file\n");
+    if (!ApplicationRunDirectory().exists("./logs")) {
+        cerr << "No ./run/logs/ directory - not writing log file" << endl;
     } else if (!log) {
-        fprintf(stderr, "Not writing log file\n");
+        cerr << "Not writing log file" << endl;
     } else {
         QString logFile =
-            QString("./run/logs/") +
+            ApplicationRunDirectory().filePath("./logs/") +
             QDateTime::currentDateTime().toString("yyyyMMdd-hhmmss.log");
         if (!processor->openLog(logFile)) {
             printf("Failed to open %s: %m\n", (const char*)logFile.toLatin1());

--- a/soccer/main.cpp
+++ b/soccer/main.cpp
@@ -154,13 +154,13 @@ int main(int argc, char* argv[]) {
 
     win->setUseRefChecked(!noref);
 
-    if (!QDir("logs").exists()) {
+    if (!QDir("./run/logs").exists()) {
         fprintf(stderr, "No logs/ directory - not writing log file\n");
     } else if (!log) {
         fprintf(stderr, "Not writing log file\n");
     } else {
         QString logFile =
-            QString("logs/") +
+            QString("./run/logs/") +
             QDateTime::currentDateTime().toString("yyyyMMdd-hhmmss.log");
         if (!processor->openLog(logFile)) {
             printf("Failed to open %s: %m\n", (const char*)logFile.toLatin1());


### PR DESCRIPTION
This fixes the various hardcoded file paths (relative to the current directory) to instead be relative to the directory where soccer is located, which makes it consistent. 

Closes #831, closes #754, closes #764. Replaces #835

Let me know if you find any other file paths referring to the current directory! Feedback is appreciated. :smile: 