### PR TITLE
Final Goalie Fixes

### DIFF
--- a/soccer/GameState.hpp
+++ b/soccer/GameState.hpp
@@ -144,7 +144,5 @@ public:
         return ballPlacementPoint;
     }
 
-    uint getGoalieId() const{
-        return OurInfo.goalie;
-    }
+    uint getGoalieId() const { return OurInfo.goalie; }
 };

--- a/soccer/GameState.hpp
+++ b/soccer/GameState.hpp
@@ -143,4 +143,8 @@ public:
     Geometry2d::Point getBallPlacementPoint() const {
         return ballPlacementPoint;
     }
+
+    uint getGoalieId() const{
+        return OurInfo.goalie;
+    }
 };

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -721,6 +721,10 @@ void MainWindow::updateStatus() {
     bool haveExternalReferee =
         (curTime - ps.lastRefereeTime) < RJ::Seconds(0.5);
 
+    if(_ui.goalieID->currentIndex() != _processor->state()->gameState.getGoalieId()+1){
+        _ui.goalieID->setCurrentIndex(_processor->state()->gameState.getGoalieId()+1);
+    }
+
     /*if (_autoExternalReferee && haveExternalReferee &&
     !_ui.externalReferee->isChecked())
     {

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -707,17 +707,17 @@ void MainWindow::updateStatus() {
 
     std::vector<int> validIds = _processor->state()->ourValidIds();
 
-    for(int i=1;i<17;i++){
-        //This will need to change if the max number of robots changes
+    for (int i = 1; i < 17; i++) {
+        // This will need to change if the max number of robots changes
         //.stdString()
-        if(std::find(validIds.begin(), validIds.end(), i-1)!=validIds.end()){
-            //The list starts with None so i is 1 higher than the shell id
-            _ui.goalieID->setItemData(i,true,Qt::UserRole);
+        if (std::find(validIds.begin(), validIds.end(), i - 1) !=
+            validIds.end()) {
+            // The list starts with None so i is 1 higher than the shell id
+            _ui.goalieID->setItemData(i, true, Qt::UserRole);
+        } else {
+            _ui.goalieID->setItemData(i, false, Qt::UserRole - 1);
         }
-        else{
-            _ui.goalieID->setItemData(i,false,Qt::UserRole -1);
-        }
-        //std::cout<<_ui.goalieID->itemText(i).toStdString();
+        // std::cout<<_ui.goalieID->itemText(i).toStdString();
     }
 
     if (haveExternalReferee && _autoExternalReferee) {

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -709,7 +709,6 @@ void MainWindow::updateStatus() {
 
     for (int i = 1; i < 17; i++) {
         // This will need to change if the max number of robots changes
-        //.stdString()
         if (std::find(validIds.begin(), validIds.end(), i - 1) !=
             validIds.end()) {
             // The list starts with None so i is 1 higher than the shell id
@@ -717,7 +716,6 @@ void MainWindow::updateStatus() {
         } else {
             _ui.goalieID->setItemData(i, false, Qt::UserRole - 1);
         }
-        // std::cout<<_ui.goalieID->itemText(i).toStdString();
     }
 
     if (haveExternalReferee && _autoExternalReferee) {

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -707,8 +707,7 @@ void MainWindow::updateStatus() {
 
     std::vector<int> validIds = _processor->state()->ourValidIds();
 
-    for (int i = 1; i < 17; i++) {
-        // This will need to change if the max number of robots changes
+    for (int i = 1; i <= Num_Shells; i++) {
         if (std::find(validIds.begin(), validIds.end(), i - 1) !=
             validIds.end()) {
             // The list starts with None so i is 1 higher than the shell id

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -752,12 +752,6 @@ void MainWindow::updateStatus() {
         _ui.goalieID->setEnabled(true);
     }
 
-    /*if (_autoExternalReferee && haveExternalReferee &&
-    !_ui.externalReferee->isChecked())
-    {
-        _ui.externalReferee->setChecked(true);
-    }*/
-
     // Is the processing thread running?
     if (curTime - ps.lastLoopTime > RJ::Seconds(0.1)) {
         // Processing loop hasn't run recently.

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -184,7 +184,7 @@ void MainWindow::initialize() {
     connect(&updateTimer, SIGNAL(timeout()), SLOT(updateViews()));
     updateTimer.start(30);
 
-    _autoExternalReferee=_processor->externalReferee();
+    _autoExternalReferee = _processor->externalReferee();
 }
 
 void MainWindow::logFileChanged() {
@@ -703,14 +703,12 @@ void MainWindow::updateStatus() {
     RJ::Time curTime = RJ::now();
 
     // Determine if we are receiving packets from an external referee
-    bool haveExternalReferee =
-        (curTime - ps.lastRefereeTime) < RJ::Seconds(1);
+    bool haveExternalReferee = (curTime - ps.lastRefereeTime) < RJ::Seconds(1);
 
     std::vector<int> validIds = _processor->state()->ourValidIds();
 
-
     if (haveExternalReferee && _autoExternalReferee) {
-        //External Ref is connected and should be used
+        // External Ref is connected and should be used
         _ui.fastHalt->setEnabled(false);
         _ui.fastStop->setEnabled(false);
         _ui.fastReady->setEnabled(false);
@@ -726,16 +724,20 @@ void MainWindow::updateStatus() {
         _ui.fastKickoffYellow->setEnabled(true);
     }
 
-    if(std::find(validIds.begin(), validIds.end(), _processor->state()->gameState.getGoalieId()) != validIds.end() && haveExternalReferee){
-        //The External Ref is connected and transmitting a valid goalie ID
+    if (std::find(validIds.begin(), validIds.end(),
+                  _processor->state()->gameState.getGoalieId()) !=
+            validIds.end() &&
+        haveExternalReferee) {
+        // The External Ref is connected and transmitting a valid goalie ID
         _ui.goalieID->setEnabled(false);
 
-        //Changes the goalie INDEX which is 1 higher than the goalie ID
-        if(_ui.goalieID->currentIndex() != _processor->state()->gameState.getGoalieId()+1){
-            _ui.goalieID->setCurrentIndex(_processor->state()->gameState.getGoalieId()+1);
+        // Changes the goalie INDEX which is 1 higher than the goalie ID
+        if (_ui.goalieID->currentIndex() !=
+            _processor->state()->gameState.getGoalieId() + 1) {
+            _ui.goalieID->setCurrentIndex(
+                _processor->state()->gameState.getGoalieId() + 1);
         }
-    }
-    else{
+    } else {
         _ui.goalieID->setEnabled(true);
     }
 
@@ -1150,7 +1152,7 @@ void MainWindow::on_goalieID_currentIndexChanged(int value) {
 }
 
 void MainWindow::on_actionUse_External_Referee_toggled(bool value) {
-    _autoExternalReferee=value;
+    _autoExternalReferee = value;
     _processor->externalReferee(value);
 }
 

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -734,10 +734,7 @@ void MainWindow::updateStatus() {
         _ui.fastKickoffYellow->setEnabled(true);
     }
 
-    if (std::find(validIds.begin(), validIds.end(),
-                  _processor->state()->gameState.getGoalieId()) !=
-            validIds.end() &&
-        haveExternalReferee) {
+    if (haveExternalReferee) {
         // The External Ref is connected and transmitting a valid goalie ID
         _ui.goalieID->setEnabled(false);
 

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -707,6 +707,19 @@ void MainWindow::updateStatus() {
 
     std::vector<int> validIds = _processor->state()->ourValidIds();
 
+    for(int i=1;i<17;i++){
+        //This will need to change if the max number of robots changes
+        //.stdString()
+        if(std::find(validIds.begin(), validIds.end(), i-1)!=validIds.end()){
+            //The list starts with None so i is 1 higher than the shell id
+            _ui.goalieID->setItemData(i,true,Qt::UserRole);
+        }
+        else{
+            _ui.goalieID->setItemData(i,false,Qt::UserRole -1);
+        }
+        //std::cout<<_ui.goalieID->itemText(i).toStdString();
+    }
+
     if (haveExternalReferee && _autoExternalReferee) {
         // External Ref is connected and should be used
         _ui.fastHalt->setEnabled(false);

--- a/soccer/MainWindow.cpp
+++ b/soccer/MainWindow.cpp
@@ -721,7 +721,8 @@ void MainWindow::updateStatus() {
     bool haveExternalReferee =
         (curTime - ps.lastRefereeTime) < RJ::Seconds(0.5);
 
-    if(_ui.goalieID->currentIndex() != _processor->state()->gameState.getGoalieId()+1){
+    std::vector<int> validIds = _processor->state()->ourValidIds();
+    if(_ui.goalieID->currentIndex() != _processor->state()->gameState.getGoalieId()+1 && std::find(validIds.begin(), validIds.end(), _processor->state()->gameState.getGoalieId()) != validIds.end()){
         _ui.goalieID->setCurrentIndex(_processor->state()->gameState.getGoalieId()+1);
     }
 

--- a/soccer/NewRefereeModule.hpp
+++ b/soccer/NewRefereeModule.hpp
@@ -214,7 +214,7 @@ protected:
     NewRefereeModuleEnums::Command prev_command;
     NewRefereeModuleEnums::Stage prev_stage;
 
-    bool _useExternalRef = true;
+    bool _useExternalRef = false;
 
     float ballPlacementx;
     float ballPlacementy;

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -401,7 +401,8 @@ void Processor::run() {
         for (NewRefereePacket* packet : refereePackets) {
             SSL_Referee* log = _state.logFrame->add_raw_refbox();
             log->CopyFrom(packet->wrapper);
-            curStatus.lastRefereeTime = std::max(curStatus.lastRefereeTime,packet->receivedTime);
+            curStatus.lastRefereeTime =
+                std::max(curStatus.lastRefereeTime, packet->receivedTime);
             delete packet;
         }
 

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -401,7 +401,7 @@ void Processor::run() {
         for (NewRefereePacket* packet : refereePackets) {
             SSL_Referee* log = _state.logFrame->add_raw_refbox();
             log->CopyFrom(packet->wrapper);
-            curStatus.lastRefereeTime = packet->receivedTime;
+            curStatus.lastRefereeTime = std::max(curStatus.lastRefereeTime,packet->receivedTime);
             delete packet;
         }
 

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -58,7 +58,6 @@ Processor::Processor(bool sim) : _loopMutex() {
     _running = true;
     _manualID = -1;
     _defendPlusX = false;
-    _externalReferee = true;
     _framerate = 0;
     _useOurHalf = true;
     _useOpponentHalf = true;
@@ -402,6 +401,7 @@ void Processor::run() {
         for (NewRefereePacket* packet : refereePackets) {
             SSL_Referee* log = _state.logFrame->add_raw_refbox();
             log->CopyFrom(packet->wrapper);
+            curStatus.lastRefereeTime = packet->receivedTime;
             delete packet;
         }
 

--- a/soccer/Processor.hpp
+++ b/soccer/Processor.hpp
@@ -94,9 +94,9 @@ public:
     bool joystickValid() const;
     JoystickControlValues getJoystickControlValues();
 
-    void externalReferee(bool value) { _externalReferee = value; }
+    void externalReferee(bool value) { _refereeModule->useExternalReferee(value); }
 
-    bool externalReferee() const { return _externalReferee; }
+    bool externalReferee() const { return _refereeModule->useExternalReferee(); }
 
     void manualID(int value);
     int manualID() const { return _manualID; }

--- a/soccer/Processor.hpp
+++ b/soccer/Processor.hpp
@@ -94,9 +94,13 @@ public:
     bool joystickValid() const;
     JoystickControlValues getJoystickControlValues();
 
-    void externalReferee(bool value) { _refereeModule->useExternalReferee(value); }
+    void externalReferee(bool value) {
+        _refereeModule->useExternalReferee(value);
+    }
 
-    bool externalReferee() const { return _refereeModule->useExternalReferee(); }
+    bool externalReferee() const {
+        return _refereeModule->useExternalReferee();
+    }
 
     void manualID(int value);
     int manualID() const { return _manualID; }

--- a/soccer/Processor.hpp
+++ b/soccer/Processor.hpp
@@ -242,9 +242,6 @@ private:
     // Processing period in microseconds
     RJ::Seconds _framePeriod = RJ::Seconds(1) / 60;
 
-    // True if we are using external referee packets
-    bool _externalReferee;
-
     /// Measured framerate
     float _framerate;
 

--- a/soccer/SystemState.cpp
+++ b/soccer/SystemState.cpp
@@ -228,3 +228,13 @@ void SystemState::drawSegment(const Geometry2d::Segment& line, const QColor& qc,
     *dbg->add_points() = line.pt[1];
     dbg->set_color(color(qc));
 }
+
+std::vector<int> SystemState::ourValidIds() {
+    std::vector<int> validIds;
+    for (int i = 0; i < self.size(); i++) {
+        if (self[i]->visible) {
+            validIds.push_back(self[i]->shell());
+        }
+    }
+    return validIds;
+}

--- a/soccer/SystemState.hpp
+++ b/soccer/SystemState.hpp
@@ -147,6 +147,8 @@ public:
     /// Returns the number of a debug layer given its name
     int findDebugLayer(QString layer);
 
+    std::vector<int> ourValidIds();
+
 private:
     /// Map from debug layer name to ID
     QMap<QString, int> _debugLayerMap;

--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -597,7 +597,8 @@ BOOST_PYTHON_MODULE(robocup) {
         .def("stay_on_side", &GameState::stayOnSide)
         .def("stay_behind_penalty_line", &GameState::stayBehindPenaltyLine)
         .def("is_our_restart", &GameState::isOurRestart)
-        .def("get_ball_placement_point", &GameState::getBallPlacementPoint);
+        .def("get_ball_placement_point", &GameState::getBallPlacementPoint)
+        .def("get_goalie_id", &GameState::getGoalieId);
 
     class_<Robot>("Robot", init<int, bool>())
         .def("shell_id", &Robot::shell)

--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -614,7 +614,6 @@ BOOST_PYTHON_MODULE(robocup) {
         .add_property("visible", &Robot::visible)
         .def("__repr__", &Robot_repr)
         .def("__eq__", &Robot::operator==);
-    
 
     class_<OurRobot, OurRobot*, bases<Robot>, boost::noncopyable>(
         "OurRobot", init<int, SystemState*>())
@@ -653,17 +652,14 @@ BOOST_PYTHON_MODULE(robocup) {
         .def("add_local_obstacle", &OurRobot_add_local_obstacle)
         .def_readwrite("is_penalty_kicker", &OurRobot::isPenaltyKicker)
         .def_readwrite("is_ball_placer", &OurRobot::isBallPlacer);
-    
 
     class_<OpponentRobot, OpponentRobot*, std::shared_ptr<OpponentRobot>,
            bases<Robot>>("OpponentRobot", init<int>());
-  
 
     class_<Ball, std::shared_ptr<Ball>>("Ball", init<>())
         .def_readonly("pos", &Ball::pos)
         .def_readonly("vel", &Ball::vel)
         .def_readonly("valid", &Ball::valid);
-   
 
     class_<std::vector<Robot*>>("vector_Robot")
         .def(vector_indexing_suite<std::vector<Robot*>>())
@@ -694,7 +690,6 @@ BOOST_PYTHON_MODULE(robocup) {
         .def("draw_arc", &State_draw_arc)
         .def("draw_raw_polygon", &State_draw_raw_polygon)
         .def("draw_arc", &State_draw_arc);
-  
 
     class_<Field_Dimensions>("Field_Dimensions")
         .add_property("Length", &Field_Dimensions::Length)
@@ -766,24 +761,20 @@ BOOST_PYTHON_MODULE(robocup) {
         .def("nameLookup", &Configuration::nameLookup,
              return_value_policy<reference_existing_object>())
         .staticmethod("FromRegisteredConfigurables");
-  
 
     // Add wrappers for ConfigItem subclasses
     class_<ConfigBool, ConfigBool*, bases<ConfigItem>>("ConfigBool", no_init)
         .add_property("value", &ConfigBool::value, &ConfigBool::setValue)
         .def("__str__", &ConfigBool::toString);
-  
 
     class_<ConfigDouble, ConfigDouble*, bases<ConfigItem>>("ConfigDouble",
                                                            no_init)
         .add_property("value", &ConfigDouble::value, &ConfigDouble::setValue)
         .def("__str__", &ConfigDouble::toString);
-  
 
     class_<ConfigInt, ConfigInt*, bases<ConfigItem>>("ConfigInt", no_init)
         .add_property("value", &ConfigInt::value, &ConfigInt::setValue)
         .def("__str__", &ConfigInt::toString);
- 
 
     class_<MotionConstraints>("MotionConstraints")
         .def_readonly("MaxRobotSpeed", &MotionConstraints::_max_speed)

--- a/soccer/gameplay/role_assignment.py
+++ b/soccer/gameplay/role_assignment.py
@@ -190,7 +190,7 @@ def assign_roles(robots, role_reqs):
             if isinstance(subtree, dict):
                 flatten_tree(subtree, path_prefix + [key])
             elif isinstance(subtree, RoleRequirements):
-                if subtree.required_shell_id == None or subtree.required_shell_id in valid_shell_ids:
+                if subtree.required_shell_id is None or subtree.required_shell_id in valid_shell_ids:
                     role_reqs_list.append(subtree)
                 tree_mapping[subtree] = path_prefix + [key]
             else:

--- a/soccer/gameplay/role_assignment.py
+++ b/soccer/gameplay/role_assignment.py
@@ -185,11 +185,13 @@ def assign_roles(robots, role_reqs):
     # To do our calculations though, we need to have a flat list of RoleRequirements to match to our list of robots
     # The flatten_tree() method does this and keeps track of how to rebuild the tree so we can do so at the end
     def flatten_tree(tree, path_prefix=[]):
+        valid_shell_ids = [bot.shell_id() for bot in robots]
         for key, subtree in tree.items():
             if isinstance(subtree, dict):
                 flatten_tree(subtree, path_prefix + [key])
             elif isinstance(subtree, RoleRequirements):
-                role_reqs_list.append(subtree)
+                if subtree.required_shell_id == None or subtree.required_shell_id in valid_shell_ids:
+                    role_reqs_list.append(subtree)
                 tree_mapping[subtree] = path_prefix + [key]
             else:
                 raise AssertionError("Unknown node type in role_reqs tree: " +


### PR DESCRIPTION
I am recreating this pull request because the old one has more lines of merge errors than I am actually adding code. This pull request:

- [x] Closes #772
- [x] Closes #765
- [x] Closes #761 
- [x] Keeps the previous goalie selected if the external ref goalie id changes to be invalid
- [x] Disables the Ref Shortuct bar IFF an external ref is connected
- [x] Disables the goalie selector IFF the external ref is transmitting a valid goalie id
- [x] Add option for No Goalie
- [x] Grey out Invalid Goalie IDs in the dropdown menu

Continuation of #777 and #774 and #783