### PR TITLE
Fix maxSpeed on PivotPlanner

### DIFF
--- a/soccer/planning/PivotPathPlanner.cpp
+++ b/soccer/planning/PivotPathPlanner.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<Path> PivotPathPlanner::run(PlanRequest& planRequest) {
         // maxSpeed = maxRadians * radius
         MotionConstraints newConstraints = planRequest.constraints.mot;
         newConstraints.maxSpeed = std::min(
-            newConstraints.maxSpeed, rotationConstraints.maxSpeed / 2 * radius);
+            newConstraints.maxSpeed, rotationConstraints.maxSpeed * radius);
 
         float startAngle = pivotPoint.angleTo(startInstant.pos);
         float targetAngle = pivotPoint.angleTo(endTarget);


### PR DESCRIPTION
For some reason I was dividing the rotational speed by 2