### PR TITLE
Add min iterations to rrt

### DIFF
--- a/soccer/planning/LineKickPlanner.hpp
+++ b/soccer/planning/LineKickPlanner.hpp
@@ -19,7 +19,7 @@ namespace Planning {
  */
 class LineKickPlanner : public SingleRobotPathPlanner {
 public:
-    LineKickPlanner() : SingleRobotPathPlanner(false), rrtPlanner(250){};
+    LineKickPlanner() : SingleRobotPathPlanner(false), rrtPlanner(0, 250){};
     virtual std::unique_ptr<Path> run(PlanRequest& planRequest) override;
 
     virtual MotionCommand::CommandType commandType() const override {

--- a/soccer/planning/RRTPlanner.cpp
+++ b/soccer/planning/RRTPlanner.cpp
@@ -19,8 +19,10 @@ using namespace Geometry2d;
 
 namespace Planning {
 
-RRTPlanner::RRTPlanner(int maxIterations)
-    : _maxIterations(maxIterations), SingleRobotPathPlanner(true) {}
+RRTPlanner::RRTPlanner(int minIterations, int maxIterations)
+    : _minIterations(minIterations),
+      _maxIterations(maxIterations),
+      SingleRobotPathPlanner(true) {}
 
 bool RRTPlanner::shouldReplan(const PlanRequest& planRequest,
                               const vector<DynamicObstacle> dynamicObs,
@@ -188,6 +190,7 @@ vector<Point> RRTPlanner::runRRT(MotionInstant start, MotionInstant goal,
     biRRT.setStartState(start.pos);
     biRRT.setGoalState(goal.pos);
     biRRT.setStepSize(*RRTConfig::StepSize);
+    biRRT.setMinIterations(_minIterations);
     biRRT.setMaxIterations(_maxIterations);
     biRRT.setGoalBias(*RRTConfig::StepSize);
 

--- a/soccer/planning/RRTPlanner.hpp
+++ b/soccer/planning/RRTPlanner.hpp
@@ -40,7 +40,7 @@ public:
     /**
      * Constructor taking in the max iterations the RRT planner should run
      */
-    RRTPlanner(int maxIterations);
+    RRTPlanner(int minIterations, int maxIterations);
 
     /**
      * gets the maximum number of iterations for the RRT algorithm
@@ -51,6 +51,9 @@ public:
      * sets the maximum number of iterations for th RRT algorithm
      */
     void maxIterations(int value) { _maxIterations = value; }
+
+    int minIterations() const { return _minIterations; }
+    void minIterations(int value) { _minIterations = value; }
 
     /**
      * Takes in a waypoints and returns a full InterpolatedPath with a generated
@@ -73,9 +76,9 @@ public:
     int reusePathTries = 0;
 
 protected:
-    /// maximum number of rrt iterations to run
+    /// minimum and maximum number of rrt iterations to run
     /// this does not include connect attempts
-    unsigned int _maxIterations;
+    int _minIterations, _maxIterations;
 
     /// Check to see if the previous path (if any) should be discarded and
     /// replaced with a newly-planned one

--- a/soccer/planning/RRTUtil.cpp
+++ b/soccer/planning/RRTUtil.cpp
@@ -32,9 +32,9 @@ void DrawRRT(const RRT::Tree<Point>& rrt, SystemState* state,
         QColor("red"),   QColor("purple"), QColor("orange")};
     QColor color = colors[shellID % colors.size()];
 
-    for (auto* node : rrt.allNodes()) {
-        if (node->parent()) {
-            state->drawLine(Segment(node->state(), node->parent()->state()),
+    for (auto& node : rrt.allNodes()) {
+        if (node.parent()) {
+            state->drawLine(Segment(node.state(), node.parent()->state()),
                             color, QString("RobotRRT%1").arg(shellID));
         }
     }

--- a/soccer/planning/SingleRobotPathPlanner.cpp
+++ b/soccer/planning/SingleRobotPathPlanner.cpp
@@ -30,7 +30,7 @@ std::unique_ptr<SingleRobotPathPlanner> PlannerForCommandType(
     SingleRobotPathPlanner* planner = nullptr;
     switch (type) {
         case MotionCommand::PathTarget:
-            planner = new RRTPlanner(250);
+            planner = new RRTPlanner(100, 250);
             break;
         case MotionCommand::DirectPathTarget:
             planner = new DirectTargetPathPlanner();


### PR DESCRIPTION
As discussed in #697, the old rrt implementation always ran for a fixed number of iterations, while the new one takes the first path it finds. This PR adds a `minIterations` parameter to the rrt so it will now (optionally) search longer in order to try to find a better path.

This value is hardcoded in SingleRobotPathPlanner.cpp next to the old maxIterations parameter. It would probably be good to make these configurable via the gui so you can tune them more easily.