### PR TITLE
Change Kicking back to on Break Beam

### DIFF
--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -292,14 +292,14 @@ void OurRobot::_kick(uint8_t strength) {
     uint8_t max = *config->kicker.maxKick;
     control->set_kcstrength(strength > max ? max : strength);
     control->set_shootmode(Packet::Control::KICK);
-    control->set_triggermode(Packet::Control::IMMEDIATE);
+    control->set_triggermode(Packet::Control::ON_BREAK_BEAM);
 }
 
 void OurRobot::_chip(uint8_t strength) {
     uint8_t max = *config->kicker.maxChip;
     control->set_kcstrength(strength > max ? max : strength);
     control->set_shootmode(Packet::Control::CHIP);
-    control->set_triggermode(Packet::Control::IMMEDIATE);
+    control->set_triggermode(Packet::Control::ON_BREAK_BEAM);
 }
 
 void OurRobot::_unkick() {


### PR DESCRIPTION
Any idea why it was changed in this commit? 
https://github.com/RoboJackets/robocup-software/commit/c609aa93c52077045937e0b5d8049a5353ba6764

I think its actually implemented in firmware. Can someone test this if they get a chance.