### PR TITLE
Temporary workaround for shotObstacle

### DIFF
--- a/soccer/gameplay/skills/_kick.py
+++ b/soccer/gameplay/skills/_kick.py
@@ -23,6 +23,7 @@ class _Kick(single_robot_behavior.SingleRobotBehavior):
         self._aim_target_point = None  # this is what our calculations on the given target boil down to
 
         self.shot_obstacle_ignoring_robots = []
+        self.enable_shot_obstacle = False
 
         self.aim_params = {}
 
@@ -184,4 +185,5 @@ class _Kick(single_robot_behavior.SingleRobotBehavior):
                     bot.add_local_obstacle(obs)
 
     def execute_running(self):
-        self.add_shot_obstacle(self.shot_obstacle_ignoring_robots)
+        if self.enable_shot_obstacle:
+            self.add_shot_obstacle(self.shot_obstacle_ignoring_robots)

--- a/soccer/gameplay/skills/pivot_kick.py
+++ b/soccer/gameplay/skills/pivot_kick.py
@@ -111,7 +111,10 @@ class PivotKick(single_robot_composite_behavior.SingleRobotCompositeBehavior,
             self.remove_subbehavior('aim')
 
     def on_enter_capturing(self):
+        # We disable the shot obstacle in this step just in case we had a
+        # failure and we're restarting this play
         self.enable_shot_obstacle = False
+
         self.remove_aim_behavior()
         self.robot.unkick()
         capture = skills.capture.Capture()

--- a/soccer/gameplay/skills/pivot_kick.py
+++ b/soccer/gameplay/skills/pivot_kick.py
@@ -111,6 +111,7 @@ class PivotKick(single_robot_composite_behavior.SingleRobotCompositeBehavior,
             self.remove_subbehavior('aim')
 
     def on_enter_capturing(self):
+        self.enable_shot_obstacle = False
         self.remove_aim_behavior()
         self.robot.unkick()
         capture = skills.capture.Capture()
@@ -133,6 +134,7 @@ class PivotKick(single_robot_composite_behavior.SingleRobotCompositeBehavior,
         self.robot.set_planning_priority(planning_priority.PIVOT_KICK)
 
     def on_enter_aiming(self):
+        self.enable_shot_obstacle = True
         if not self.has_subbehavior_with_name('aim'):
             aim = skills.aim.Aim()
             self.add_subbehavior(aim, 'aim', required=True)


### PR DESCRIPTION
Only enables the shotObstacle during the kicking and aiming phase of pivot kick instead of the entire time for kicking. Just prevents the constant impossible paths when most of the screen is blocked off while the robot isn't even near the ball while capturing.

Should be replaced with #875