### PR TITLE
Fixes Python Draw Functions

### DIFF
--- a/soccer/gameplay/GameplayModule.cpp
+++ b/soccer/gameplay/GameplayModule.cpp
@@ -361,7 +361,7 @@ void Gameplay::GameplayModule::run() {
 
             getMainModule().attr("set_game_state")(_state->gameState);
 
-            getMainModule().attr("set_system_state")(_state);
+            getMainModule().attr("set_system_state")(&_state);
 
             getMainModule().attr("set_ball")(_state->ball);
 


### PR DESCRIPTION
Closes #878 

Before, only a copy of the global `state` object was passed so it would be reset to the default by the next frame. This should allow the changes to the layers list to be propagated back up to the main `state` variable and allow it to exist across frames.