### PR TITLE
Fix passing issues in two side attack

### DIFF
--- a/soccer/gameplay/plays/offense/two_side_attack.py
+++ b/soccer/gameplay/plays/offense/two_side_attack.py
@@ -46,7 +46,8 @@ class TwoSideAttack(standard_play.StandardPlay):
 
         self.add_transition(
             TwoSideAttack.State.passing, TwoSideAttack.State.kicking,
-            lambda: not 'pass' in [self.subbehaviors_by_name] or self.self.subbehavior_with_name('pass').state == behavior.Behavior.State.completed,
+            lambda: (not self.has_subbehavior_with_name('pass') or
+                     self.subbehavior_with_name('pass').state == behavior.Behavior.State.completed),
             'Pass completed')
 
         self.add_transition(


### PR DESCRIPTION
Fixes a bug where the center robot would always take a direct shot rather than passing to the side, even when the direct shot was infeasible. This was caused by a faulty state transition condition that always returned `True`. Therefore, the play never spent any time in the `passing` state and transitioned immediately from `setup` to `kicking`.

Closes #888 