### PR TITLE
Add support for Ubuntu 16.10

### DIFF
--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -40,6 +40,10 @@ elif cat /etc/os-release | grep -iq '^NAME=.*Ubuntu'; then # We are using a vers
         echo "Ubuntu 16.04 Detected..."
         SYSTEM="ubuntu-16.04"
         ADD_REPOS=false
+    elif cat /etc/os-release | grep -iq '^VERSION=.*16.10'; then # Using Ubuntu 16.10
+        echo "Ubuntu 16.10 Detected..."
+        SYSTEM="ubuntu-16.10"
+        ADD_REPOS=false
     else
         echo "$DISTRO_STR" >&2
         exit 1


### PR DESCRIPTION
This adds support for Ubuntu 16.10 to the `ubuntu-setup` util script. The required dependencies are the same as 16.04. Previously, the setup script failed saying that the current distro was unsupported.