### PR TITLE
Fix rrt build failing when checking out a new version or pulling a new version of rrt without a clean.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,6 @@ include_directories("${PROJECT_SOURCE_DIR}/common") # for headers in common/
 include_directories("${PROJECT_BINARY_DIR}/common") # for generated protobuf headers
 include_directories("${CMAKE_BINARY_DIR}/common") # for generated protobuf headers
 
-include_directories("${PROJECT_SOURCE_DIR}/external/rrt/src") # rrt library TODO is there a better way to do this?
 
 # setup ccache to speed up recompiles.  It's especially useful when switching back and forth
 # between branches where you'd normally have to recompile things many times.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,8 @@ include_directories("${PROJECT_SOURCE_DIR}/common") # for headers in common/
 include_directories("${PROJECT_BINARY_DIR}/common") # for generated protobuf headers
 include_directories("${CMAKE_BINARY_DIR}/common") # for generated protobuf headers
 
+include_directories("${PROJECT_SOURCE_DIR}/external/rrt/src") # rrt library TODO is there a better way to do this?
+
 # setup ccache to speed up recompiles.  It's especially useful when switching back and forth
 # between branches where you'd normally have to recompile things many times.
 # see http://stackoverflow.com/questions/1815688/how-to-use-ccache-with-cmake
@@ -129,6 +131,7 @@ endif()
 
 # run all the other CMakeLists files
 add_subdirectory(common)
+add_subdirectory(external)
 add_subdirectory(soccer)
 add_subdirectory(simulator)
 add_subdirectory(logging)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory(rrt)

--- a/run/.gitignore
+++ b/run/.gitignore
@@ -9,6 +9,7 @@ soccer_tests
 simple_logger
 log_viewer
 log_converter
+rrt-viewer
 radio
 convert_tcpdump
 sslrefbox

--- a/soccer/CMakeLists.txt
+++ b/soccer/CMakeLists.txt
@@ -5,23 +5,7 @@ set(CMAKE_AUTOMOC ON)
 # include Eigen3 for linear algebra
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIR})
 
-# use rrt library from external/ directory
-set(rrt_install_dir ${CMAKE_CURRENT_BINARY_DIR}/rrt)
-set(rrt_lib_path ${rrt_install_dir}/lib/libRRT.a)
-ExternalProject_Add(rrt_project
-    URL ${PROJECT_SOURCE_DIR}/external/rrt
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${rrt_install_dir}
-    BUILD_BYPRODUCTS ${rrt_lib_path}
-)
-set_target_properties(rrt_project PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
-# add rrt library target.  IMPORTED means that it is created externally
-add_library(rrt STATIC IMPORTED)
-set_property(TARGET rrt PROPERTY IMPORTED_LOCATION ${rrt_lib_path})
-add_dependencies(rrt rrt_project)
-
-# include rrt library headers
-include_directories(${rrt_install_dir}/include/)
+# RRT library is included via add_subdirectories above us.
 
 # All sources for the robocup library used for the python module, soccer, and log log viewer
 # Note that main.cpp and LogViewer.cpp aren't present in this list because they're executable-specific
@@ -149,7 +133,7 @@ target_link_libraries(robocup GL GLU glut)
 target_link_libraries(robocup pthread)
 target_link_libraries(robocup spnav)
 target_link_libraries(robocup ${SDL2_LIBRARIES})
-target_link_libraries(robocup rrt)
+
 
 # python
 # note: these are set in the root CMakeLists.txt file
@@ -183,7 +167,6 @@ else()
 endif()
 qt5_use_modules(soccer Widgets Xml Core OpenGL Network Svg)
 target_link_libraries(soccer robocup)
-
 
 # build the 'log_viewer' program
 qt5_add_resources(LOG_VIEWER_RSRC ui/log_icons.qrc)

--- a/soccer/CMakeLists.txt
+++ b/soccer/CMakeLists.txt
@@ -5,8 +5,6 @@ set(CMAKE_AUTOMOC ON)
 # include Eigen3 for linear algebra
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIR})
 
-# RRT library is included via add_subdirectories above us.
-
 # All sources for the robocup library used for the python module, soccer, and log log viewer
 # Note that main.cpp and LogViewer.cpp aren't present in this list because they're executable-specific
 set(ROBOCUP_LIB_SRC
@@ -133,6 +131,11 @@ target_link_libraries(robocup GL GLU glut)
 target_link_libraries(robocup pthread)
 target_link_libraries(robocup spnav)
 target_link_libraries(robocup ${SDL2_LIBRARIES})
+
+
+# RRT
+include_directories(${RRT_INCLUDE_DIR})
+target_link_libraries(robocup RRT)
 
 
 # python


### PR DESCRIPTION
I think I fixed the build issues with the rrt. This needs cleanup and verifications though. 

There's an rrt update, included in this pr too.