### PR TITLE
Fix rotation bug when halting during stop play

### DIFF
--- a/soccer/gameplay/main.py
+++ b/soccer/gameplay/main.py
@@ -48,7 +48,6 @@ def init():
 
     # this callback lets us do cool stuff when our python files change on disk
     def fswatch_callback(event_type, module_path):
-        print(str(constants.Robots_Per_Team))
         # the top-level folders we care about watching
         autoloadables = ['plays', 'skills', 'tactics', 'evaluation']
 

--- a/soccer/gameplay/main.py
+++ b/soccer/gameplay/main.py
@@ -48,6 +48,7 @@ def init():
 
     # this callback lets us do cool stuff when our python files change on disk
     def fswatch_callback(event_type, module_path):
+        print(str(constants.Robots_Per_Team))
         # the top-level folders we care about watching
         autoloadables = ['plays', 'skills', 'tactics', 'evaluation']
 

--- a/soccer/gameplay/tactics/stopped/circle_near_ball.py
+++ b/soccer/gameplay/tactics/stopped/circle_near_ball.py
@@ -143,23 +143,18 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
         if (self.num_robots != num_robots):
             self.num_robots = num_robots
             self.remove_all_subbehaviors()
-            i = 0
             for pt in range(6):
                 self.add_subbehavior(skills.move.Move(),
-                                     name="robot" + str(i),
+                                     name="robot" + str(pt),
                                      required=False,
-                                     priority=6 - i)
-                i = i + 1
-
-        i = 0
+                                     priority=6 - pt)
         #assign destinations for the number of robots we have
-        for pt in self.get_circle_points(num_robots):
+        for i, pt in enumerate(self.get_circle_points(num_robots)):
             self.subbehavior_with_name("robot" + str(i)).pos = pt
-            i = i + 1
+
         #unassign destinations from behaviors without robots
         for i in range(num_robots, 6):
             self.subbehavior_with_name("robot" + str(i)).pos = None
-            i = i + 1
 
         # set robot attributes
         for b in self.all_subbehaviors():

--- a/soccer/gameplay/tactics/stopped/circle_near_ball.py
+++ b/soccer/gameplay/tactics/stopped/circle_near_ball.py
@@ -29,14 +29,12 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
                             lambda: not self.all_subbehaviors_completed(),
                             "robots aren't lined up")
 
-        i = 0
         #create move behaviors with no position (we can't assign position because we don't know how many bots we have)
-        for pt in range(6):
+        for i in range(6):
             self.add_subbehavior(skills.move.Move(),
                                  name="robot" + str(i),
                                  required=False,
                                  priority=6 - i)
-            i = i + 1
 
     def get_circle_points(self, num_of_points):
         radius = constants.Field.CenterRadius + constants.Robot.Radius + 0.01
@@ -143,11 +141,11 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
         if (self.num_robots != num_robots):
             self.num_robots = num_robots
             self.remove_all_subbehaviors()
-            for pt in range(6):
+            for i in range(6):
                 self.add_subbehavior(skills.move.Move(),
-                                     name="robot" + str(pt),
+                                     name="robot" + str(i),
                                      required=False,
-                                     priority=6 - pt)
+                                     priority=6 - i)
         #assign destinations for the number of robots we have
         for i, pt in enumerate(self.get_circle_points(num_robots)):
             self.subbehavior_with_name("robot" + str(i)).pos = pt

--- a/soccer/gameplay/tactics/stopped/circle_near_ball.py
+++ b/soccer/gameplay/tactics/stopped/circle_near_ball.py
@@ -16,7 +16,7 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
     def __init__(self):
         super().__init__(continuous=True)
 
-        self.num_robots = 0;
+        self.num_robots = 0
         self.add_transition(behavior.Behavior.State.start,
                             behavior.Behavior.State.running, lambda: True,
                             'immediately')
@@ -32,11 +32,10 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
         i = 0
         #create move behaviors with no position (we can't assign position because we don't know how many bots we have)
         for pt in range(6):
-            self.add_subbehavior(
-                skills.move.Move(),
-                name="robot" + str(i),
-                required=False,
-                priority=6 - i)
+            self.add_subbehavior(skills.move.Move(),
+                                 name="robot" + str(i),
+                                 required=False,
+                                 priority=6 - i)
             i = i + 1
 
     def get_circle_points(self, num_of_points):
@@ -146,11 +145,10 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
             self.remove_all_subbehaviors()
             i = 0
             for pt in range(6):
-                self.add_subbehavior(
-                    skills.move.Move(),
-                    name="robot" + str(i),
-                    required=False,
-                    priority=6 - i)
+                self.add_subbehavior(skills.move.Move(),
+                                     name="robot" + str(i),
+                                     required=False,
+                                     priority=6 - i)
                 i = i + 1
 
         i = 0
@@ -160,9 +158,8 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
             i = i + 1
         #unassign destinations from behaviors without robots
         for i in range(num_robots, 6):
-            self.subbehavior_with_name("robot" + str(i)).pos = None;
+            self.subbehavior_with_name("robot" + str(i)).pos = None
             i = i + 1
-
 
         # set robot attributes
         for b in self.all_subbehaviors():

--- a/soccer/gameplay/tactics/stopped/circle_near_ball.py
+++ b/soccer/gameplay/tactics/stopped/circle_near_ball.py
@@ -156,7 +156,6 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
         i = 0
         #assign destinations for the number of robots we have
         for pt in self.get_circle_points(num_robots):
-            print("Robots: " + str(self.get_circle_points(num_robots)))
             self.subbehavior_with_name("robot" + str(i)).pos = pt
             i = i + 1
         #unassign destinations from behaviors without robots

--- a/soccer/gameplay/tactics/stopped/circle_near_ball.py
+++ b/soccer/gameplay/tactics/stopped/circle_near_ball.py
@@ -16,6 +16,7 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
     def __init__(self):
         super().__init__(continuous=True)
 
+        self.num_robots = 0;
         self.add_transition(behavior.Behavior.State.start,
                             behavior.Behavior.State.running, lambda: True,
                             'immediately')
@@ -29,9 +30,10 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
                             "robots aren't lined up")
 
         i = 0
-        for pt in self.get_circle_points(6):
+        #create move behaviors with no position (we can't assign position because we don't know how many bots we have)
+        for pt in range(6):
             self.add_subbehavior(
-                skills.move.Move(pt),
+                skills.move.Move(),
                 name="robot" + str(i),
                 required=False,
                 priority=6 - i)
@@ -124,23 +126,6 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
 
         return final_points
 
-    def execute_completed(self):
-        num_robots = 0
-        for b in self.all_subbehaviors():
-            if b.robot is not None:
-                num_robots += 1
-
-        i = 0
-        for pt in self.get_circle_points(num_robots):
-            self.subbehavior_with_name("robot" + str(i)).pos = pt
-            i = i + 1
-
-        # set robot attributes
-        for b in self.all_subbehaviors():
-            if b.robot is not None:
-                b.robot.set_avoid_ball_radius(constants.Field.CenterRadius)
-                b.robot.face(main.ball().pos)
-
     # Makes an angle > 0, < pi * 2
     def normalize_angle(self, angle):
         # TODO make this O(1) and move to cpp
@@ -155,11 +140,24 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
         for b in self.all_subbehaviors():
             if b.robot is not None:
                 num_robots += 1
+        if (self.num_robots != num_robots):
+            self.num_robots = num_robots
+            self.remove_all_subbehaviors()
+            i = 0
+            for pt in range(6):
+                self.add_subbehavior(
+                    skills.move.Move(),
+                    name="robot" + str(i),
+                    required=False,
+                    priority=6 - i)
+                i = i + 1
 
         i = 0
         for pt in self.get_circle_points(num_robots):
+            print("Robots: " + str(self.get_circle_points(num_robots)))
             self.subbehavior_with_name("robot" + str(i)).pos = pt
             i = i + 1
+
 
         # set robot attributes
         for b in self.all_subbehaviors():

--- a/soccer/gameplay/tactics/stopped/circle_near_ball.py
+++ b/soccer/gameplay/tactics/stopped/circle_near_ball.py
@@ -140,6 +140,7 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
         for b in self.all_subbehaviors():
             if b.robot is not None:
                 num_robots += 1
+        #if the number of robots has changed, recreate move behaviors to match new number of robots
         if (self.num_robots != num_robots):
             self.num_robots = num_robots
             self.remove_all_subbehaviors()
@@ -153,9 +154,14 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
                 i = i + 1
 
         i = 0
+        #assign destinations for the number of robots we have
         for pt in self.get_circle_points(num_robots):
             print("Robots: " + str(self.get_circle_points(num_robots)))
             self.subbehavior_with_name("robot" + str(i)).pos = pt
+            i = i + 1
+        #unassign destinations from behaviors without robots
+        for i in range(num_robots, 6):
+            self.subbehavior_with_name("robot" + str(i)).pos = None;
             i = i + 1
 
 

--- a/soccer/gameplay/tactics/stopped/circle_on_center.py
+++ b/soccer/gameplay/tactics/stopped/circle_on_center.py
@@ -26,17 +26,16 @@ class CircleOnCenter(composite_behavior.CompositeBehavior):
                             "robots aren't lined up")
 
         self.min_robots = min_robots
-        self.num_robots = 0;
+        self.num_robots = 0
 
         #create move behaviors with no position (we can't assign position because we don't know how many bots we have)
         for i in range(6):
             req = i < min_robots
-            self.add_subbehavior(
-                skills.move.Move(),
-                name="robot" + str(i),
-                required=req,
-                priority=6 - i)
-            
+            self.add_subbehavior(skills.move.Move(),
+                                 name="robot" + str(i),
+                                 required=req,
+                                 priority=6 - i)
+
     def goto_center(self):
         num_robots = 0
         for b in self.all_subbehaviors():
@@ -49,11 +48,10 @@ class CircleOnCenter(composite_behavior.CompositeBehavior):
             self.remove_all_subbehaviors()
             i = 0
             for pt in range(6):
-                self.add_subbehavior(
-                    skills.move.Move(),
-                    name="robot" + str(i),
-                    required=False,
-                    priority=6 - i)
+                self.add_subbehavior(skills.move.Move(),
+                                     name="robot" + str(i),
+                                     required=False,
+                                     priority=6 - i)
                 i = i + 1
 
         num_robots = max(self.min_robots, num_robots)

--- a/soccer/gameplay/tactics/stopped/circle_on_center.py
+++ b/soccer/gameplay/tactics/stopped/circle_on_center.py
@@ -46,13 +46,11 @@ class CircleOnCenter(composite_behavior.CompositeBehavior):
         if (self.num_robots != num_robots):
             self.num_robots = num_robots
             self.remove_all_subbehaviors()
-            i = 0
             for pt in range(6):
                 self.add_subbehavior(skills.move.Move(),
-                                     name="robot" + str(i),
+                                     name="robot" + str(pt),
                                      required=False,
-                                     priority=6 - i)
-                i = i + 1
+                                     priority=6 - pt)
 
         num_robots = max(self.min_robots, num_robots)
 

--- a/soccer/gameplay/tactics/stopped/circle_on_center.py
+++ b/soccer/gameplay/tactics/stopped/circle_on_center.py
@@ -27,26 +27,15 @@ class CircleOnCenter(composite_behavior.CompositeBehavior):
 
         self.min_robots = min_robots
 
-        # Define circle to circle up on
-        radius = constants.Field.CenterRadius + constants.Robot.Radius + 0.01
-
-        perRobot = (2 * constants.Robot.Radius * 1.25) / radius
-
-        ball_pos = robocup.Point(0, constants.Field.Length / 2)
-
-        dirvec = (robocup.Point(0, 0) - ball_pos).normalized() * radius
-
+        #create move behaviors with no position (we can't assign position because we don't know how many bots we have)
         for i in range(6):
             req = i < min_robots
-
-            pt = ball_pos + dirvec
             self.add_subbehavior(
-                skills.move.Move(pt),
+                skills.move.Move(),
                 name="robot" + str(i),
                 required=req,
                 priority=6 - i)
-            dirvec.rotate(robocup.Point(0, 0), perRobot)
-
+            
     def goto_center(self):
         num_robots = 0
         for b in self.all_subbehaviors():
@@ -64,7 +53,8 @@ class CircleOnCenter(composite_behavior.CompositeBehavior):
         dirvec = (robocup.Point(0, 0) - ball_pos).normalized() * radius
         dirvec.rotate(robocup.Point(0, 0), -perRobot * ((num_robots - 1) / 2))
 
-        for i in range(6):
+        #assign points to the behaviors with robots
+        for i in range(num_robots):
             pt = ball_pos + dirvec
             self.subbehavior_with_name("robot" + str(i)).pos = pt
             dirvec.rotate(robocup.Point(0, 0), perRobot)

--- a/soccer/gameplay/tactics/stopped/circle_on_center.py
+++ b/soccer/gameplay/tactics/stopped/circle_on_center.py
@@ -26,6 +26,7 @@ class CircleOnCenter(composite_behavior.CompositeBehavior):
                             "robots aren't lined up")
 
         self.min_robots = min_robots
+        self.num_robots = 0
 
         #create move behaviors with no position (we can't assign position because we don't know how many bots we have)
         for i in range(6):
@@ -41,6 +42,19 @@ class CircleOnCenter(composite_behavior.CompositeBehavior):
         for b in self.all_subbehaviors():
             if b.robot is not None:
                 num_robots += 1
+
+        #if the number of robots has changed, recreate move behaviors to match new number of robots
+        if (self.num_robots != num_robots):
+            self.num_robots = num_robots
+            self.remove_all_subbehaviors()
+            i = 0
+            for pt in range(6):
+                self.add_subbehavior(
+                    skills.move.Move(),
+                    name="robot" + str(i),
+                    required=False,
+                    priority=6 - i)
+                i = i + 1
 
         num_robots = max(self.min_robots, num_robots)
 
@@ -64,9 +78,6 @@ class CircleOnCenter(composite_behavior.CompositeBehavior):
             if b.robot is not None:
                 b.robot.set_avoid_ball_radius(constants.Field.CenterRadius)
                 b.robot.face(main.ball().pos)
-
-    def execute_completed(self):
-        self.goto_center()
 
     def execute_running(self):
         self.goto_center()


### PR DESCRIPTION
Closes #866 . So the following was happening:

1. Stop play starts and selects a tactic (circle around ball vs. circle around center)
2. Tactic doesn't know how many robots it will receive so it creates 6 move behaviors with destinations evenly spaced around the circle
3. Role assignment occurs and the tactic might not receive 6 robots, usually it gets 3
4. The (usually 3) robots are assigned to 3 of the 6 points around the circle based on their proximity to those original points
5. The move behaviors' points are updated now that the tactic knows it only has 3 robots
6. The robots stick to their current behavior because of the high robot change cost, and move to the new destination

I basically made the original assignment points impossible to reach so the tactic doesn't make stupid assignments, and once it knows how many robots it gets it can make actual assignments.

As a side note, do you think it might be a good idea to let behaviors assign their own robot change cost? This would let some behaviors that have a lower actual cost of switch robots, like the move play, switch easier than other with more overhead, like aiming and kicking.