### PR TITLE
Remove dips in observed robot velocity

### DIFF
--- a/soccer/modeling/RobotFilter.cpp
+++ b/soccer/modeling/RobotFilter.cpp
@@ -22,7 +22,7 @@ void RobotFilter::update(const RobotObservation* obs) {
     // bool reset = _currentEstimate[s].time == 0 || (dtime > Coast_Time);
 
     bool reset = (dtime > Coast_Time);
-    if (reset || dtime < Min_Frame_Time) {
+    if (reset) {
         _estimate[s].vel = Point();
         _estimate[s].angleVel = 0;
     } else {


### PR DESCRIPTION
Addresses #956. So I'm unsure what the purpose of this line of code that I changed is, but getting rid of it dramatically improves the smoothness of the observed velocity. I'd like to know what the purpose of what I deleted is.