### PR TITLE
Fixes Kick Eval calculating the wrong pass when target is across -PI +PI

### DIFF
--- a/soccer/KickEvaluator.cpp
+++ b/soccer/KickEvaluator.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 #include <math.h>
 #include <cmath>
-#include <iostream>
 
 REGISTER_CONFIGURABLE(KickEvaluator)
 

--- a/soccer/KickEvaluator.cpp
+++ b/soccer/KickEvaluator.cpp
@@ -265,7 +265,7 @@ float KickEvaluator::get_target_angle(const Point origin,
     Point left = target.pt[0] - origin;
     Point right = target.pt[1] - origin;
 
-    float angle = left.dot(right) / (left.mag()*right.mag());
+    float angle = left.dot(right) / (left.mag() * right.mag());
     angle = std::min(std::max(angle, -1.0f), 1.0f);
 
     return abs(acos(angle));
@@ -296,7 +296,8 @@ tuple<float, float> KickEvaluator::rect_to_polar(const Point origin,
                                                  const Point obstacle) {
     Point obstacleDir = obstacle - origin;
     Point targetDir = target - origin;
-    float angle = targetDir.dot(obstacleDir) / (targetDir.mag()*obstacleDir.mag());
+    float angle =
+        targetDir.dot(obstacleDir) / (targetDir.mag() * obstacleDir.mag());
     angle = std::min(std::max(angle, -1.0f), 1.0f);
 
     return make_tuple(obstacleDir.mag(), fixAngleRadians(acos(angle)));

--- a/soccer/KickEvaluator.cpp
+++ b/soccer/KickEvaluator.cpp
@@ -299,7 +299,7 @@ tuple<float, float> KickEvaluator::rect_to_polar(const Point origin,
     float angle = targetDir.dot(obstacleDir) / (targetDir.mag()*obstacleDir.mag());
     angle = std::min(std::max(angle, -1.0f), 1.0f);
 
-    return make_tuple(obstacleDir.mag(), fixAngleRadians(angle));
+    return make_tuple(obstacleDir.mag(), fixAngleRadians(acos(angle)));
 }
 
 vector<tuple<float, float> > KickEvaluator::convert_robots_to_polar(

--- a/soccer/KickEvaluator.cpp
+++ b/soccer/KickEvaluator.cpp
@@ -265,10 +265,7 @@ float KickEvaluator::get_target_angle(const Point origin,
     Point left = target.pt[0] - origin;
     Point right = target.pt[1] - origin;
 
-    float angle = left.dot(right) / (left.mag() * right.mag());
-    angle = std::min(std::max(angle, -1.0f), 1.0f);
-
-    return abs(acos(angle));
+    return abs(left.angleBetween(right));
 }
 
 vector<Robot*> KickEvaluator::get_valid_robots() {
@@ -296,11 +293,9 @@ tuple<float, float> KickEvaluator::rect_to_polar(const Point origin,
                                                  const Point obstacle) {
     Point obstacleDir = obstacle - origin;
     Point targetDir = target - origin;
-    float angle =
-        targetDir.dot(obstacleDir) / (targetDir.mag() * obstacleDir.mag());
-    angle = std::min(std::max(angle, -1.0f), 1.0f);
 
-    return make_tuple(obstacleDir.mag(), fixAngleRadians(acos(angle)));
+    return make_tuple(obstacleDir.mag(),
+                      fixAngleRadians(targetDir.angleBetween(obstacleDir)));
 }
 
 vector<tuple<float, float> > KickEvaluator::convert_robots_to_polar(

--- a/soccer/KickEvaluator.cpp
+++ b/soccer/KickEvaluator.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <math.h>
 #include <cmath>
+#include <iostream>
 
 REGISTER_CONFIGURABLE(KickEvaluator)
 
@@ -114,10 +115,10 @@ KickResults KickEvaluator::eval_pt_to_seg(Point origin, Segment target) {
     // No opponent robots on the field
     if (botMeans.size() == 0) {
         // Push it off to the side
-        botMeans.push_back(3);
+        botMeans.push_back(4);
         // Must be non-zero as 1 / botStDev is used
         botStDevs.push_back(0.1);
-        botVertScales.push_back(0.01);
+        botVertScales.push_back(0.001);
 
         // Center will always be the best target X with no robots
         return pair<Point, float>(center, get<0>(keFunc(0)));
@@ -265,7 +266,10 @@ float KickEvaluator::get_target_angle(const Point origin,
     Point left = target.pt[0] - origin;
     Point right = target.pt[1] - origin;
 
-    return abs(left.angle() - right.angle());
+    float angle = left.dot(right) / (left.mag()*right.mag());
+    angle = std::min(std::max(angle, -1.0f), 1.0f);
+
+    return abs(acos(angle));
 }
 
 vector<Robot*> KickEvaluator::get_valid_robots() {
@@ -293,7 +297,8 @@ tuple<float, float> KickEvaluator::rect_to_polar(const Point origin,
                                                  const Point obstacle) {
     Point obstacleDir = obstacle - origin;
     Point targetDir = target - origin;
-    float angle = obstacleDir.angle() - targetDir.angle();
+    float angle = targetDir.dot(obstacleDir) / (targetDir.mag()*obstacleDir.mag());
+    angle = std::min(std::max(angle, -1.0f), 1.0f);
 
     return make_tuple(obstacleDir.mag(), fixAngleRadians(angle));
 }

--- a/soccer/KickEvaluatorTest.cpp
+++ b/soccer/KickEvaluatorTest.cpp
@@ -60,3 +60,14 @@ TEST(KickEvaluator, eval_calculation) {
     EXPECT_NEAR(std::get<0>(res), std::get<0>(res), 0.01);  // Value
     EXPECT_NEAR(std::get<1>(res), std::get<1>(res), 0.01);  // Derivative
 }
+
+TEST(KickEvaluator, eval_kick_at_pi_transition) {
+    SystemState state;
+
+    KickEvaluator kickEval(&state);
+    std::pair<Point, double> pt_to_our_goal;
+
+    pt_to_our_goal = kickEval.eval_pt_to_robot(Point(3, 2), Point(-3,2));
+
+    EXPECT_LT(std::get<1>(pt_to_our_goal), 0.99);
+}

--- a/soccer/KickEvaluatorTest.cpp
+++ b/soccer/KickEvaluatorTest.cpp
@@ -67,7 +67,7 @@ TEST(KickEvaluator, eval_kick_at_pi_transition) {
     KickEvaluator kickEval(&state);
     std::pair<Point, double> pt_to_our_goal;
 
-    pt_to_our_goal = kickEval.eval_pt_to_robot(Point(3, 2), Point(-3,2));
+    pt_to_our_goal = kickEval.eval_pt_to_robot(Point(3, 2), Point(-3, 2));
 
     EXPECT_LT(std::get<1>(pt_to_our_goal), 0.99);
 }


### PR DESCRIPTION
Fixes #1029 

Here's the new results:
![image](https://user-images.githubusercontent.com/5797304/31057814-a7362f84-a6b6-11e7-8242-71d51ef3ee59.png)
