### PR TITLE
Fix SDL include path and add std namespace prefix.

### DIFF
--- a/soccer/Logger.hpp
+++ b/soccer/Logger.hpp
@@ -91,7 +91,7 @@ public:
         if (numFromBack >= _history.size()) {
             return 0;
         } else {
-            advance(end, numFromBack);
+            std::advance(end, numFromBack);
             int startFrame = _nextFrameNumber - _history.size();
             int numToCopy = std::min(endIndex - 1 - startFrame, num);
             copy_n(end, numToCopy, result);

--- a/soccer/joystick/GamepadJoystick.hpp
+++ b/soccer/joystick/GamepadJoystick.hpp
@@ -2,7 +2,7 @@
 
 #include "Joystick.hpp"
 
-#include <SDL/SDL.h>
+#include <SDL.h>
 
 /**
  * @brief Logitecch Gamepad/Joystick used to control robots


### PR DESCRIPTION
These issues were preventing a build with more recent versions of boost and sdl in Arch.