### PR TITLE
Goalie intercepting without concern for face

### DIFF
--- a/soccer/gameplay/skills/intercept.py
+++ b/soccer/gameplay/skills/intercept.py
@@ -6,7 +6,6 @@ import main
 
 # wraps up OurRobot.move() into a Skill so we can use it in the play system more easily
 class Intercept(single_robot_behavior.SingleRobotBehavior):
-
     def __init__(self, pos=None, faceBall=True):
         super().__init__(continuous=True)
 

--- a/soccer/gameplay/skills/intercept.py
+++ b/soccer/gameplay/skills/intercept.py
@@ -10,7 +10,7 @@ class Intercept(single_robot_behavior.SingleRobotBehavior):
     #controls if the robot should face the ball while intercepting
     faceBall = False
 
-    def __init__(self, pos=None, faceBall=False):
+    def __init__(self, pos=None, faceBall=True):
         super().__init__(continuous=True)
 
         self.faceBall = faceBall

--- a/soccer/gameplay/skills/intercept.py
+++ b/soccer/gameplay/skills/intercept.py
@@ -7,9 +7,6 @@ import main
 # wraps up OurRobot.move() into a Skill so we can use it in the play system more easily
 class Intercept(single_robot_behavior.SingleRobotBehavior):
 
-    #controls if the robot should face the ball while intercepting
-    faceBall = False
-
     def __init__(self, pos=None, faceBall=True):
         super().__init__(continuous=True)
 

--- a/soccer/gameplay/skills/intercept.py
+++ b/soccer/gameplay/skills/intercept.py
@@ -17,7 +17,8 @@ class Intercept(single_robot_behavior.SingleRobotBehavior):
 
         self._shape_constraint = None
 
-        self.ball_line = lambda: robocup.Segment(main.ball().pos, main.ball().pos + (main.ball().vel.normalized() * 8.))
+        self.ball_line = lambda: robocup.Segment(main.ball(
+        ).pos, main.ball().pos + (main.ball().vel.normalized() * 8.))
 
         self.add_transition(behavior.Behavior.State.start,
                             behavior.Behavior.State.running, lambda: True,

--- a/soccer/gameplay/skills/intercept.py
+++ b/soccer/gameplay/skills/intercept.py
@@ -7,6 +7,7 @@ import main
 # wraps up OurRobot.move() into a Skill so we can use it in the play system more easily
 class Intercept(single_robot_behavior.SingleRobotBehavior):
 
+    #controls if the robot should face the ball while intercepting
     faceBall = False
 
     def __init__(self, pos=None, faceBall=False):

--- a/soccer/gameplay/skills/intercept.py
+++ b/soccer/gameplay/skills/intercept.py
@@ -6,8 +6,13 @@ import main
 
 # wraps up OurRobot.move() into a Skill so we can use it in the play system more easily
 class Intercept(single_robot_behavior.SingleRobotBehavior):
-    def __init__(self, pos=None):
+
+    faceBall = False
+
+    def __init__(self, pos=None, faceBall=False):
         super().__init__(continuous=True)
+
+        self.faceBall = faceBall
 
         self._shape_constraint = None
 
@@ -38,7 +43,9 @@ class Intercept(single_robot_behavior.SingleRobotBehavior):
                     self.robot.pos)
 
             self.robot.move_to_direct(self.target_pos)
-            self.robot.face(main.ball().pos)
+
+            if self.faceBall:
+                self.robot.face(main.ball().pos)
 
     def role_requirements(self):
         reqs = super().role_requirements()

--- a/soccer/gameplay/tactics/positions/goalie.py
+++ b/soccer/gameplay/tactics/positions/goalie.py
@@ -111,7 +111,7 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
     def execute_running(self):
         if self.robot != None:
             #face the ball in all states but intercept
-            if not self.isInter: 
+            if not self.isInter:
                 self.robot.face(main.ball().pos)
             self.robot.set_planning_priority(planning_priority.GOALIE)
 

--- a/soccer/gameplay/tactics/positions/goalie.py
+++ b/soccer/gameplay/tactics/positions/goalie.py
@@ -21,10 +21,6 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
         robocup.Point(MaxX, constants.Robot.Radius + OFFSET))
     OpponentFacingThreshold = math.pi / 8.0
 
-    #Keeps track of when the goalie is intercepting the ball, used
-    #to disable the face command when intercepting.
-    isInter = False
-
     class State(enum.Enum):
         ## Normal gameplay, stay towards the side of the goal that the ball is on.
         defend = 1
@@ -182,12 +178,10 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
         self.remove_subbehavior('kick-clear')
 
     def on_enter_intercept(self):
-        self.isInter = True
         i = skills.intercept.Intercept(None, False)
         self.add_subbehavior(i, 'intercept', required=True)
 
     def on_exit_intercept(self):
-        self.isInter = False
         self.remove_subbehavior('intercept')
 
     def execute_block(self):

--- a/soccer/gameplay/tactics/positions/goalie.py
+++ b/soccer/gameplay/tactics/positions/goalie.py
@@ -21,6 +21,9 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
         robocup.Point(MaxX, constants.Robot.Radius + OFFSET))
     OpponentFacingThreshold = math.pi / 8.0
 
+
+    isInter = False;
+
     class State(enum.Enum):
         ## Normal gameplay, stay towards the side of the goal that the ball is on.
         defend = 1
@@ -106,7 +109,8 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
     # note that execute_running() gets called BEFORE any of the execute_SUBSTATE methods gets called
     def execute_running(self):
         if self.robot != None:
-            self.robot.face(main.ball().pos)
+            if not self.isInter:
+                self.robot.face(main.ball().pos)
             self.robot.set_planning_priority(planning_priority.GOALIE)
 
     def execute_chill(self):
@@ -164,17 +168,15 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
         self.remove_subbehavior('kick-clear')
 
     def on_enter_intercept(self):
-        i = skills.intercept.Intercept()
+        self.isInter = True
+        i = skills.intercept.Intercept(None, False)
         self.add_subbehavior(i, 'intercept', required=True)
 
     def execute_intercept(self):
-        ball_path = robocup.Segment(
-            main.ball().pos,
-            main.ball().pos + main.ball().vel.normalized() * 10.0)
-        dest = ball_path.nearest_point(self.robot.pos)
-        self.robot.move_to(dest)
+        pass
 
     def on_exit_intercept(self):
+        self.isInter = False
         self.remove_subbehavior('intercept')
 
     def execute_block(self):

--- a/soccer/gameplay/tactics/positions/goalie.py
+++ b/soccer/gameplay/tactics/positions/goalie.py
@@ -23,7 +23,7 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
 
     #Keeps track of when the goalie is intercepting the ball, used
     #to disable the face command when intercepting.
-    isInter = False;
+    isInter = False
 
     class State(enum.Enum):
         ## Normal gameplay, stay towards the side of the goal that the ball is on.
@@ -45,53 +45,65 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
         for substate in Goalie.State:
             self.add_state(substate, behavior.Behavior.State.running)
 
-        self.add_transition(behavior.Behavior.State.start, Goalie.State.chill,
-                            lambda: True, "immediately")
+        self.add_transition(behavior.Behavior.State.start,
+                            Goalie.State.chill, lambda: True, "immediately")
 
-        self.add_transition(Goalie.State.chill, Goalie.State.defend,
-                            lambda: main.ball().valid, "ball is valid")
+        self.add_transition(Goalie.State.chill,
+                            Goalie.State.defend, lambda: main.ball().valid,
+                            "ball is valid")
 
         non_chill_states = [s for s in Goalie.State if s != Goalie.State.chill]
 
         # if ball is invalid, chill
         for state in non_chill_states:
-            self.add_transition(state, Goalie.State.chill,
-                                lambda: not main.ball().valid,
-                                "ball is invalid")
+            self.add_transition(
+                state, Goalie.State.chill, lambda: not main.ball().valid,
+                "ball is invalid")
 
         for state in non_chill_states:
             self.add_transition(
-                state, Goalie.State.setup_penalty,
-                lambda: main.game_state().is_their_penalty() and main.game_state().is_setup_state(),
+                state, Goalie.State.setup_penalty, lambda: main.game_state(
+                ).is_their_penalty() and main.game_state().is_setup_state(),
                 "setting up for opponent penalty")
 
-        for state in [s2
-                      for s2 in non_chill_states
-                      if s2 != Goalie.State.intercept]:
+        for state in [
+                s2 for s2 in non_chill_states if s2 != Goalie.State.intercept
+        ]:
             self.add_transition(
-                state, Goalie.State.intercept,
-                lambda: evaluation.ball.is_moving_towards_our_goal() and not self.robot_is_facing_our_goal(evaluation.ball.opponent_with_ball()),
+                state, Goalie.State.intercept, lambda: evaluation.ball.
+                is_moving_towards_our_goal() and not self.
+                robot_is_facing_our_goal(evaluation.ball.opponent_with_ball()),
                 "ball coming towards our goal")
 
-        for state in [s2 for s2 in non_chill_states if s2 != Goalie.State.clear
-                      ]:
+        for state in [
+                s2 for s2 in non_chill_states if s2 != Goalie.State.clear
+        ]:
             self.add_transition(
-                state, Goalie.State.clear,
-                lambda: evaluation.ball.is_in_our_goalie_zone() and not main.game_state().is_their_penalty() and not evaluation.ball.is_moving_towards_our_goal() and evaluation.ball.opponent_with_ball() is None,
+                state, Goalie.State.clear, lambda: evaluation.ball.
+                is_in_our_goalie_zone() and not main.game_state(
+                ).is_their_penalty(
+                ) and not evaluation.ball.is_moving_towards_our_goal(
+                ) and evaluation.ball.opponent_with_ball() is None,
                 "ball in our goalie box, but not headed toward goal")
 
-        for state in [s2 for s2 in non_chill_states
-                      if s2 != Goalie.State.defend]:
+        for state in [
+                s2 for s2 in non_chill_states if s2 != Goalie.State.defend
+        ]:
             self.add_transition(
-                state, Goalie.State.defend,
-                lambda: not evaluation.ball.is_in_our_goalie_zone() and not evaluation.ball.is_moving_towards_our_goal() and not main.game_state().is_their_penalty() and not self.robot_is_facing_our_goal(evaluation.ball.opponent_with_ball()),
-                'not much going on')
+                state, Goalie.State.defend, lambda: not evaluation.ball.
+                is_in_our_goalie_zone() and not evaluation.ball.
+                is_moving_towards_our_goal() and not main.game_state(
+                ).is_their_penalty() and not self.robot_is_facing_our_goal(
+                    evaluation.ball.opponent_with_ball()), 'not much going on')
 
-        for state in [s2 for s2 in non_chill_states if s2 != Goalie.State.block
-                      ]:
+        for state in [
+                s2 for s2 in non_chill_states if s2 != Goalie.State.block
+        ]:
             self.add_transition(
-                state, Goalie.State.block,
-                lambda: not evaluation.ball.is_in_our_goalie_zone() and not evaluation.ball.is_moving_towards_our_goal() and self.robot_is_facing_our_goal(evaluation.ball.opponent_with_ball()),
+                state, Goalie.State.block, lambda: not evaluation.ball.
+                is_in_our_goalie_zone() and not evaluation.ball.
+                is_moving_towards_our_goal() and self.robot_is_facing_our_goal(
+                    evaluation.ball.opponent_with_ball()),
                 "opponents have possession")
 
     def robot_is_facing_our_goal(self, robot):
@@ -111,14 +123,14 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
     def execute_running(self):
         if self.robot != None:
             #face the ball in all states but intercept
-            if not self.isInter:
+            if not self.has_subbehavior_with_name('intercept'):
                 self.robot.face(main.ball().pos)
             self.robot.set_planning_priority(planning_priority.GOALIE)
 
     def execute_chill(self):
         if self.robot != None:
-            self.robot.move_to(robocup.Point(0, constants.Robot.Radius +
-                                             Goalie.OFFSET))
+            self.robot.move_to(
+                robocup.Point(0, constants.Robot.Radius + Goalie.OFFSET))
 
     def execute_setup_penalty(self):
         pt = robocup.Point(0, constants.Field.PenaltyDist)
@@ -131,8 +143,8 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
 
         dest = Goalie.RobotSegment.line_intersection(shot_line)
         if dest is None:
-            self.robot.move_to(robocup.Point(0, constants.Robot.Radius +
-                                             Goalie.OFFSET))
+            self.robot.move_to(
+                robocup.Point(0, constants.Robot.Radius + Goalie.OFFSET))
         else:
             dest.x = max(-Goalie.MaxX + constants.Robot.Radius, dest.x)
             dest.x = min(Goalie.MaxX - constants.Robot.Radius, dest.x)
@@ -174,9 +186,6 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
         i = skills.intercept.Intercept(None, False)
         self.add_subbehavior(i, 'intercept', required=True)
 
-    def execute_intercept(self):
-        pass
-
     def on_exit_intercept(self):
         self.isInter = False
         self.remove_subbehavior('intercept')
@@ -192,22 +201,23 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
                 block_line = robocup.Line(
                     robocup.Point(
                         best.segment.get_pt(0).x - constants.Robot.Radius,
-                        constants.Robot.Radius), robocup.Point(
-                            best.segment.get_pt(1).x + constants.Robot.Radius,
-                            constants.Robot.Radius))
+                        constants.Robot.Radius),
+                    robocup.Point(
+                        best.segment.get_pt(1).x + constants.Robot.Radius,
+                        constants.Robot.Radius))
                 main.system_state().draw_line(block_line, (255, 0, 0), "Debug")
                 dest = block_line.line_intersection(shot_line)
                 dest.x = min(Goalie.MaxX, dest.x)
                 dest.x = max(-Goalie.MaxX, dest.x)
                 self.robot.move_to(dest)
                 return
-        self.robot.move_to(robocup.Point(0, constants.Robot.Radius +
-                                         Goalie.OFFSET))
+        self.robot.move_to(
+            robocup.Point(0, constants.Robot.Radius + Goalie.OFFSET))
 
     def execute_defend(self):
         dest_x = main.ball().pos.x / constants.Field.Width * Goalie.MaxX
-        self.robot.move_to(robocup.Point(dest_x, constants.Robot.Radius +
-                                         Goalie.OFFSET))
+        self.robot.move_to(
+            robocup.Point(dest_x, constants.Robot.Radius + Goalie.OFFSET))
 
     def role_requirements(self):
         reqs = super().role_requirements()

--- a/soccer/gameplay/tactics/positions/goalie.py
+++ b/soccer/gameplay/tactics/positions/goalie.py
@@ -21,7 +21,8 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
         robocup.Point(MaxX, constants.Robot.Radius + OFFSET))
     OpponentFacingThreshold = math.pi / 8.0
 
-
+    #Keeps track of when the goalie is intercepting the ball, used
+    #to disable the face command when intercepting.
     isInter = False;
 
     class State(enum.Enum):
@@ -109,7 +110,8 @@ class Goalie(single_robot_composite_behavior.SingleRobotCompositeBehavior):
     # note that execute_running() gets called BEFORE any of the execute_SUBSTATE methods gets called
     def execute_running(self):
         if self.robot != None:
-            if not self.isInter:
+            #face the ball in all states but intercept
+            if not self.isInter: 
                 self.robot.face(main.ball().pos)
             self.robot.set_planning_priority(planning_priority.GOALIE)
 

--- a/soccer/gameplay/tactics/positions/submissive_goalie.py
+++ b/soccer/gameplay/tactics/positions/submissive_goalie.py
@@ -99,7 +99,8 @@ class SubmissiveGoalie(
 
     # note that execute_running() gets called BEFORE any of the execute_SUBSTATE methods gets called
     def execute_running(self):
-        self.robot.face(main.ball().pos)
+        if not self.has_subbehavior_with_name('intercept'):
+            self.robot.face(main.ball().pos)
         self.robot.set_planning_priority(planning_priority.GOALIE)
 
     def on_enter_clear(self):
@@ -133,7 +134,7 @@ class SubmissiveGoalie(
         self.remove_subbehavior('kick-clear')
 
     def on_enter_intercept(self):
-        i = skills.intercept.Intercept()
+        i = skills.intercept.Intercept(None, False)
         i.shape_constraint = self.RobotSegment
         self.add_subbehavior(i, 'intercept', required=True)
 

--- a/soccer/gameplay/tactics/positions/submissive_goalie.py
+++ b/soccer/gameplay/tactics/positions/submissive_goalie.py
@@ -16,7 +16,7 @@ import planning_priority
 # This goalie lets someone else (the Defense tactic) handle calculations and blocks things based on that
 # TODO: merge this back into the regular goalie?
 class SubmissiveGoalie(
-    single_robot_composite_behavior.SingleRobotCompositeBehavior):
+        single_robot_composite_behavior.SingleRobotCompositeBehavior):
     class State(enum.Enum):
         "Actively blocking based on a given threat"
         block = 2
@@ -44,30 +44,36 @@ class SubmissiveGoalie(
                             SubmissiveGoalie.State.block, lambda: True,
                             "immediately")
 
-        non_block_states = [s
-                            for s in SubmissiveGoalie.State
-                            if s != SubmissiveGoalie.State.block]
+        non_block_states = [
+            s for s in SubmissiveGoalie.State
+            if s != SubmissiveGoalie.State.block
+        ]
 
-        for state in [s2
-                      for s2 in SubmissiveGoalie.State
-                      if s2 != SubmissiveGoalie.State.intercept]:
-            self.add_transition(
-                state, SubmissiveGoalie.State.intercept,
-                lambda: evaluation.ball.is_moving_towards_our_goal(),
-                "ball coming towards our goal")
+        for state in [
+                s2 for s2 in SubmissiveGoalie.State
+                if s2 != SubmissiveGoalie.State.intercept
+        ]:
+            self.add_transition(state,
+                                SubmissiveGoalie.State.intercept, lambda:
+                                evaluation.ball.is_moving_towards_our_goal(),
+                                "ball coming towards our goal")
 
-        for state in [s2
-                      for s2 in SubmissiveGoalie.State
-                      if s2 != SubmissiveGoalie.State.clear]:
+        for state in [
+                s2 for s2 in SubmissiveGoalie.State
+                if s2 != SubmissiveGoalie.State.clear
+        ]:
             self.add_transition(
-                state, SubmissiveGoalie.State.clear,
-                lambda: evaluation.ball.is_in_our_goalie_zone() and not evaluation.ball.is_moving_towards_our_goal() and main.ball().vel.mag() < 0.4 and evaluation.ball.opponent_with_ball() is None,
+                state, SubmissiveGoalie.State.clear, lambda: evaluation.ball.
+                is_in_our_goalie_zone() and not evaluation.ball.
+                is_moving_towards_our_goal() and main.ball().vel.mag(
+                ) < 0.4 and evaluation.ball.opponent_with_ball() is None,
                 "ball in our goalie box, but not headed toward goal")
 
         for state in non_block_states:
             self.add_transition(
-                state, SubmissiveGoalie.State.block,
-                lambda: not evaluation.ball.is_in_our_goalie_zone() and not evaluation.ball.is_moving_towards_our_goal(),
+                state, SubmissiveGoalie.State.block, lambda: not evaluation.
+                ball.is_in_our_goalie_zone(
+                ) and not evaluation.ball.is_moving_towards_our_goal(),
                 'ball not in goal or moving towards it')
 
         self.block_line = None


### PR DESCRIPTION
Issue #1046 

Note: I don't currently know how to run check style or the make pretty, If style (or function for that matter) is a problem then I can revise at the meeting tomorrow. 

Three changes:
1. Removed redundant goalie code:
        In intercept_execute there was code that was duplicating the functionality of the intercept sub behavior while the intercept sub behavior was also being called. This has been removed. 

2. Made goalie not always face the ball
        There was a function being called continuously in goalie that would make it face the ball, a condition has been added so that this function will not be called in the intercept state, but still in all other states.

3. Made facing the ball during the intercept sub-behavior optional
       Previously the intercept sub behavior made the active robot face the ball, a parameter has been added to the intercept constructor to make this optional for faster intercepts.

I'm happy to make any changes needed.

 