### PR TITLE
Switch to new version of stylize

### DIFF
--- a/.stylize.yml
+++ b/.stylize.yml
@@ -1,0 +1,14 @@
+formatters:
+    .py: yapf
+    .h: clang
+    .hpp: clang
+    .c: clang
+    .cc: clang
+    .cpp: clang
+yapf_style: .style.yapf
+clang_style: file
+exclude_dirs:
+    - build
+    - external
+    - old
+

--- a/makefile
+++ b/makefile
@@ -126,13 +126,12 @@ apidocs:
 	@echo "\n=> Open up 'api_docs/html/index.html' in a browser to view a local copy of the documentation"
 
 STYLIZE_DIFFBASE ?= master
-STYLE_EXCLUDE_DIRS=build \
-	external
+STYLE_EXCLUDE_DIRS=build,external
 # automatically format code according to our style config defined in .clang-format
 pretty:
-	@stylize --diffbase=$(STYLIZE_DIFFBASE) --clang_style=file --yapf_style=.style.yapf --exclude_dirs $(STYLE_EXCLUDE_DIRS)
+	@stylize -i --git_diffbase=$(STYLIZE_DIFFBASE) --clang_style=file --yapf_style=.style.yapf --exclude_dirs $(STYLE_EXCLUDE_DIRS)
 # check if everything in our codebase is in accordance with the style config defined in .clang-format
 # a nonzero exit code indicates that there's a formatting error somewhere
 checkstyle:
 	@printf "Run this command to reformat code if needed:\n\ngit apply <(curl -L $${LINK_PREFIX:-file://}clean.patch)\n\n"
-	@stylize --diffbase=$(STYLIZE_DIFFBASE) --clang_style=file --yapf_style=.style.yapf --exclude_dirs $(STYLE_EXCLUDE_DIRS) --check --output_patch_file="$${CIRCLE_ARTIFACTS:-.}/clean.patch"
+	@stylize --diffbase=$(STYLIZE_DIFFBASE) --clang_style=file --yapf_style=.style.yapf --exclude_dirs $(STYLE_EXCLUDE_DIRS) --patch_output "$${CIRCLE_ARTIFACTS:-.}/clean.patch"

--- a/makefile
+++ b/makefile
@@ -126,12 +126,11 @@ apidocs:
 	@echo "\n=> Open up 'api_docs/html/index.html' in a browser to view a local copy of the documentation"
 
 STYLIZE_DIFFBASE ?= master
-STYLE_EXCLUDE_DIRS=build,external
 # automatically format code according to our style config defined in .clang-format
 pretty:
-	@stylize -i --git_diffbase=$(STYLIZE_DIFFBASE) --clang_style=file --yapf_style=.style.yapf --exclude_dirs $(STYLE_EXCLUDE_DIRS)
+	@stylize -i --git_diffbase=$(STYLIZE_DIFFBASE)
 # check if everything in our codebase is in accordance with the style config defined in .clang-format
 # a nonzero exit code indicates that there's a formatting error somewhere
 checkstyle:
 	@printf "Run this command to reformat code if needed:\n\ngit apply <(curl -L $${LINK_PREFIX:-file://}clean.patch)\n\n"
-	@stylize --diffbase=$(STYLIZE_DIFFBASE) --clang_style=file --yapf_style=.style.yapf --exclude_dirs $(STYLE_EXCLUDE_DIRS) --patch_output "$${CIRCLE_ARTIFACTS:-.}/clean.patch"
+	@stylize --diffbase=$(STYLIZE_DIFFBASE) --patch_output "$${CIRCLE_ARTIFACTS:-.}/clean.patch"

--- a/util/arch-packages.txt
+++ b/util/arch-packages.txt
@@ -60,3 +60,5 @@ iverilog
 # grSim
 qt4
 ode
+
+go

--- a/util/arch-setup
+++ b/util/arch-setup
@@ -30,7 +30,11 @@ sudo pip install -r $BASE/util/requirements3.txt
 sudo pip2 install -r $BASE/util/requirements2.txt
 
 # install stylize
-go get github.com/justbuchanan/stylize
+if [ -z "$GOPATH" ]; then
+    echo "[WARN] No GOPATH set, not installing stylize."
+else
+    go get github.com/justbuchanan/stylize
+fi
 
 echo "-- Updating submodules"
 git submodule sync

--- a/util/arch-setup
+++ b/util/arch-setup
@@ -29,6 +29,9 @@ sudo pip install -r $BASE/util/requirements3.txt
 
 sudo pip2 install -r $BASE/util/requirements2.txt
 
+# install stylize
+go get github.com/justbuchanan/stylize
+
 echo "-- Updating submodules"
 git submodule sync
 git submodule update --init --recursive

--- a/util/docker/baseimage/Dockerfile
+++ b/util/docker/baseimage/Dockerfile
@@ -31,5 +31,9 @@ ENV HOME /home/developer
 RUN mkdir -p /home/developer/project
 WORKDIR /home/developer/project
 
+RUN mkdir -p /home/developer/golang
+ENV GOPATH /home/developer/golang
+
+
 # This image is not meant to be run directly, it has not been compiled yet!
 # In addition, it does not contain any source code, only dependencies

--- a/util/osx-packages.txt
+++ b/util/osx-packages.txt
@@ -23,6 +23,7 @@ bullet --with-shared
 protobuf
 clang-format
 graphviz
+go
 
 # firmware - required
 hg

--- a/util/osx-setup
+++ b/util/osx-setup
@@ -39,6 +39,9 @@ brew linkapps qt5
 echo "-- Installing python3 dependencies"
 sudo pip3 install -r "$BASE/util/requirements3.txt"
 
+# install stylize
+go get github.com/justbuchanan/stylize
+
 # prevent OS X's AppNap "feature" from sleeping the simulator
 echo "-- Disabling AppNap for simulator"
 defaults write org.robojackets.robocup.simulator NSAppSleepDisabled -bool YES

--- a/util/osx-setup
+++ b/util/osx-setup
@@ -40,7 +40,11 @@ echo "-- Installing python3 dependencies"
 sudo pip3 install -r "$BASE/util/requirements3.txt"
 
 # install stylize
-go get github.com/justbuchanan/stylize
+if [ -z "$GOPATH" ]; then
+    echo "[WARN] No GOPATH set, not installing stylize."
+else
+    go get github.com/justbuchanan/stylize
+fi
 
 # prevent OS X's AppNap "feature" from sleeping the simulator
 echo "-- Disabling AppNap for simulator"

--- a/util/requirements3.txt
+++ b/util/requirements3.txt
@@ -7,5 +7,4 @@ munkres	# provides the 'hungarian algorithm', which we use for robot role assign
 pylint==1.6.5 # static checker for python
 mypy==0.510   # static arugment checker
 
-stylize>=0.3.2 # code reformatting and checkstyling
 yapf==0.15.2 # python checker

--- a/util/ubuntu-packages.txt
+++ b/util/ubuntu-packages.txt
@@ -107,3 +107,4 @@ python-matplotlib
 python-usb
 freeglut3-dev
 mercurial
+go

--- a/util/ubuntu-packages.txt
+++ b/util/ubuntu-packages.txt
@@ -107,4 +107,4 @@ python-matplotlib
 python-usb
 freeglut3-dev
 mercurial
-go
+golang

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -164,6 +164,9 @@ pip3 install -r $BASE/util/requirements3.txt
 # install python2 requirements
 pip2 install -r $BASE/util/requirements2.txt
 
+# install stylize
+go get github.com/justbuchanan/stylize
+
 # This script is run as sudo, but we don't want submodules to be owned by the
 # root user, so we use `su` to update submodules as the normal user
 SETUP_USER="$SUDO_USER"

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -165,7 +165,11 @@ pip3 install -r $BASE/util/requirements3.txt
 pip2 install -r $BASE/util/requirements2.txt
 
 # install stylize
-go get github.com/justbuchanan/stylize
+if [ -z "$GOPATH" ]; then
+    echo "[WARN] No GOPATH set, not installing stylize."
+else
+    go get github.com/justbuchanan/stylize
+fi
 
 # This script is run as sudo, but we don't want submodules to be owned by the
 # root user, so we use `su` to update submodules as the normal user


### PR DESCRIPTION
I made some updates to stylize and rewrote it in go (it was python before). The old version is still registered with pypi (so `pip install stylize` still works) and the code is still available at https://github.com/justbuchanan/stylize/tree/python. Everything should continue to work as-is.

Since robocup is the only project using stylize (that I know of), I figured I'd send an update in case you're interested in trying the new version. It's a bit faster than before and handles some edge cases better.

In addition to the setup script changes in this PR, you'll also have to set the `GOPATH` environment variable and uninstall the old python version (`pip uninstall stylize`).

Note: the new version of stylize needs some testing - let me know if you run into any issues.