### PR TITLE
Fix get closest opponent

### DIFF
--- a/soccer/gameplay/evaluation/opponent.py
+++ b/soccer/gameplay/evaluation/opponent.py
@@ -51,13 +51,13 @@ def get_closest_opponent(pos, direction_weight=1, excluded_robots=[]):
 
     closest_bot, closest_dist = None, float("inf")
     for bot in main.their_robots():
-        if bot.visible:
+        if bot.visible and bot not in excluded_robots:
             dist = (bot.pos - pos).mag()
 
             if (pos.y <= bot.pos.y):
-                dist *= direction_weight
+                dist *= (1 - direction_weight / 2)
             else:
-                dist *= (1 - direction_weight)
+                dist *= (1 + direction_weight / 2)
 
             if dist < closest_dist:
                 closest_bot = bot

--- a/soccer/gameplay/evaluation/opponent.py
+++ b/soccer/gameplay/evaluation/opponent.py
@@ -46,7 +46,7 @@ def num_on_offense():
 ## Returns the closest opponent to the pos inclusive of the directional weight
 #
 # @param direction_weight: How much to weight the positive y direction,
-#     0 <= direction weight <= 2
+#     0 <= direction weight < 2
 #     If < 1, then robots < pos.y are weighted by direction_weight
 def get_closest_opponent(pos, direction_weight=1, excluded_robots=[]):
 

--- a/soccer/gameplay/evaluation/opponent.py
+++ b/soccer/gameplay/evaluation/opponent.py
@@ -45,7 +45,8 @@ def num_on_offense():
 
 ## Returns the closest opponent to the pos inclusive of the directional weight
 #
-# @param direction_weight: How much to weight the positive y direction
+# @param direction_weight: How much to weight the positive y direction,
+#     0 <= direction weight <= 2
 #     If < 1, then robots < pos.y are weighted by direction_weight
 def get_closest_opponent(pos, direction_weight=1, excluded_robots=[]):
 

--- a/soccer/gameplay/evaluation/opponent.py
+++ b/soccer/gameplay/evaluation/opponent.py
@@ -46,7 +46,7 @@ def num_on_offense():
 ## Returns the closest opponent to the pos inclusive of the directional weight
 #
 # @param direction_weight: How much to weight the positive y direction,
-#     0 <= direction weight < 2
+#     0 <= direction weight <= 2
 #     If < 1, then robots < pos.y are weighted by direction_weight
 def get_closest_opponent(pos, direction_weight=1, excluded_robots=[]):
 
@@ -56,9 +56,9 @@ def get_closest_opponent(pos, direction_weight=1, excluded_robots=[]):
             dist = (bot.pos - pos).mag()
 
             if (pos.y <= bot.pos.y):
-                dist *= (1 - direction_weight / 2)
+                dist *= (2 - direction_weight / 2)
             else:
-                dist *= (1 + direction_weight / 2)
+                dist *= (2 + direction_weight / 2)
 
             if dist < closest_dist:
                 closest_bot = bot


### PR DESCRIPTION
Considered distance scaling factor as a function of direction weight. We want to create two functions such that a robot that is behind the goal point(closer to the enemy goal) is weighted higher. That is, if two robots are equidistant from the goal point, we want our function to return the robot that is closer to the enemy goal.
When direction weight is 0, we want our distance scaling factor to be the same for both cases
When distance weight is 2, we want our distance factor to return a significantly lower value for the robot closer to the enemy goal

the two functions I chose were f(x) = 2 - x/2 and f(x) = 2 + x/2
https://i.imgur.com/bnsWJCr.png

These two functions both return a scaling factor of 2 when direction weight is 0
When the direction weight is 0, one function returns 1 while the other function returns 3, so a robot would have to be 3x closer to the goal point for it to be selected over a robot that is behind the goal point.

Edit: Also have the function account for excluded robots


