### PR TITLE
Reduce the issue with the ball velocity being too low

### DIFF
--- a/soccer/modeling/BallFilter.cpp
+++ b/soccer/modeling/BallFilter.cpp
@@ -7,7 +7,7 @@
 
 using namespace Geometry2d;
 
-static const float Velocity_Alpha = 0.05;
+static const float Velocity_Alpha = 0.9;
 
 BallFilter::BallFilter() {}
 


### PR DESCRIPTION
Change the Alpha value from 0.05 to 0.9. This should make the ball velocity more accurate at the expense of not being smoothed as well.