### PR TITLE
Change debug error to a printout so soccer doesn't crash

### DIFF
--- a/soccer/SystemState.cpp
+++ b/soccer/SystemState.cpp
@@ -1,10 +1,10 @@
-#include <SystemState.hpp>
 #include <protobuf/LogFrame.pb.h>
-#include <LogUtils.hpp>
-#include <RobotConfig.hpp>
-#include <Robot.hpp>
-#include <Geometry2d/Polygon.hpp>
 #include <Geometry2d/Line.hpp>
+#include <Geometry2d/Polygon.hpp>
+#include <LogUtils.hpp>
+#include <Robot.hpp>
+#include <RobotConfig.hpp>
+#include <SystemState.hpp>
 #include "planning/Path.hpp"
 
 using namespace Packet;

--- a/soccer/SystemState.cpp
+++ b/soccer/SystemState.cpp
@@ -63,8 +63,12 @@ std::unique_ptr<Planning::Path> Ball::path(RJ::Time startTime) const {
 
 Planning::MotionInstant Ball::predict(RJ::Time estimateTime) const {
     if (estimateTime < time) {
-        debugThrow("Estimated Time can't be before observation time.");
-        return MotionInstant();
+        //debugThrow("Estimated Time can't be before observation time.");
+        std::cout<<"CRITICAL ERROR: Estimated Time can't be before observation time"<<std::endl;
+        std::cout<<"estimateTime: "<<RJ::timestamp(estimateTime)<<std::endl;
+        std::cout<<"actualTime: "<<RJ::timestamp(time)<<std::endl;
+        estimateTime = time;
+        //return MotionInstant();
     }
 
     MotionInstant instant;

--- a/soccer/SystemState.cpp
+++ b/soccer/SystemState.cpp
@@ -63,12 +63,16 @@ std::unique_ptr<Planning::Path> Ball::path(RJ::Time startTime) const {
 
 Planning::MotionInstant Ball::predict(RJ::Time estimateTime) const {
     if (estimateTime < time) {
-        //debugThrow("Estimated Time can't be before observation time.");
-        std::cout<<"CRITICAL ERROR: Estimated Time can't be before observation time"<<std::endl;
-        std::cout<<"estimateTime: "<<RJ::timestamp(estimateTime)<<std::endl;
-        std::cout<<"actualTime: "<<RJ::timestamp(time)<<std::endl;
+        // debugThrow("Estimated Time can't be before observation time.");
+        std::cout
+            << "CRITICAL ERROR: Estimated Time can't be before observation time"
+            << std::endl;
+        std::cout << "estimateTime: " << RJ::timestamp(estimateTime)
+                  << std::endl;
+        std::cout << "actualTime: " << RJ::timestamp(time) << std::endl;
         estimateTime = time;
-        //return MotionInstant();
+
+        // return MotionInstant();
     }
 
     MotionInstant instant;


### PR DESCRIPTION
This doesn't fix the underlying problem from #1105, it just keeps soccer from crashing, we will still need to figure out why this is happening at some point.