### PR TITLE
Get encoder values from bot

### DIFF
--- a/common/protobuf/RadioRx.proto
+++ b/common/protobuf/RadioRx.proto
@@ -69,5 +69,5 @@ message RadioRx
 	
 	optional Quaternion quaternion = 13;
 
-	repeated DebugResponses debug_responses = 15;
+	repeated uint32 enc_delta = 16;
 }

--- a/common/protobuf/RadioRx.proto
+++ b/common/protobuf/RadioRx.proto
@@ -68,6 +68,4 @@ message RadioRx
 	optional HardwareVersion hardware_version = 12 [default = Unknown];
 	
 	optional Quaternion quaternion = 13;
-
-	repeated uint32 enc_delta = 16;
 }

--- a/soccer/radio/USBRadio.cpp
+++ b/soccer/radio/USBRadio.cpp
@@ -311,6 +311,10 @@ void USBRadio::handleRxData(uint8_t* buf) {
                                     : MotorStatus::Good);
     }
 
+    for (std::size_t i = 0; i < 4; i++) {
+        packet.add_enc_delta(msg->encDeltas[i]);
+    }
+
     // fpga status
     if (FpgaStatus_IsValid(msg->fpgaStatus)) {
         packet.set_fpga_status(FpgaStatus(msg->fpgaStatus));

--- a/soccer/radio/USBRadio.cpp
+++ b/soccer/radio/USBRadio.cpp
@@ -312,7 +312,7 @@ void USBRadio::handleRxData(uint8_t* buf) {
     }
 
     for (std::size_t i = 0; i < 4; i++) {
-        packet.add_enc_delta(msg->encDeltas[i]);
+        packet.add_encoders(msg->encDeltas[i]);
     }
 
     // fpga status


### PR DESCRIPTION
Grab encoder values from the robot packet. This lets us see encoder deltas since the last packet in the radio rx packets, and the robot estimator is being built on top of this.

[robocup-fshare](https://github.com/RoboJackets/robocup-fshare/pull/1)
[robocup-firmware](https://github.com/RoboJackets/robocup-firmware/pull/55)
