### PR TITLE
bumped y_start value to avoid weird path planning in repeated lineups

### DIFF
--- a/soccer/gameplay/plays/testing/repeated_line_up.py
+++ b/soccer/gameplay/plays/testing/repeated_line_up.py
@@ -38,7 +38,7 @@ class RepeatedLineUp(play.Play):
     def generate_line(self, x_multiplier):
         x = (constants.Field.Width / 2 - constants.Robot.Radius * 2
              ) * x_multiplier
-        y_start = 1.0
+        y_start = 1.2
         line = robocup.Segment(
             robocup.Point(x, constants.Robot.Radius + y_start),
             robocup.Point(x,

--- a/soccer/gameplay/plays/testing/repeated_turning_line_up.py
+++ b/soccer/gameplay/plays/testing/repeated_turning_line_up.py
@@ -84,7 +84,7 @@ class RepeatedTurningLineUp(play.Play):
     def generate_line(self, x_multiplier):
         x = (constants.Field.Width / 2 - constants.Robot.Radius *
              2) * x_multiplier
-        y_start = 1.0
+        y_start = 1.2
         line = robocup.Segment(
             robocup.Point(x, constants.Robot.Radius + y_start), robocup.Point(
                 x, (constants.Robot.Radius * 2.3 + 0.1) * 6 + y_start))


### PR DESCRIPTION
The bottom bot on lineups barely intersects with the new defense area, causing vertical replans that are pretty gross. I didn't see this fixed in master so I bumped the y_start so the robots stay in a line (at least in sim).