### PR TITLE
Remove Model reset from play reloading

### DIFF
--- a/soccer/gameplay/main.py
+++ b/soccer/gameplay/main.py
@@ -112,6 +112,11 @@ def init(log_errors=True):
                         # FIXME: this logic should go inside the play_registry
                         play_reg_node = _play_registry.node_for_module_path(
                             module_path[1:])
+                        if play_reg_node is None:
+                            logging.error("Error reloading module '" + '.'.join(
+                                module_path) + "':")
+                            traceback.print_exc()
+                            return
                         play_reg_node.play_class = class_import.find_subclasses(
                             module, play.Play)[0]
 

--- a/soccer/gameplay/main.py
+++ b/soccer/gameplay/main.py
@@ -114,7 +114,6 @@ def init(log_errors=True):
                             module_path[1:])
                         play_reg_node.play_class = class_import.find_subclasses(
                             module, play.Play)[0]
-                        # _play_registry.modelReset.emit()
 
                         # kill currently-running stuff if needed
                     if not is_play:

--- a/soccer/gameplay/main.py
+++ b/soccer/gameplay/main.py
@@ -130,7 +130,7 @@ def init(log_errors=True):
                     if not is_play:
                         _root_play.drop_current_play()
                         _root_play.drop_goalie_behavior()
-                    elif is_play and root_play != None and root_play.__class__.__name__ == play_reg_node.play_class.__name__:
+                    elif is_play and root_play is not None and root_play.__class__.__name__ == play_reg_node.play_class.__name__:
                         _root_play.drop_current_play()
 
                 except Exception as e:
@@ -145,7 +145,7 @@ def init(log_errors=True):
                         logging.error("Error removing module '" + '.'.join(
                             module_path) + "'")
                         return
-                    if _root_play.play != None and _root_play.play.__class__.__name__ == node.play_class.__name__:
+                    if _root_play.play is not None and _root_play.play.__class__.__name__ == node.play_class.__name__:
                         _root_play.drop_current_play()
 
                     _play_registry.delete(module_path[1:])
@@ -199,7 +199,7 @@ def run():
         raise AssertionError("Error: must call init() before run()")
 
     try:
-        if root_play() != None:
+        if root_play() is not None:
             root_play().spin()
     except:
         exc = sys.exc_info()[0]

--- a/soccer/gameplay/main.py
+++ b/soccer/gameplay/main.py
@@ -47,6 +47,11 @@ def init(log_errors=True):
         mod_path = entry[0][1:]
         _play_registry.insert(mod_path, entry[1])
 
+    def _module_blacklisted(module):
+        """Return true if a module has been filtered out of autoloading."""
+        return (module[0] == '.' or
+                module.startswith('flycheck'))
+
     # this callback lets us do cool stuff when our python files change on disk
     def fswatch_callback(event_type, module_path):
         # the top-level folders we care about watching
@@ -55,7 +60,8 @@ def init(log_errors=True):
         ]
 
         # Don't load if we aren't a special module or if the filename is hidden
-        if module_path[0] in autoloadables and module_path[-1][0] != '.':
+        if (module_path[0] in autoloadables and
+                not _module_blacklisted(module_path[-1])):
             logging.info('.'.join(module_path) + " " + event_type)
 
             is_play = module_path[0] == 'plays'

--- a/soccer/gameplay/play_registry.py
+++ b/soccer/gameplay/play_registry.py
@@ -40,9 +40,6 @@ class PlayRegistry(QtCore.QAbstractItemModel):
         #     raise AssertionError("There's already a play registered for the given module path")
         category.append_child(playNode)
 
-        # note: this is a shitty way to do this - we should really only reload part of the model
-        self.modelReset.emit()
-
     def load_playbook(self, list_of_plays):
         self.clear()
         for play in list_of_plays:
@@ -52,9 +49,6 @@ class PlayRegistry(QtCore.QAbstractItemModel):
             else:
                 logging.warn("Attempt to load non-existent play " + '/'.join(
                     play) + " from playbook.")
-
-        # note: this is a shitty way to do this - we should really only reload part of the model
-        self.modelReset.emit()
 
     def delete(self, module_path):
         node = self.node_for_module_path(module_path)
@@ -68,9 +62,6 @@ class PlayRegistry(QtCore.QAbstractItemModel):
                 node = node.parent
             else:
                 break
-
-        # note: this is a shitty way to do this - we should really only reload part of the model
-        self.modelReset.emit()
 
     def clear(self):
         enabled_plays = self.get_enabled_plays_paths()


### PR DESCRIPTION
According to [this doc page](http://doc.qt.io/qt-5/qabstractitemmodel.html#modelReset) the modelReset signal shouldn't be fired by us. Additionally it collapses the treeview and dosen't seem to do anything else (from my tests at least).

I also fixed a couple crashes while using flycheck (due to reloading classes that already exist twice), by adding the ability to easily blacklist files to the play reloading system.
