### PR TITLE
New Path Planner to Intercept Ball

### DIFF
--- a/soccer/CMakeLists.txt
+++ b/soccer/CMakeLists.txt
@@ -37,6 +37,7 @@ set(ROBOCUP_LIB_SRC
     "planning/EscapeObstaclesPathPlanner.cpp"
     "planning/InterpolatedPath.cpp"
     "planning/IndependentMultiRobotPathPlanner.cpp"
+    "planning/InterceptPlanner.cpp"
     "planning/MotionConstraints.cpp"
     "planning/RotationConstraints.cpp"
     "planning/Path.cpp"

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -213,7 +213,7 @@ void OurRobot::lineKick(Point target) {
 
     disableAvoidBall();
     _motionCommand =
-        std::make_unique<Planning::LineKickCommand>(std::move(target));
+        std::make_unique<Planning::LineKickCommand>(target);
 }
 
 void OurRobot::intercept(Point target) {
@@ -221,7 +221,7 @@ void OurRobot::intercept(Point target) {
 
     disableAvoidBall();
     _motionCommand =
-        std::make_unique<Planning::InterceptCommand>(std::move(target));
+        std::make_unique<Planning::InterceptCommand>(target);
 }
 
 void OurRobot::worldVelocity(Geometry2d::Point v) {

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -216,6 +216,14 @@ void OurRobot::lineKick(Point target) {
         std::make_unique<Planning::LineKickCommand>(std::move(target));
 }
 
+void OurRobot::intercept(Point target) {
+    if (!visible) return;
+
+    disableAvoidBall();
+    _motionCommand =
+        std::make_unique<Planning::InterceptCommand>(std::move(target));
+}
+
 void OurRobot::worldVelocity(Geometry2d::Point v) {
     _motionCommand = std::make_unique<Planning::WorldVelTargetCommand>(v);
     setPath(nullptr);

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -222,6 +222,14 @@ public:
     void lineKick(Geometry2d::Point target);
 
     /**
+     * Intercept the ball as quickly as possible
+     * May just slam into the ball if it does not have time to stop 
+     * 
+     * @param target - The target position to intercept the ball at
+     */
+    void intercept(Geometry2d::Point target);
+
+    /**
      * @brief Move to a given point using the default RRT planner
      * @param endSpeed - the speed we should be going when we reach the end of
      * the path

--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -793,6 +793,7 @@ BOOST_PYTHON_MODULE(robocup) {
         .def("face", &OurRobot::face)
         .def("pivot", &OurRobot::pivot)
         .def("line_kick", &OurRobot::lineKick)
+        .def("intercept", &OurRobot::intercept)
         .def("set_planning_priority", &OurRobot::setPlanningPriority)
         .def("set_max_angle_speed", OurRobot_set_max_angle_speed)
         .def("set_max_speed", OurRobot_set_max_speed)

--- a/soccer/gameplay/skills/intercept.py
+++ b/soccer/gameplay/skills/intercept.py
@@ -43,8 +43,8 @@ class Intercept(single_robot_behavior.SingleRobotBehavior):
             #self.robot.move_to_direct(self.target_pos)
             self.robot.intercept(self.target_pos)
 
-            #if self.faceBall:
-            #    self.robot.face(main.ball().pos)
+            if self.faceBall:
+                self.robot.face(main.ball().pos)
 
     def role_requirements(self):
         reqs = super().role_requirements()

--- a/soccer/gameplay/skills/intercept.py
+++ b/soccer/gameplay/skills/intercept.py
@@ -40,10 +40,11 @@ class Intercept(single_robot_behavior.SingleRobotBehavior):
                 self.target_pos = self.ball_line().nearest_point(
                     self.robot.pos)
 
-            self.robot.move_to_direct(self.target_pos)
+            #self.robot.move_to_direct(self.target_pos)
+            self.robot.intercept(self.target_pos)
 
-            if self.faceBall:
-                self.robot.face(main.ball().pos)
+            #if self.faceBall:
+            #    self.robot.face(main.ball().pos)
 
     def role_requirements(self):
         reqs = super().role_requirements()

--- a/soccer/gameplay/skills/intercept.py
+++ b/soccer/gameplay/skills/intercept.py
@@ -40,7 +40,6 @@ class Intercept(single_robot_behavior.SingleRobotBehavior):
                 self.target_pos = self.ball_line().nearest_point(
                     self.robot.pos)
 
-            #self.robot.move_to_direct(self.target_pos)
             self.robot.intercept(self.target_pos)
 
             if self.faceBall:

--- a/soccer/planning/InterceptPlanner.cpp
+++ b/soccer/planning/InterceptPlanner.cpp
@@ -1,0 +1,104 @@
+#include "InterceptPlanner.hpp"
+
+#include <Configuration.hpp>
+#include <motion/TrapezoidalMotion.hpp>
+
+#include <iostream>
+
+#include "RRTPlanner.hpp"
+#include "MotionInstant.hpp"
+
+namespace Planning{
+
+bool InterceptPlanner::shouldReplan(const PlanRequest& planRequest) const {
+    // Intercept point is > 1 radius from current ball path
+    std::cout << "Should Replace" << std::endl;
+    return false;
+}
+
+std::unique_ptr<Path> InterceptPlanner::run(PlanRequest& planRequest) {
+    std::cout << "Entering run" << std::endl;
+
+    const InterceptCommand& command = 
+        dynamic_cast<const InterceptCommand&>(*planRequest.motionCommand);
+
+    targetInterceptPos = command.target;
+
+    // Start state for the specified robot
+    const MotionInstant& startInstant = planRequest.start;
+    // All the max velocity / acceleration constraints for translation / rotation
+    const MotionConstraints& motionConstraints = planRequest.constraints.mot;
+    const RobotConstraints& robotConstraints = planRequest.constraints;
+    // List of obstacles
+    Geometry2d::ShapeSet& obstacles = planRequest.obstacles;
+    std::vector<DynamicObstacle>& dynamicObstacles = planRequest.dynamicObstacles;
+
+    SystemState systemState = planRequest.systemState;
+    const Ball& ball = systemState.ball;
+
+    const RJ::Time curTime = RJ::now();
+
+    // Intercept the ball at closest point to the ball vel
+    
+    // Get closest point to ball vel vector
+    // Calc ball time to pos
+    // Find path to point
+    // Up end vel until time to pos = ball pos
+
+    MotionInstant ballCurrent = ball.predict(curTime);
+    
+    // Normalized vector between target and robot
+    Geometry2d::Point botToTargetNorm = (targetInterceptPos - startInstant.pos).normalized();
+
+    // Time for ball to hit target point
+    RJ::Seconds ballToPointTime = ball.estimateTimeTo(targetInterceptPos) - curTime;
+
+    std::unique_ptr<Path> path;
+    std::vector<Geometry2d::Point> startEndPoints{startInstant.pos, targetInterceptPos};
+
+    std::cout << "Starting to check velocities" << std::endl;
+
+    // Scale the end velocity by % of max velocity to see if we can reach the target
+    // at the same time as the ball
+    for (double mag = 0.0; mag <= 1.0; mag += .05) {
+        path = RRTPlanner::generatePath(startEndPoints, obstacles, motionConstraints,
+                                        startInstant.vel, 
+                                        mag*motionConstraints.maxSpeed * botToTargetNorm);
+
+        // First path where we can reach the point at or before the ball
+        // If the end velocity is not 0, you should reach the point as close
+        // to the ball time as possible to just ram it
+        if (path) {
+            if (path->getDuration() <= ballToPointTime) {
+                std::cout << "Returning" << std::endl;
+                path->setDebugText("Found Path " + QString::number(path->getDuration().count()));
+                std::cout << "Done Printing" << std::endl;
+                
+                return std::make_unique<AngleFunctionPath>(
+                    std::move(path), 
+                    angleFunctionForCommandType(FacePointCommand(ball.pos))); 
+            }
+        }
+    }
+
+    std::cout << "Giving up" << std::endl;
+
+    MotionInstant target(targetInterceptPos, Geometry2d::Point(0, 0));
+
+    // Couldn't find a good path, give up
+    std::unique_ptr<MotionCommand> rrtCommand =
+        std::make_unique<PathTargetCommand>(target);
+
+    PlanRequest request = PlanRequest(systemState, startInstant, std::move(rrtCommand),
+                                      robotConstraints, nullptr, obstacles,
+                                      dynamicObstacles, planRequest.shellID);
+    path = rrtPlanner.run(request);
+    path->setDebugText("Giving Up");
+
+    std::cout << "Returning" << std::endl;
+
+    return std::make_unique<AngleFunctionPath>(
+        std::move(path),
+        angleFunctionForCommandType(FacePointCommand(targetInterceptPos)));
+}
+}

--- a/soccer/planning/InterceptPlanner.cpp
+++ b/soccer/planning/InterceptPlanner.cpp
@@ -37,14 +37,14 @@ std::unique_ptr<Path> InterceptPlanner::run(PlanRequest& planRequest) {
     const RJ::Time curTime = RJ::now();
 
     // Intercept the ball at closest point to the ball vel
-    
+
     // Get closest point to ball vel vector
     // Calc ball time to pos
     // Find path to point
     // Up end vel until time to pos = ball pos
 
     MotionInstant ballCurrent = ball.predict(curTime);
-    
+
 
     // Time for ball to hit target point
     Geometry2d::Point targetPosOnLine;
@@ -63,9 +63,17 @@ std::unique_ptr<Path> InterceptPlanner::run(PlanRequest& planRequest) {
     // Scale the end velocity by % of max velocity to see if we can reach the target
     // at the same time as the ball
     for (double mag = 0.0; mag <= 1.0; mag += .05) {
-        path = RRTPlanner::generatePath(startEndPoints, obstacles, motionConstraints,
-                                        startInstant.vel, 
-                                        mag*motionConstraints.maxSpeed * botToTargetNorm);
+        // path = RRTPlanner::generatePath(startEndPoints, obstacles, motionConstraints,
+        //                                 startInstant.vel,
+        //                                 mag*motionConstraints.maxSpeed * botToTargetNorm);
+
+        MotionInstant finalStoppingMotion(targetPosOnLine, Geometry2d::Point(0,0));
+        std::unique_ptr<MotionCommand> directCommand =
+                std::make_unique<DirectPathTargetCommand>(finalStoppingMotion);
+        auto request = PlanRequest(systemState, startInstant, std::move(directCommand),
+                                   robotConstraints, nullptr, obstacles,
+                                   dynamicObstacles, planRequest.shellID);
+        std::unique_ptr<Path> path = directPlanner.run(request);
 
         // First path where we can reach the point at or before the ball
         // If the end velocity is not 0, you should reach the point as close
@@ -77,10 +85,10 @@ std::unique_ptr<Path> InterceptPlanner::run(PlanRequest& planRequest) {
                 path->setDebugText("Found Path. RT " + QString::number(botToPointTime.count(), 'g', 2) +
                                    " BT " + QString::number(ballToPointTime.count(), 'g', 2) +
                                    " FS " + QString::number(mag));
-                
+
                 return std::make_unique<AngleFunctionPath>(
-                    std::move(path), 
-                    angleFunctionForCommandType(FacePointCommand(ball.pos))); 
+                    std::move(path),
+                    angleFunctionForCommandType(FacePointCommand(ball.pos)));
             }
         }
     }
@@ -89,7 +97,7 @@ std::unique_ptr<Path> InterceptPlanner::run(PlanRequest& planRequest) {
 
     MotionInstant target;
     target.pos = targetPosOnLine;
-    
+
     // If we are already almost at the correct point, dont speed out of the way
     // We may not find a path that is shorter to the ball because our ball filter is off a lot...
     if (botToTarget.mag() < Robot_Radius / 2) {
@@ -101,13 +109,13 @@ std::unique_ptr<Path> InterceptPlanner::run(PlanRequest& planRequest) {
      }
 
     // Couldn't find a good path, give up
-    std::unique_ptr<MotionCommand> rrtCommand =
-        std::make_unique<PathTargetCommand>(target);
+    std::unique_ptr<MotionCommand> directCommand =
+        std::make_unique<DirectPathTargetCommand>(target);
 
-    PlanRequest request = PlanRequest(systemState, startInstant, std::move(rrtCommand),
+    PlanRequest request = PlanRequest(systemState, startInstant, std::move(directCommand),
                                       robotConstraints, nullptr, obstacles,
                                       dynamicObstacles, planRequest.shellID);
-    path = rrtPlanner.run(request);
+    path = directPlanner.run(request);
     path->setDebugText(debug + ". RT " + QString::number(botToPointTime.count(), 'g', 2) +
                        " BT " + QString::number(ballToPointTime.count(), 'g', 2));
 

--- a/soccer/planning/InterceptPlanner.hpp
+++ b/soccer/planning/InterceptPlanner.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "RRTPlanner.hpp"
+#include "SingleRobotPathPlanner.hpp"
+
+class Configuration;
+class ConfigDouble;
+
+namespace Planning {
+
+/**
+ * Planner which tries to intercept the path ball as quickly as possible
+ * Whether this means moving and stopping in the path of the ball
+ * or completely driving through and "slapping" the ball.
+ * 
+ * Mostly used for the goalie / defenders to block shots
+ */
+
+class InterceptPlanner : public SingleRobotPathPlanner {
+public:
+    InterceptPlanner() : SingleRobotPathPlanner(false), rrtPlanner(0, 250){};
+    virtual std::unique_ptr<Path> run(PlanRequest& planRequest) override;
+
+    virtual MotionCommand::CommandType commandType() const override {
+        return MotionCommand::Intercept;
+    }
+
+private:
+    bool shouldReplan(const PlanRequest& planRequest) const;
+
+    RRTPlanner rrtPlanner;
+    Geometry2d::Point targetInterceptPos;
+    int reusePathCount = 0;
+};
+
+} // namespace Planning

--- a/soccer/planning/InterceptPlanner.hpp
+++ b/soccer/planning/InterceptPlanner.hpp
@@ -18,7 +18,9 @@ namespace Planning {
 
 class InterceptPlanner : public SingleRobotPathPlanner {
 public:
-    InterceptPlanner() : SingleRobotPathPlanner(false), directPlanner(){};
+    InterceptPlanner() : SingleRobotPathPlanner(false),
+                         directPlanner(),
+                         prevPathTarget(0, 0){};
 
     virtual std::unique_ptr<Path> run(PlanRequest& planRequest) override;
 
@@ -28,5 +30,6 @@ public:
 
 private:
     DirectTargetPathPlanner directPlanner;
+    Geometry2d::Point prevPathTarget;
 };
 } // namespace Planning

--- a/soccer/planning/InterceptPlanner.hpp
+++ b/soccer/planning/InterceptPlanner.hpp
@@ -19,6 +19,7 @@ namespace Planning {
 class InterceptPlanner : public SingleRobotPathPlanner {
 public:
     InterceptPlanner() : SingleRobotPathPlanner(false), directPlanner(){};
+
     virtual std::unique_ptr<Path> run(PlanRequest& planRequest) override;
 
     virtual MotionCommand::CommandType commandType() const override {
@@ -26,11 +27,8 @@ public:
     }
 
 private:
-    bool shouldReplan(const PlanRequest& planRequest) const;
-
     DirectTargetPathPlanner directPlanner;
     Geometry2d::Point targetInterceptPos;
-    int reusePathCount = 0;
 };
 
 } // namespace Planning

--- a/soccer/planning/InterceptPlanner.hpp
+++ b/soccer/planning/InterceptPlanner.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "RRTPlanner.hpp"
+#include "DirectTargetPathPlanner.hpp"
 #include "SingleRobotPathPlanner.hpp"
 
 class Configuration;
@@ -18,7 +18,7 @@ namespace Planning {
 
 class InterceptPlanner : public SingleRobotPathPlanner {
 public:
-    InterceptPlanner() : SingleRobotPathPlanner(false), rrtPlanner(0, 250){};
+    InterceptPlanner() : SingleRobotPathPlanner(false), directPlanner(){};
     virtual std::unique_ptr<Path> run(PlanRequest& planRequest) override;
 
     virtual MotionCommand::CommandType commandType() const override {
@@ -28,7 +28,7 @@ public:
 private:
     bool shouldReplan(const PlanRequest& planRequest) const;
 
-    RRTPlanner rrtPlanner;
+    DirectTargetPathPlanner directPlanner;
     Geometry2d::Point targetInterceptPos;
     int reusePathCount = 0;
 };

--- a/soccer/planning/InterceptPlanner.hpp
+++ b/soccer/planning/InterceptPlanner.hpp
@@ -28,7 +28,5 @@ public:
 
 private:
     DirectTargetPathPlanner directPlanner;
-    Geometry2d::Point targetInterceptPos;
 };
-
 } // namespace Planning

--- a/soccer/planning/MotionCommand.hpp
+++ b/soccer/planning/MotionCommand.hpp
@@ -21,6 +21,7 @@ public:
         DirectPathTarget,
         TuningPath,
         LineKick,
+        Intercept,
         None
     };
     virtual ~MotionCommand() = default;
@@ -102,6 +103,17 @@ struct LineKickCommand : public MotionCommand {
 
     virtual std::unique_ptr<Planning::MotionCommand> clone() const override {
         return std::make_unique<LineKickCommand>(*this);
+    };
+
+    const Geometry2d::Point target;
+};
+
+struct InterceptCommand : public MotionCommand {
+    explicit InterceptCommand(Geometry2d::Point target)
+        : MotionCommand(MotionCommand::Intercept), target(target){};
+
+    virtual std::unique_ptr<Planning::MotionCommand> clone() const override {
+        return std::make_unique<InterceptCommand>(*this);
     };
 
     const Geometry2d::Point target;

--- a/soccer/planning/SingleRobotPathPlanner.cpp
+++ b/soccer/planning/SingleRobotPathPlanner.cpp
@@ -3,6 +3,7 @@
 #include "TuningPathPlanner.hpp"
 #include "EscapeObstaclesPathPlanner.hpp"
 #include "LineKickPlanner.hpp"
+#include "InterceptPlanner.hpp"
 //#include "PivotPathPlanner.hpp"
 //#include "RRTPlanner.hpp"
 //#include "TargetVelPathPlanner.hpp"
@@ -50,6 +51,9 @@ std::unique_ptr<SingleRobotPathPlanner> PlannerForCommandType(
             break;
         case MotionCommand::LineKick:
             planner = new LineKickPlanner();
+            break;
+        case MotionCommand::Intercept:
+            planner = new InterceptPlanner();
             break;
         case MotionCommand::None:
             planner = new EscapeObstaclesPathPlanner();


### PR DESCRIPTION
Intercepts ball as quickly as possible. It tries to stop in the path of the ball if there is enough time, but if there isn't, it will just hit the ball while the robot is in motion. This is mostly geared towards the goalie

@ashaw596 I'm getting some segfaults when I try to test this. It's getting through the run method completely and dies sometime after I return the path. Any ideas where I should look to try and debug it?

Also, what happens when I pass a final velocity that is much higher than can realistically be reached in the distance between the start and end of the path? Is it actually smart enough to cut it down to something realistic? Here's specifically the code I'm talking about.

```
path = RRTPlanner::generatePath(startEndPoints, obstacles, motionConstraints,
                                        startInstant.vel, 
                                        mag*motionConstraints.maxSpeed * botToTargetNorm);
```