### PR TITLE
Disable Dribbler When Out of Bounds

### DIFF
--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -47,6 +47,7 @@ REGISTER_CONFIGURABLE(OurRobot)
 ConfigDouble* OurRobot::_selfAvoidRadius;
 ConfigDouble* OurRobot::_oppAvoidRadius;
 ConfigDouble* OurRobot::_oppGoalieAvoidRadius;
+ConfigDouble* OurRobot::_dribbleOutOfBoundsMult;
 
 void OurRobot::createConfiguration(Configuration* cfg) {
     _selfAvoidRadius =
@@ -55,6 +56,8 @@ void OurRobot::createConfiguration(Configuration* cfg) {
                                        Robot_Radius - 0.01);
     _oppGoalieAvoidRadius = new ConfigDouble(
         cfg, "PathPlanner/oppGoalieAvoidRadius", Robot_Radius + 0.05);
+    _dribbleOutOfBoundsMult = new ConfigDouble(
+        cfg, "PathPlanner/dribbleOutOfBoundsMult", 1.05);
 }
 
 OurRobot::OurRobot(int shell, SystemState* state)
@@ -265,10 +268,13 @@ float OurRobot::kickTimer() const {
 }
 
 void OurRobot::dribble(uint8_t speed) {
-    uint8_t scaled = *config->dribbler.multiplier * speed;
-    control->set_dvelocity(scaled);
+    Geometry2d::Rect modifiedField = Field_Dimensions::Current_Dimensions.FieldRect() * (*_dribbleOutOfBoundsMult);
+    if (modifiedField.containsPoint(pos)) {
+        uint8_t scaled = *config->dribbler.multiplier * speed;
+        control->set_dvelocity(scaled);
 
-    *_cmdText << "dribble(" << (float)speed << ")" << endl;
+        *_cmdText << "dribble(" << (float)speed << ")" << endl;
+    }
 }
 
 void OurRobot::face(Geometry2d::Point pt) {

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -57,7 +57,7 @@ void OurRobot::createConfiguration(Configuration* cfg) {
     _oppGoalieAvoidRadius = new ConfigDouble(
         cfg, "PathPlanner/oppGoalieAvoidRadius", Robot_Radius + 0.05);
     _dribbleOutOfBoundsOffset = new ConfigDouble(
-        cfg, "PathPlanner/dribbleOutOfBoundsOffset", 1.0);
+        cfg, "PathPlanner/dribbleOutOfBoundsOffset", 0.05);
 }
 
 OurRobot::OurRobot(int shell, SystemState* state)
@@ -268,8 +268,14 @@ float OurRobot::kickTimer() const {
 }
 
 void OurRobot::dribble(uint8_t speed) {
-    Geometry2d::Rect modifiedField = Field_Dimensions::Current_Dimensions.FieldRect();
-    modifiedField.expand(*new Point(*_dribbleOutOfBoundsOffset,*_dribbleOutOfBoundsOffset));
+    Field_Dimensions current_dimensions = Field_Dimensions::Current_Dimensions;
+    float offset = *_dribbleOutOfBoundsOffset;
+
+    Geometry2d::Rect modifiedField = Geometry2d::Rect(
+        Point((-current_dimensions.Width() / 2) - offset, -offset),
+        Point((current_dimensions.Width() / 2) + offset,
+              current_dimensions.Length() + offset));
+
     if (modifiedField.containsPoint(pos)) {
         uint8_t scaled = *config->dribbler.multiplier * speed;
         control->set_dvelocity(scaled);

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -274,6 +274,8 @@ void OurRobot::dribble(uint8_t speed) {
         control->set_dvelocity(scaled);
 
         *_cmdText << "dribble(" << (float)speed << ")" << endl;
+    } else {
+        control->set_dvelocity(0);
     }
 }
 

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -269,7 +269,7 @@ float OurRobot::kickTimer() const {
 
 // TODO make speed a float from 0->1 to make this more clear.
 void OurRobot::dribble(uint8_t speed) {
-\    Field_Dimensions current_dimensions = Field_Dimensions::Current_Dimensions;
+    Field_Dimensions current_dimensions = Field_Dimensions::Current_Dimensions;
     float offset = *_dribbleOutOfBoundsOffset;
 
     Geometry2d::Rect modifiedField = Geometry2d::Rect(

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -47,7 +47,7 @@ REGISTER_CONFIGURABLE(OurRobot)
 ConfigDouble* OurRobot::_selfAvoidRadius;
 ConfigDouble* OurRobot::_oppAvoidRadius;
 ConfigDouble* OurRobot::_oppGoalieAvoidRadius;
-ConfigDouble* OurRobot::_dribbleOutOfBoundsMult;
+ConfigDouble* OurRobot::_dribbleOutOfBoundsOffset;
 
 void OurRobot::createConfiguration(Configuration* cfg) {
     _selfAvoidRadius =
@@ -56,8 +56,8 @@ void OurRobot::createConfiguration(Configuration* cfg) {
                                        Robot_Radius - 0.01);
     _oppGoalieAvoidRadius = new ConfigDouble(
         cfg, "PathPlanner/oppGoalieAvoidRadius", Robot_Radius + 0.05);
-    _dribbleOutOfBoundsMult = new ConfigDouble(
-        cfg, "PathPlanner/dribbleOutOfBoundsMult", 1.05);
+    _dribbleOutOfBoundsOffset = new ConfigDouble(
+        cfg, "PathPlanner/dribbleOutOfBoundsOffset", 1.0);
 }
 
 OurRobot::OurRobot(int shell, SystemState* state)
@@ -268,7 +268,8 @@ float OurRobot::kickTimer() const {
 }
 
 void OurRobot::dribble(uint8_t speed) {
-    Geometry2d::Rect modifiedField = Field_Dimensions::Current_Dimensions.FieldRect() * (*_dribbleOutOfBoundsMult);
+    Geometry2d::Rect modifiedField = Field_Dimensions::Current_Dimensions.FieldRect();
+    modifiedField.expand(*new Point(*_dribbleOutOfBoundsOffset,*_dribbleOutOfBoundsOffset));
     if (modifiedField.containsPoint(pos)) {
         uint8_t scaled = *config->dribbler.multiplier * speed;
         control->set_dvelocity(scaled);

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -51,7 +51,8 @@ class RRTPlanner;
 /**
  * @brief Contains robot motion state data
  * @details This class contains data that comes from the vision system
- * including position data and which camera this robot was seen by and
+ * including position data and wDouble check with mechanical to see if they still want this
+hich camera this robot was seen by and
  * what time it was last seen.
  */
 class RobotPose {
@@ -581,6 +582,7 @@ private:
     static ConfigDouble* _selfAvoidRadius;
     static ConfigDouble* _oppAvoidRadius;
     static ConfigDouble* _oppGoalieAvoidRadius;
+    static ConfigDouble* _dribbleOutOfBoundsMult;
 
     int8_t _planningPriority;
 };

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -581,7 +581,7 @@ private:
     static ConfigDouble* _selfAvoidRadius;
     static ConfigDouble* _oppAvoidRadius;
     static ConfigDouble* _oppGoalieAvoidRadius;
-    static ConfigDouble* _dribbleOutOfBoundsMult;
+    static ConfigDouble* _dribbleOutOfBoundsOffset;
 
     int8_t _planningPriority;
 };

--- a/soccer/Robot.hpp
+++ b/soccer/Robot.hpp
@@ -51,8 +51,7 @@ class RRTPlanner;
 /**
  * @brief Contains robot motion state data
  * @details This class contains data that comes from the vision system
- * including position data and wDouble check with mechanical to see if they still want this
-hich camera this robot was seen by and
+ * including position data and which camera this robot was seen by and
  * what time it was last seen.
  */
 class RobotPose {


### PR DESCRIPTION
Closes #1163  Added a quick check in Robot.cpp that checks if the robot is outside of configurable field bounds and disables the dribblers. May need to move config out of pathplanning tab.