### PR TITLE
Add fixes for downgraded git version in dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ ENV LANG en_US.UTF-8
 COPY . ~/robocup-software
 WORKDIR ~/robocup-software
 
-RUN sudo ./util/ubuntu-setup --yes
+RUN sudo ./util/ubuntu-setup --yes --no-submodules

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -34,4 +34,4 @@ ENV LANG en_US.UTF-8
 COPY . ~/robocup-software
 WORKDIR ~/robocup-software
 
-RUN sudo ./util/ubuntu-setup --yes
+RUN sudo ./util/ubuntu-setup --yes --no-submodules

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -18,6 +18,7 @@ DISTRO_STR="The linux distro you are using is not supported by ubuntu-setup. Ple
 OVERWRITE_SOURCES=false
 YES=false
 SYSTEM="unknown"
+NO_SUBMODULES=false
 
 if cat /etc/os-release | grep -iq '^NAME=.*Debian'; then # dont add repositories on debian, unsupported
     echo "[WARN] You are using a flavor of debian. This configuration is not officially supported..." >&2
@@ -75,6 +76,10 @@ do
         -h|--help)
             echo -e "$HELP_STR"
             exit 1
+            ;;
+        --no-submodules)
+            # only for CI
+            NO_SUBMODULES=true
             ;;
         *)
             echo "Unrecognized Option: $i"
@@ -158,14 +163,15 @@ pip3 install -r $BASE/util/requirements3.txt
 # install python2 requirements
 pip2 install -r $BASE/util/requirements2.txt
 
-# This script is run as sudo, but we don't want submodules to be owned by the
-# root user, so we use `su` to update submodules as the normal user
-SETUP_USER="$SUDO_USER"
-if [ -z "$SETUP_USER" ]; then
-    SETUP_USER="$(whoami)"
+if [ "$NO_SUBMODULES" != "true" ]; then
+    # This script is run as sudo, but we don't want submodules to be owned by the
+    # root user, so we use `su` to update submodules as the normal user
+    echo "-- Updating submodules"
+    SETUP_USER="$SUDO_USER"
+    if [ -z "$SETUP_USER" ]; then
+        SETUP_USER="$(whoami)"
+    fi
+    chown -R $SETUP_USER:$SETUP_USER $BASE/external
+    su $SETUP_USER -c 'git submodule sync'
+    su $SETUP_USER -c 'git submodule update --init --recursive'
 fi
-
-echo "-- Updating submodules"
-chown -R $SETUP_USER:$SETUP_USER $BASE/external
-su $SETUP_USER -c 'git submodule sync'
-su $SETUP_USER -c 'git submodule update --init --recursive'


### PR DESCRIPTION
At some point, the docker hub downgraded their version of git to bootstrap the dockerfiles (or they're using faulty scripts somewhere), which causes the docker hub baseimage builds to fail. This fixes that by turning off submodules in the docker hub build (they should still get populated on circle since they should have an up-to-date git version).

[here's the basimage build page for the curious](https://hub.docker.com/r/robojackets/robocup-software/builds/)

This incorporates the fixes I found in https://github.com/RoboJackets/robocup-firmware/pull/66