### PR TITLE
Fixed Memory Leak in Nelder Mead Python Function Pointer

### DIFF
--- a/soccer/CMakeLists.txt
+++ b/soccer/CMakeLists.txt
@@ -30,6 +30,7 @@ set(ROBOCUP_LIB_SRC
     "optimization/GradientAscent1D.cpp"
     "optimization/ParallelGradientAscent1D.cpp"
     "optimization/NelderMead2D.cpp"
+    "optimization/PythonFunctionWrapper.cpp"
     "planning/CompositePath.cpp"
     "planning/DynamicObstacle.cpp"
     "planning/DirectTargetPathPlanner.cpp"

--- a/soccer/gameplay/evaluation/passing_positioning.py
+++ b/soccer/gameplay/evaluation/passing_positioning.py
@@ -102,7 +102,7 @@ def eval_best_receive_point(kick_point,
                                  field_weights, weights)
     cppfunc = robocup.PythonFunctionWrapper(pythfunc)
     nmConfig = robocup.NelderMead2DConfig(
-        cppfunc.get_function(), kick_point, nelder_mead_args[0], nelder_mead_args[1],
+        cppfunc, kick_point, nelder_mead_args[0], nelder_mead_args[1],
         nelder_mead_args[2], nelder_mead_args[3], nelder_mead_args[4],
         nelder_mead_args[5], nelder_mead_args[6], nelder_mead_args[7],
         nelder_mead_args[8])

--- a/soccer/gameplay/evaluation/passing_positioning.py
+++ b/soccer/gameplay/evaluation/passing_positioning.py
@@ -100,9 +100,9 @@ def eval_best_receive_point(kick_point,
                             weights=(1, 4, 15, 1)):
     pythfunc = functools.partial(eval_single_point, kick_point, ignore_robots,
                                  field_weights, weights)
-    cppfunc = robocup.stdfunction(pythfunc)
+    cppfunc = robocup.PythonFunctionWrapper(pythfunc)
     nmConfig = robocup.NelderMead2DConfig(
-        cppfunc, kick_point, nelder_mead_args[0], nelder_mead_args[1],
+        cppfunc.get_function(), kick_point, nelder_mead_args[0], nelder_mead_args[1],
         nelder_mead_args[2], nelder_mead_args[3], nelder_mead_args[4],
         nelder_mead_args[5], nelder_mead_args[6], nelder_mead_args[7],
         nelder_mead_args[8])

--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -26,6 +26,7 @@ using namespace boost::python;
 #include "motion/TrapezoidalMotion.hpp"
 #include "optimization/NelderMead2D.hpp"
 #include "optimization/NelderMead2DConfig.hpp"
+#include "optimization/PythonFunctionWrapper.hpp"
 #include "planning/MotionConstraints.hpp"
 
 #include <boost/python/exception_translator.hpp>
@@ -593,22 +594,30 @@ void KickEval_add_excluded_robot(KickEvaluator* self, Robot* robot) {
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Point_overloads, normalized, 0, 1)
 
+boost::shared_ptr<PythonFunctionWrapper> PythonFunctionWrapper_constructor(
+    PyObject* pf) {
+
+    return boost::shared_ptr<PythonFunctionWrapper>(new PythonFunctionWrapper(pf));
+}
+
 float Point_get_x(const Geometry2d::Point* self) { return self->x(); }
 float Point_get_y(const Geometry2d::Point* self) { return self->y(); }
 void Point_set_x(Geometry2d::Point* self, float x) { self->x() = x; }
 void Point_set_y(Geometry2d::Point* self, float y) { self->y() = y; }
 
 boost::shared_ptr<NelderMead2DConfig> NelderMead2DConfig_constructor(
-    std::function<float(Geometry2d::Point)>* function,
+    PythonFunctionWrapper* functionWrapper,
     Geometry2d::Point start = Geometry2d::Point(0, 0),
     Geometry2d::Point step = Geometry2d::Point(1, 1),
     Geometry2d::Point minDist = Geometry2d::Point(0.001, 0.001),
     float reflectionCoeff = 1, float expansionCoeff = 2,
     float contractionCoeff = 0.5, float shrinkCoeff = 0.5,
     int maxIterations = 100, float maxValue = 0, float maxThresh = 0) {
+
     return boost::shared_ptr<NelderMead2DConfig>(new NelderMead2DConfig(
-        *function, start, step, minDist, reflectionCoeff, expansionCoeff,
-        contractionCoeff, shrinkCoeff, maxIterations, maxValue, maxThresh));
+        functionWrapper->f, start, step, minDist, 
+        reflectionCoeff, expansionCoeff, contractionCoeff, shrinkCoeff,
+        maxIterations, maxValue, maxThresh));
 }
 
 boost::shared_ptr<NelderMead2D> NelderMead2D_constructor(
@@ -929,8 +938,8 @@ BOOST_PYTHON_MODULE(robocup) {
         .def("eval_pt_to_our_goal", &KickEval_eval_pt_to_our_goal)
         .def("eval_pt_to_seg", &KickEval_eval_pt_to_seg);
 
-    class_<PythonFunctionWrapper>("PythonFunctionWrapper")
-        .def("get_function", &PythonFunctionWrapper::getFunction);
+    class_<PythonFunctionWrapper>("PythonFunctionWrapper", no_init)
+        .def("__init__", make_constructor(&PythonFunctionWrapper_constructor));
 
     class_<NelderMead2DConfig>("NelderMead2DConfig", no_init)
         .def("__init__", make_constructor(&NelderMead2DConfig_constructor),

--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -598,35 +598,6 @@ float Point_get_y(const Geometry2d::Point* self) { return self->y(); }
 void Point_set_x(Geometry2d::Point* self, float x) { self->x() = x; }
 void Point_set_y(Geometry2d::Point* self, float y) { self->y() = y; }
 
-/**
- * Python function must be in the form...
- * [float] pythonFunc(... float x, float y)
- */
-float point_python_callback(Geometry2d::Point p, PyObject* pyfun) {
-    PyObject* pyresult =
-        PyObject_CallObject(pyfun, Py_BuildValue("ff", p.x(), p.y()));
-
-    if (pyresult == NULL) {
-        std::cerr << "Python callback function returned a bad value with args ";
-        std::cerr << p << std::endl;
-        return -1;
-    }
-
-    return PyFloat_AsDouble(pyresult);
-}
-
-boost::shared_ptr<std::function<float(Geometry2d::Point)>>
-stdfunction_constructor(PyObject* function) {
-    Py_INCREF(function);
-
-    // Create aliased function to hid python function args
-    std::function<float(Geometry2d::Point)> f =
-        std::bind(&point_python_callback, std::placeholders::_1, function);
-
-    return boost::shared_ptr<std::function<float(Geometry2d::Point)>>(
-        new std::function<float(Geometry2d::Point)>(f));
-}
-
 boost::shared_ptr<NelderMead2DConfig> NelderMead2DConfig_constructor(
     std::function<float(Geometry2d::Point)>* function,
     Geometry2d::Point start = Geometry2d::Point(0, 0),
@@ -958,9 +929,8 @@ BOOST_PYTHON_MODULE(robocup) {
         .def("eval_pt_to_our_goal", &KickEval_eval_pt_to_our_goal)
         .def("eval_pt_to_seg", &KickEval_eval_pt_to_seg);
 
-    class_<std::function<float(Geometry2d::Point)>,
-           std::function<float(Geometry2d::Point)>*>("stdfunction", no_init)
-        .def("__init__", make_constructor(&stdfunction_constructor));
+    class_<PythonFunctionWrapper>("PythonFunctionWrapper")
+        .def("get_function", &PythonFunctionWrapper::getFunction);
 
     class_<NelderMead2DConfig>("NelderMead2DConfig", no_init)
         .def("__init__", make_constructor(&NelderMead2DConfig_constructor),

--- a/soccer/optimization/PythonFunctionWrapper.cpp
+++ b/soccer/optimization/PythonFunctionWrapper.cpp
@@ -1,0 +1,38 @@
+#include "PythonFunctionWrapper.hpp"
+#include <iostream>
+
+float cpp_function_cb(Geometry2d::Point p, PyObject* pyfunc) {
+    if (pyfunc == nullptr) {
+        std::cerr << "Pyfunction is null. Does the PythonFunctionWrapper " <<
+                     "have the same lifetime as the NelderMead object?" << std::endl;
+
+        return -1;
+    }
+
+    PyObject* pyresult =
+        PyObject_CallObject(pyfunc, Py_BuildValue("ff", p.x(), p.y()));
+
+    if (pyresult == NULL) {
+        std::cerr << "Python callback function returned a bad value with args ";
+        std::cerr << p << std::endl;
+
+        return -1;
+    }
+
+    return PyFloat_AsDouble(pyresult);
+}
+
+PythonFunctionWrapper::PythonFunctionWrapper(PyObject* pf) {
+    pyFunc = pf;
+
+    Py_INCREF(pyFunc);
+
+    f = std::bind(&cpp_function_cb,
+                  std::placeholders::_1,
+                  pyFunc);
+}
+
+PythonFunctionWrapper::~PythonFunctionWrapper() {
+    Py_DECREF(pyFunc);
+    pyFunc = nullptr;
+}

--- a/soccer/optimization/PythonFunctionWrapper.hpp
+++ b/soccer/optimization/PythonFunctionWrapper.hpp
@@ -3,48 +3,14 @@
 #include <Geometry2d/Point.hpp>
 
 
-float cpp_function_cb(Geometry2d::Point p, PyObject* pyfunc) {
-    if (pyfunc == nullptr) {
-        std::cerr << "Pyfunction is null. Does the PythonFunctionWrapper have the same lifetime as the NelderMead object?"
-
-        return -1;
-    }
-
-    PyObject* pyresult =
-        PyObject_CallObject(pyfunc, Py_BuildValue("ff", p.x(), p.y()));
-
-    if (pyresult == NULL) {
-        std::cerr << "Python callback function returned a bad value with args ";
-        std::cerr << p << std::endl;
-
-        return -1;
-    }
-
-    return PyFloat_AsDouble(pyresult);
-}
+float cpp_function_cb(Geometry2d::Point p, PyObject* pyfunc);
 
 class PythonFunctionWrapper {
 public:
     PyObject* pyFunc;
     std::function<float(Geometry2d::Point)> f;
 
-    PythonFunctionWrapper(PyObject* pf) {
-        pyFunc = pf;
+    PythonFunctionWrapper(PyObject* pf);
 
-        Py_INCREF(pyFunc);
-
-        f = std::bind(&cpp_function_cb,
-                      std::placeholders::_1,
-                      pyFunc);
-    }
-
-    ~PythonFunctionWrapper() {
-        Py_DECREF(pyFunc);
-        pyFunc = nullptr;
-    }
-
-    std::function<float(Geometry2d::Point)> getFunction() {
-        return f;
-    }
-
+    ~PythonFunctionWrapper();
 };

--- a/soccer/optimization/PythonFunctionWrapper.hpp
+++ b/soccer/optimization/PythonFunctionWrapper.hpp
@@ -1,0 +1,50 @@
+#include <functional>
+#include <Python.h>
+#include <Geometry2d/Point.hpp>
+
+
+float cpp_function_cb(Geometry2d::Point p, PyObject* pyfunc) {
+    if (pyfunc == nullptr) {
+        std::cerr << "Pyfunction is null. Does the PythonFunctionWrapper have the same lifetime as the NelderMead object?"
+
+        return -1;
+    }
+
+    PyObject* pyresult =
+        PyObject_CallObject(pyfunc, Py_BuildValue("ff", p.x(), p.y()));
+
+    if (pyresult == NULL) {
+        std::cerr << "Python callback function returned a bad value with args ";
+        std::cerr << p << std::endl;
+
+        return -1;
+    }
+
+    return PyFloat_AsDouble(pyresult);
+}
+
+class PythonFunctionWrapper {
+public:
+    PyObject* pyFunc;
+    std::function<float(Geometry2d::Point)> f;
+
+    PythonFunctionWrapper(PyObject* pf) {
+        pyFunc = pf;
+
+        Py_INCREF(pyFunc);
+
+        f = std::bind(&cpp_function_cb,
+                      std::placeholders::_1,
+                      pyFunc);
+    }
+
+    ~PythonFunctionWrapper() {
+        Py_DECREF(pyFunc);
+        pyFunc = nullptr;
+    }
+
+    std::function<float(Geometry2d::Point)> getFunction() {
+        return f;
+    }
+
+};


### PR DESCRIPTION
I still need to test this but and clean up the code a little, but I'm 90% sure this is needed. Otherwise we were leaking python objects every time we called this.

Double check me and make sure I actually need this and it's done correctly. In my mind, we have to take control of the `PyObject` when it gets passed to us since we are using it, not the parent method. If we take control, we then would need to release control and let the garbage collector eat the leftovers.

I'm also not sure about setting the pointer to `nullptr` after `decref`'ing it. It makes it an easy test so I can tell people about this weird idiosyncrasy, but it's kinda jank.