### PR TITLE
Remove spaces in project name to fix CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0.0)
-project("GT RoboJackets RoboCup")
+project("GT_RoboJackets_RoboCup")
 
 
 # include cmake files in the 'cmake folder'


### PR DESCRIPTION
The build was broken on Ubuntu 18.10+, because some tool was generating a directory named after the project name which would then break Make.

To fix this, replace the spaces in the project name with underscores to ensure it'll be a valid token in the Makefile (`gt_robojackets_robocup`).