### PR TITLE
Fix race condition in radio code

### DIFF
--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -382,7 +382,8 @@ void Processor::run() {
         // Read radio reverse packets
         _radio->receive();
 
-        for (Packet::RadioRx& rx : _radio->reversePackets()) {
+        while (_radio->hasReversePackets()) {
+            Packet::RadioRx rx = _radio->popReversePacket();
             _state.logFrame->add_radio_rx()->CopyFrom(rx);
 
             curStatus.lastRadioRxTime =
@@ -398,7 +399,7 @@ void Processor::run() {
                 _state.self[board]->radioRxUpdated();
             }
         }
-        _radio->clear();
+
         for (Joystick* joystick : _joysticks) {
             joystick->update();
         }

--- a/soccer/radio/Radio.hpp
+++ b/soccer/radio/Radio.hpp
@@ -41,8 +41,9 @@ public:
     void clear() {
         std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
 
-        // Clear the reverse packets queue
-        _reversePackets = {};
+        // Clear the reverse packets queue by copy-swap
+        std::queue<Packet::RadioRx> cleared;
+        std::swap(cleared, _reversePackets);
     }
 
 protected:

--- a/soccer/radio/Radio.hpp
+++ b/soccer/radio/Radio.hpp
@@ -23,15 +23,23 @@ public:
 
     int channel() const { return _channel; }
 
-    const std::vector<Packet::RadioRx>& reversePackets() const {
-        return _reversePackets;
+    bool hasReversePackets() {
+        std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
+        return _reversePackets.size();
     }
 
-    std::vector<Packet::RadioRx>& reversePackets() { return _reversePackets; }
+    const Packet::RadioRx popReversePacket() {
+        std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
+        Packet::RadioRx packet = _reversePackets.back();
+        _reversePackets.pop_back();
+        return packet;
+    }
 
     void clear() { _reversePackets.clear(); }
 
 protected:
+    std::mutex _reverse_packets_mutex;
+
     std::vector<Packet::RadioRx> _reversePackets;
     int _channel;
 };

--- a/soccer/radio/Radio.hpp
+++ b/soccer/radio/Radio.hpp
@@ -4,7 +4,7 @@
 #include <protobuf/RadioTx.pb.h>
 
 #include <mutex>
-#include <queue>
+#include <deque>
 
 /**
  * @brief Sends and receives information to/from our robots.
@@ -34,22 +34,19 @@ public:
     inline const Packet::RadioRx popReversePacket() {
         std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
         Packet::RadioRx packet = std::move(_reversePackets.front());
-        _reversePackets.pop();
+        _reversePackets.pop_front();
         return packet;
     }
 
     void clear() {
         std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
-
-        // Clear the reverse packets queue by copy-swap
-        std::queue<Packet::RadioRx> cleared;
-        std::swap(cleared, _reversePackets);
+        _reversePackets.clear();
     }
 
 protected:
     // A queue for the reverse packets as they come in through libusb.
     // Access to this queue should be controlled by locking the mutex.
-    std::queue<Packet::RadioRx> _reversePackets;
+    std::deque<Packet::RadioRx> _reversePackets;
     std::mutex _reverse_packets_mutex;
 
     int _channel;

--- a/soccer/radio/Radio.hpp
+++ b/soccer/radio/Radio.hpp
@@ -31,7 +31,7 @@ public:
         return _reversePackets.size();
     }
 
-    inline const Packet::RadioRx popReversePacket() {
+    const Packet::RadioRx popReversePacket() {
         std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
         Packet::RadioRx packet = std::move(_reversePackets.front());
         _reversePackets.pop_front();

--- a/soccer/radio/SimRadio.cpp
+++ b/soccer/radio/SimRadio.cpp
@@ -121,7 +121,7 @@ void SimRadio::receive() {
         rx.set_kicker_voltage(200);
 
         std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
-        _reversePackets.push_back(rx);
+        _reversePackets.push(rx);
     }
 }
 

--- a/soccer/radio/SimRadio.cpp
+++ b/soccer/radio/SimRadio.cpp
@@ -120,6 +120,7 @@ void SimRadio::receive() {
                                          : kicker_status_ready);
         rx.set_kicker_voltage(200);
 
+        std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
         _reversePackets.push_back(rx);
     }
 }

--- a/soccer/radio/SimRadio.cpp
+++ b/soccer/radio/SimRadio.cpp
@@ -121,7 +121,7 @@ void SimRadio::receive() {
         rx.set_kicker_voltage(200);
 
         std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
-        _reversePackets.push(rx);
+        _reversePackets.push_back(rx);
     }
 }
 

--- a/soccer/radio/USBRadio.cpp
+++ b/soccer/radio/USBRadio.cpp
@@ -321,7 +321,7 @@ void USBRadio::handleRxData(uint8_t* buf) {
     }
 
     std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
-    _reversePackets.push(packet);
+    _reversePackets.push_back(packet);
 }
 
 void USBRadio::channel(int n) {

--- a/soccer/radio/USBRadio.cpp
+++ b/soccer/radio/USBRadio.cpp
@@ -320,6 +320,7 @@ void USBRadio::handleRxData(uint8_t* buf) {
         packet.set_fpga_status(FpgaStatus(msg->fpgaStatus));
     }
 
+    std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
     _reversePackets.push_back(packet);
 }
 

--- a/soccer/radio/USBRadio.cpp
+++ b/soccer/radio/USBRadio.cpp
@@ -321,7 +321,7 @@ void USBRadio::handleRxData(uint8_t* buf) {
     }
 
     std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
-    _reversePackets.push_back(packet);
+    _reversePackets.push(packet);
 }
 
 void USBRadio::channel(int n) {


### PR DESCRIPTION
There's a race condition in the old USBRadio code when it writes to the reverse packet buffer: https://github.com/RoboJackets/robocup-software/blob/master/soccer/radio/USBRadio.cpp#L323. Because this function will be called asynchronously by libusb, and the rpackets can be accessed at any time through https://github.com/RoboJackets/robocup-software/blob/master/soccer/radio/Radio.hpp#L30 (and are accessed through the main thread), there can be writes to/from that vector concurrently, which is not good (Undefined Behavior :tm:) and could lead to any of the following:
- Dropped packets
- Corrupted packets
- Corruption in other random possibly unrelated sections of code
- Crashes (almost impossible, but theoretically a possibility under certain conditions)