### PR TITLE
New Play System Setup

### DIFF
--- a/soccer/gameplay/composite_behavior.py
+++ b/soccer/gameplay/composite_behavior.py
@@ -50,6 +50,13 @@ class CompositeBehavior(behavior.Behavior):
     def subbehavior_with_name(self, name: str):
         return self._subbehavior_info[name]['behavior']
 
+    def subbehavior_info_with_behavior(self, bhvr: behavior.Behavior):
+        info = None
+        for name in self._subbehavior_info:
+            if (self._subbehavior_info[name]['behavior'] is bhvr):
+                info = self._subbehavior_info[name]
+        return info
+
     def subbehaviors_by_name(self) -> Dict[str, Dict]:
         by_name = {}
         for name in self._subbehavior_info:

--- a/soccer/gameplay/playbooks/testing.pbk
+++ b/soccer/gameplay/playbooks/testing.pbk
@@ -1,1 +1,10 @@
-offense/static_formation
+# -*-conf-*-
+
+# This is a file to specify deafult playbooks when doing 'make run'
+# It starts off empty, but is useful when debugging.
+
+# Comment out these lines for examples:
+
+# offense/basic_122
+
+# testing/repeated_line_up

--- a/soccer/gameplay/playbooks/testing.pbk
+++ b/soccer/gameplay/playbooks/testing.pbk
@@ -1,10 +1,1 @@
-# -*-conf-*-
-
-# This is a file to specify deafult playbooks when doing 'make run'
-# It starts off empty, but is useful when debugging.
-
-# Comment out these lines for examples:
-
-# offense/basic_122
-
-# testing/repeated_line_up
+offense/static_formation

--- a/soccer/gameplay/plays/offense/static_formation.py
+++ b/soccer/gameplay/plays/offense/static_formation.py
@@ -1,0 +1,237 @@
+import main
+import robocup
+import behavior
+import constants
+import enum
+import random
+
+import standard_play
+import evaluation.ball
+import evaluation.passing_positioning
+import tactics.coordinated_pass
+import skills.move
+import skills.capture
+import tactics.positions.goalie
+
+
+
+class StaticFormation(standard_play.StandardPlay):
+
+    FORMATION_FULLBACK = 2
+    FORMATION_MIDFIELD = 1
+    FORMATION_STRIKER  = 2
+
+    FORMATION_FULLBACK_SQUEEZE = 0.5
+    FORMATION_MIDFIELD_SQUEEZE = 1
+    FORMATION_STRIKER_SQUEEZE = 1
+
+    class State(enum.Enum):
+        # We don't have the ball
+        # do some stuff here
+        defense = 1
+
+        # Passes around the formation
+        # making slow progress forward
+        passing = 2
+
+        # A defender has the ball
+        # Passes to the midfielder
+        # moves up the outside of the field
+        # Recieves a pass from the midfielder
+        # (The midfielder then takes over the defenders spot)
+        overtake = 3
+
+        # Move the ball to the other side of the field
+        # without going through one of the center robots
+        switch = 4
+
+        # Chip the ball across the opponent goal towards a few of
+        # our strikers / midfielder
+        cross = 5
+
+        # Through pass between two opponent defenders
+        # and let one of our robots move onto the pass
+        through = 6
+
+        # Shoot on goal
+        shoot = 7
+
+        # Default state to transition to all the others
+        formation = 8
+
+
+    def __init__(self):
+        super().__init__(continuous=False)
+
+        for s in StaticFormation.State:
+            self.add_state(s, behavior.Behavior.State.running)
+
+        self.width = constants.Field.Width
+        self.length = constants.Field.Length
+
+        self.formation_width = self.width * .8
+        self.formation_length = self.length / 3
+        
+        self.formation_center = main.ball().pos - robocup.Point(0, 0.1)
+
+
+        self.fullback_moves = []
+        self.midfield_moves = []
+        self.striker_moves = []
+
+        # This is really the goalie, but naming it defense allows us not to have the defense automatically be added
+        self.add_subbehavior(skills.move.Move(robocup.Point(0,0)), "defense", required=True, priority=100)
+
+        self.add_transition(behavior.Behavior.State.start,
+                            StaticFormation.State.formation, lambda: True,
+                            'immediately')
+
+        self.add_transition(StaticFormation.State.formation,
+                            StaticFormation.State.passing,
+                            lambda: True,
+                            'passing')
+
+    def on_enter_running(self):
+        self.fullback_x_locs = self.get_horizontal_locations(StaticFormation.FORMATION_FULLBACK_SQUEEZE, StaticFormation.FORMATION_FULLBACK)
+        self.midfield_x_locs = self.get_horizontal_locations(StaticFormation.FORMATION_MIDFIELD_SQUEEZE, StaticFormation.FORMATION_MIDFIELD)
+        self.striker_x_locs  = self.get_horizontal_locations(StaticFormation.FORMATION_STRIKER_SQUEEZE,   StaticFormation.FORMATION_STRIKER)
+
+        self.set_location_movement(self.fullback_moves, StaticFormation.FORMATION_FULLBACK, self.fullback_x_locs, -self.formation_length/2, "fullback", [100]*StaticFormation.FORMATION_FULLBACK)
+        self.set_location_movement(self.midfield_moves, StaticFormation.FORMATION_MIDFIELD, self.midfield_x_locs,                        0, "midfield", [100]*StaticFormation.FORMATION_MIDFIELD)
+        self.set_location_movement(self.striker_moves,  StaticFormation.FORMATION_STRIKER,  self.striker_x_locs,   self.formation_length/2, "striker",  [100]*StaticFormation.FORMATION_STRIKER)
+
+    def execute_running(self):
+        self.formation_center = self.get_formation_center()
+
+        self.set_location_movement(self.fullback_moves, StaticFormation.FORMATION_FULLBACK, self.fullback_x_locs, -self.formation_length/2, "fullback", [100]*StaticFormation.FORMATION_FULLBACK)
+        self.set_location_movement(self.midfield_moves, StaticFormation.FORMATION_MIDFIELD, self.midfield_x_locs,                        0, "midfield", [100]*StaticFormation.FORMATION_MIDFIELD)
+        self.set_location_movement(self.striker_moves,  StaticFormation.FORMATION_STRIKER,  self.striker_x_locs,   self.formation_length/2, "striker",  [100]*StaticFormation.FORMATION_STRIKER)
+
+    def get_horizontal_locations(self, squeeze, num_robots):
+        if (num_robots == 1):
+            return [0]
+        offset = self.formation_width / (num_robots - 1)
+
+        locs = []
+        for i in range(num_robots):
+            locs.append(squeeze*(-self.formation_width/2 + i*offset))
+
+        return locs
+
+    def set_location_movement(self, move_reference_list, num_robots, x_locs, y_loc, name_base, priority_list):
+        # if it hasn't been initialized yet, create all the moves
+        if (len(move_reference_list) == 0):
+            for i in range(num_robots):
+                move_reference_list.append(
+                    skills.move.Move(
+                        robocup.Point(self.formation_center.x + x_locs[i], self.formation_center.y + y_loc)
+                    )
+                )
+
+                self.add_subbehavior(move_reference_list[i], name_base + str(i), required=True, priority=priority_list[i])
+
+            print("Created list")
+        # List has already been created, just change target on moves
+        else:
+            for i in range(num_robots):
+                move_reference_list[i].pos = robocup.Point(self.formation_center.x + x_locs[i], self.formation_center.y + y_loc)
+
+    def get_formation_center(self):
+        return main.ball().pos - robocup.Point(0, 0.1)
+
+    def on_enter_passing(self):
+        # Get pass target
+        # Pass to them
+        # Use current robot nearest to ball
+        pass_pt = self.get_closest_robot_to_ball()
+
+        possible_targets = self.get_possible_pass_targets(pass_pt)
+
+        print(possible_targets)
+        rand_target = random.choice(possible_targets)
+
+        self.passer = self.get_move_at_pos(pass_pt)
+        self.receiver = self.get_move_at_pos(rand_target)
+
+        self.subbehavior_info_with_behavior(self.passer)['required'] = False
+        self.subbehavior_info_with_behavior(self.receiver)['required'] = False
+
+        self.add_subbehavior(tactics.coordinated_pass.CoordinatedPass(rand_target), "passing", required=True, priority=10)
+
+    def get_possible_pass_targets(self, from_robot_pos):
+        # Get all the robots within 1/2 the max formation distance
+        # From forwards to back
+
+        # There's a better way to do this that we should look into
+        max_dist = robocup.Point(self.formation_width, self.formation_length).mag()/2
+        min_dist = 0.01
+
+        valid_targets = []
+
+        for m in self.striker_moves:
+            dist = (from_robot_pos - m.pos).mag()
+            if (dist < max_dist and dist > min_dist):
+                valid_targets.append(m.pos)
+
+        for m in self.midfield_moves:
+            dist = (from_robot_pos - m.pos).mag()
+            if (dist < max_dist and dist > min_dist):
+                valid_targets.append(m.pos)
+        
+        for m in self.fullback_moves:
+            dist = (from_robot_pos - m.pos).mag()
+            if (dist < max_dist and dist > min_dist):
+                valid_targets.append(m.pos)
+
+        return valid_targets
+
+    def get_closest_robot_to_ball(self):
+        min_dist = float('inf')
+        min_pos = None
+
+        for m in self.striker_moves:
+            dist = (main.ball().pos - m.pos).mag()
+            if (dist < min_dist):
+                min_pos = m.pos
+                min_dist = dist
+
+
+        for m in self.midfield_moves:
+            dist = (main.ball().pos - m.pos).mag()
+            if (dist < min_dist):
+                min_pos = m.pos
+                min_dist = dist
+
+        
+        for m in self.fullback_moves:
+            dist = (main.ball().pos - m.pos).mag()
+            if (dist < min_dist):
+                min_pos = m.pos
+                min_dist = dist
+
+        if (min_pos is None):
+            print('No closest robot')
+
+        return min_pos
+
+    def get_move_at_pos(self, pos):
+        for m in self.striker_moves:
+            dist = (pos - m.pos).mag()
+            if (dist < 0.01):
+                return m
+
+        for m in self.midfield_moves:
+            dist = (pos - m.pos).mag()
+            if (dist < 0.01):
+                return m
+        
+        for m in self.fullback_moves:
+            dist = (pos - m.pos).mag()
+            if (dist < 0.01):
+                return m
+
+    @classmethod
+    def score(cls):
+        if (not main.game_state().is_playing()):
+            return float("inf")
+        return 10

--- a/soccer/gameplay/plays/offense/static_formation.py
+++ b/soccer/gameplay/plays/offense/static_formation.py
@@ -13,17 +13,47 @@ import skills.move
 import skills.capture
 import tactics.positions.goalie
 
-
-
 class StaticFormation(standard_play.StandardPlay):
+    # Contains the target robot position, move subehavior
+    # As well as all the pas targets from this position
+    #
+    # TODO: Think about just returning the controller robot position instead of the target robot position
+    # Or just when doing which robot has ball, use the real robot positions
+    class FormationPosition():
+        def __init__(self, relative_pos, name, formation_center, formation_half_width, formation_half_length):
+            # Relative position inside formation
+            self.relative_pos = relative_pos
 
-    FORMATION_FULLBACK = 2
-    FORMATION_MIDFIELD = 1
-    FORMATION_STRIKER  = 2
+            self.formation_center = formation_center
+            self.formation_half_width = formation_half_width
+            self.formation_half_length = formation_half_length
 
-    FORMATION_FULLBACK_SQUEEZE = 0.5
-    FORMATION_MIDFIELD_SQUEEZE = 1
-    FORMATION_STRIKER_SQUEEZE = 1
+            self.update_target_pos()
+
+            # Other positions that we should pass to
+            self.pass_positions = []
+
+            # All the stuff needed for pass behaviors
+            self.name = name
+            self.priority = 10
+            self.required = True
+            self.move_behavior = skills.move.Move(self.target_pos)
+
+        def update_target_pos(self):
+            offset_in_formation = robocup.Point(self.relative_pos.x * self.formation_half_width,
+                                                self.relative_pos.y * self.formation_half_length)
+            self.target_pos = self.formation_center + offset_in_formation
+
+        def update_move_target(self):
+            self.move_behavior.pos = self.target_pos
+
+        def take_control(self):
+            self.required = False
+            self.priority = 100
+
+        def release_control(self):
+            self.required = True
+            self.priority = 10
 
     class State(enum.Enum):
         # We don't have the ball
@@ -34,201 +64,529 @@ class StaticFormation(standard_play.StandardPlay):
         # making slow progress forward
         passing = 2
 
-        # A defender has the ball
-        # Passes to the midfielder
+        # A defender (or midfielder) has the ball
+        # Passes to the midfielder (or striker)
         # moves up the outside of the field
-        # Recieves a pass from the midfielder
-        # (The midfielder then takes over the defenders spot)
+        # Receives a pass from the midfielder (or striker)
         overtake = 3
+        overtake_second_pass = 4
 
         # Move the ball to the other side of the field
         # without going through one of the center robots
-        switch = 4
+        switch = 5
 
         # Chip the ball across the opponent goal towards a few of
         # our strikers / midfielder
-        cross = 5
+        cross = 6
 
         # Through pass between two opponent defenders
         # and let one of our robots move onto the pass
-        through = 6
+        through = 7
 
         # Shoot on goal
-        shoot = 7
+        shoot = 8
 
         # Default state to transition to all the others
-        formation = 8
+        formation = 9
 
 
     def __init__(self):
-        super().__init__(continuous=False)
+        super().__init__(continuous=True)
 
         for s in StaticFormation.State:
             self.add_state(s, behavior.Behavior.State.running)
 
+
+        # This is really the goalie, but naming it defense allows us not to have the defense automatically be added
+        self.remove_all_subbehaviors()
+        self.add_subbehavior(skills.move.Move(robocup.Point(0,0)), 'defense', required=True, priority=100)
+
         self.width = constants.Field.Width
         self.length = constants.Field.Length
 
-        self.formation_width = self.width * .8
-        self.formation_length = self.length / 3
-        
+        self.formation_width = self.width * .6
+        self.formation_length = self.length * .3
+
+        # Forces at least one frame between starting the other play stuff
+        self.ctr = 0
+
+        # Random number that selects which play to run
+        # Rand num is between 0 and 99
+        # The score we comapre against represents probability of being chosen
+        # For simplicity, the plays are chosen in reverse order of declaration
+        self.rand_num = 0
+
+        # Center location of the defense        
         self.formation_center = main.ball().pos - robocup.Point(0, 0.1)
 
+        # List of the positions we have in this formation
+        self.strikers = []
+        self.midfielders = []
+        self.fullbacks = []
+        self.all_positions = []
 
-        self.fullback_moves = []
-        self.midfield_moves = []
-        self.striker_moves = []
+        self.create_formation()
 
-        # This is really the goalie, but naming it defense allows us not to have the defense automatically be added
-        self.add_subbehavior(skills.move.Move(robocup.Point(0,0)), "defense", required=True, priority=100)
+        # Special args to the robot selection function for each play
+        self.position_with_ball = None
+
+
+        ################################################################################
+        ######                                                                    ######
+        ######                       Private Play Variables                       ######
+        ######                                                                    ######
+        ################################################################################
+
+        #######################################
+        ####                               ####
+        #### Private Variables for passing ####
+        ####                               ####
+        #######################################
+        self.passing_kicker_position = None
+        self.passing_receiver_position = None
+
+        ########################################
+        ####                                ####
+        #### Private Variables for overtake ####
+        ####                                ####
+        ########################################
+        self.overtake_kicker_position = None
+        self.overtake_receiver_position = None
+
+        ######################################
+        ####                              ####
+        #### Private Variables for switch ####
+        ####                              ####
+        ######################################
+        self.switch_kicker_position = None
+        self.switch_receiver_position = None
+
+        #####################################################################
+        ######                                                         ######
+        ######                       Transitions                       ######
+        ######                                                         ######
+        #####################################################################
+
 
         self.add_transition(behavior.Behavior.State.start,
-                            StaticFormation.State.formation, lambda: True,
+                            StaticFormation.State.formation,
+                            lambda: True,
                             'immediately')
+
+        #################################
+        ####                         ####
+        #### Transitions for passing ####
+        ####                         ####
+        #################################
 
         self.add_transition(StaticFormation.State.formation,
                             StaticFormation.State.passing,
-                            lambda: True,
+                            lambda: self.try_choosing_play(self.passing_score_function) and
+                                    self.enforce_play_priority_order(StaticFormation.State.passing),
                             'passing')
 
-    def on_enter_running(self):
-        self.fullback_x_locs = self.get_horizontal_locations(StaticFormation.FORMATION_FULLBACK_SQUEEZE, StaticFormation.FORMATION_FULLBACK)
-        self.midfield_x_locs = self.get_horizontal_locations(StaticFormation.FORMATION_MIDFIELD_SQUEEZE, StaticFormation.FORMATION_MIDFIELD)
-        self.striker_x_locs  = self.get_horizontal_locations(StaticFormation.FORMATION_STRIKER_SQUEEZE,   StaticFormation.FORMATION_STRIKER)
+        self.add_transition(StaticFormation.State.passing,
+                            StaticFormation.State.formation,
+                            lambda: self.subbehavior_with_name('simple_pass').is_done_running(),
+                            'done passing')
 
-        self.set_location_movement(self.fullback_moves, StaticFormation.FORMATION_FULLBACK, self.fullback_x_locs, -self.formation_length/2, "fullback", [100]*StaticFormation.FORMATION_FULLBACK)
-        self.set_location_movement(self.midfield_moves, StaticFormation.FORMATION_MIDFIELD, self.midfield_x_locs,                        0, "midfield", [100]*StaticFormation.FORMATION_MIDFIELD)
-        self.set_location_movement(self.striker_moves,  StaticFormation.FORMATION_STRIKER,  self.striker_x_locs,   self.formation_length/2, "striker",  [100]*StaticFormation.FORMATION_STRIKER)
+
+        ##################################
+        ####                          ####
+        #### Transitions for overtake ####
+        ####                          ####
+        ##################################
+        
+        self.add_transition(StaticFormation.State.formation,
+                            StaticFormation.State.overtake,
+                            lambda: self.try_choosing_play(self.overtake_score_function) and
+                                    self.enforce_play_priority_order(StaticFormation.State.overtake),
+                            'overtake first pass')
+
+        self.add_transition(StaticFormation.State.overtake,
+                            StaticFormation.State.overtake_second_pass,
+                            lambda: self.subbehavior_with_name('overtake_first_pass').is_done_running(),
+                            'overtake second pass')
+
+        self.add_transition(StaticFormation.State.overtake_second_pass,
+                            StaticFormation.State.formation,
+                            lambda: self.subbehavior_with_name('overtake_second_pass').is_done_running(),
+                            'done overtake')
+
+
+        ################################
+        ####                        ####
+        #### Transitions for switch ####
+        ####                        ####
+        ################################
+        
+        self.add_transition(StaticFormation.State.formation,
+                            StaticFormation.State.switch,
+                            lambda: self.try_choosing_play(self.switch_score_function) and
+                                    self.enforce_play_priority_order(StaticFormation.State.switch),
+                            'switch')
+
+        self.add_transition(StaticFormation.State.switch,
+                            StaticFormation.State.formation,
+                            lambda: self.subbehavior_with_name('switch_pass').is_done_running(),
+                            'done switch')
+
+
+
+    ###########################################################################
+    ######                                                               ######
+    ######                       Scoring Functions                       ######
+    ######                                                               ######
+    ###########################################################################
+
+
+    #
+    # Scores will just be out of 100 right now
+    # and if a random number between 0 and 99 is less than
+    # the score, it is chosen
+    #
+
+    ###########################################
+    ####                                   ####
+    #### Passing score transition function ####
+    ####                                   ####
+    ###########################################
+    def passing_score_function(self):
+        # Always an ok choice to pass around
+        # But other choices may be significantly better
+        # This is the default choice if nothing else is valid
+        return 100
+
+    ############################################
+    ####                                    ####
+    #### Overtake score transition function ####
+    ####                                    ####
+    ############################################
+    def overtake_score_function(self):
+        ball_away_from_their_goal = main.ball().pos.y < self.length * .6
+        
+        ball_with_midfielders = self.position_with_ball in self.midfielders
+        ball_with_fullbacks   = self.position_with_ball in self.fullbacks
+
+        # If we are in a good position, do it 40% of the time, otherwise dont at all
+        if (ball_away_from_their_goal and (ball_with_midfielders or ball_with_fullbacks)):
+            return 100
+        else:
+            return 0
+
+    ##########################################
+    ####                                  ####
+    #### Switch score transition function ####
+    ####                                  ####
+    ##########################################
+    def switch_score_function(self):
+        average_opponent_x_loc = 0
+
+        for r in main.their_robots():
+            average_opponent_x_loc += r.pos.x
+
+        average_opponent_x_loc /= len(main.their_robots())
+
+        # Switch if most of the opponents are on our side with the ball
+        # If the ball and x loc are the same sign, multiplying them together 
+        # gives a positive number
+        if (abs(average_opponent_x_loc) > (self.width/2) * .3 and
+            main.ball().pos.x * average_opponent_x_loc > 0):
+            return 100
+        else:
+            return 0
+
+    ###################################################################################
+    ######                                                                       ######
+    ######                       Individual State Machines                       ######
+    ######                                                                       ######
+    ###################################################################################
+
+
+    ######################################
+    ####                              ####
+    #### Parent Formation Class Stuff ####
+    ####                              ####
+    ######################################
+    def try_choosing_play(self, func):
+        return self.rand_num < func()
+
+    def enforce_play_priority_order(self, state):
+        return self.ctr > -state.value + 30
+
+    # Create random number so we randomly choose a "play" to do
+    def on_enter_formation(self):
+        self.rand_num = random.randint(0, 99)
 
     def execute_running(self):
-        self.formation_center = self.get_formation_center()
+        self.update_formation_center()
+        self.update_formation()
+        self.set_special_roles()
+        self.update_subbehaviors_settings()
 
-        self.set_location_movement(self.fullback_moves, StaticFormation.FORMATION_FULLBACK, self.fullback_x_locs, -self.formation_length/2, "fullback", [100]*StaticFormation.FORMATION_FULLBACK)
-        self.set_location_movement(self.midfield_moves, StaticFormation.FORMATION_MIDFIELD, self.midfield_x_locs,                        0, "midfield", [100]*StaticFormation.FORMATION_MIDFIELD)
-        self.set_location_movement(self.striker_moves,  StaticFormation.FORMATION_STRIKER,  self.striker_x_locs,   self.formation_length/2, "striker",  [100]*StaticFormation.FORMATION_STRIKER)
+        self.ctr += 1
 
-    def get_horizontal_locations(self, squeeze, num_robots):
-        if (num_robots == 1):
-            return [0]
-        offset = self.formation_width / (num_robots - 1)
+    def create_formation(self):
+        # Create formation specifics
+        # TODO: Move this to a config file or something
 
-        locs = []
-        for i in range(num_robots):
-            locs.append(squeeze*(-self.formation_width/2 + i*offset))
+        # Relative positions of the robots inside the formation
+        # 0,0 is the middle of the centerbacks
+        # +-1 is furthest left or right robots who should be at edge of formation
+        # +1 is furthest forward robot in front of formation
+        #
+        #
+        #
+        # +1   ST              ST
+        #
+        #              MF 
+        #
+        # -1     FB          FB
+        #
+        #      -1              +1
+        striker_left_rel_pos  = robocup.Point(-1, 1)
+        striker_right_rel_pos = robocup.Point( 1, 1)
 
-        return locs
+        midfielder_center_rel_pos = robocup.Point(0, 0)
 
-    def set_location_movement(self, move_reference_list, num_robots, x_locs, y_loc, name_base, priority_list):
-        # if it hasn't been initialized yet, create all the moves
-        if (len(move_reference_list) == 0):
-            for i in range(num_robots):
-                move_reference_list.append(
-                    skills.move.Move(
-                        robocup.Point(self.formation_center.x + x_locs[i], self.formation_center.y + y_loc)
-                    )
-                )
+        fullback_left_rel_pos  = robocup.Point(-.6, -1)
+        fullback_right_rel_pos = robocup.Point( .6, -1)
 
-                self.add_subbehavior(move_reference_list[i], name_base + str(i), required=True, priority=priority_list[i])
+        CreateFormationPosition = lambda rel_pos, name: StaticFormation.FormationPosition(rel_pos, name, self.formation_center, self.formation_width/2, self.formation_length/2)
 
-            print("Created list")
-        # List has already been created, just change target on moves
-        else:
-            for i in range(num_robots):
-                move_reference_list[i].pos = robocup.Point(self.formation_center.x + x_locs[i], self.formation_center.y + y_loc)
+        # Create the FormationPositions objects
+        striker_left  = CreateFormationPosition(striker_left_rel_pos, 'striker_left')
+        striker_right = CreateFormationPosition(striker_right_rel_pos, 'striker_right')
 
-    def get_formation_center(self):
-        return main.ball().pos - robocup.Point(0, 0.1)
-
-    def on_enter_passing(self):
-        # Get pass target
-        # Pass to them
-        # Use current robot nearest to ball
-        pass_pt = self.get_closest_robot_to_ball()
-
-        possible_targets = self.get_possible_pass_targets(pass_pt)
-
-        print(possible_targets)
-        rand_target = random.choice(possible_targets)
-
-        self.passer = self.get_move_at_pos(pass_pt)
-        self.receiver = self.get_move_at_pos(rand_target)
-
-        self.subbehavior_info_with_behavior(self.passer)['required'] = False
-        self.subbehavior_info_with_behavior(self.receiver)['required'] = False
-
-        self.add_subbehavior(tactics.coordinated_pass.CoordinatedPass(rand_target), "passing", required=True, priority=10)
-
-    def get_possible_pass_targets(self, from_robot_pos):
-        # Get all the robots within 1/2 the max formation distance
-        # From forwards to back
-
-        # There's a better way to do this that we should look into
-        max_dist = robocup.Point(self.formation_width, self.formation_length).mag()/2
-        min_dist = 0.01
-
-        valid_targets = []
-
-        for m in self.striker_moves:
-            dist = (from_robot_pos - m.pos).mag()
-            if (dist < max_dist and dist > min_dist):
-                valid_targets.append(m.pos)
-
-        for m in self.midfield_moves:
-            dist = (from_robot_pos - m.pos).mag()
-            if (dist < max_dist and dist > min_dist):
-                valid_targets.append(m.pos)
+        midfielder_center = CreateFormationPosition(midfielder_center_rel_pos, 'midfielder_center')
         
-        for m in self.fullback_moves:
-            dist = (from_robot_pos - m.pos).mag()
-            if (dist < max_dist and dist > min_dist):
-                valid_targets.append(m.pos)
+        fullback_left  = CreateFormationPosition(fullback_left_rel_pos, 'fullback_left')
+        fullback_right = CreateFormationPosition(fullback_right_rel_pos, 'fullback_right')
 
-        return valid_targets
+        # Create list of all other positions they should pass to normally
+        # List is from left to right, front to back
+        striker_left.pass_positions  = [striker_right, midfielder_center, fullback_left]
+        striker_right.pass_positions = [striker_left, midfielder_center, fullback_right]
+        
+        midfielder_center.pass_positions = [striker_left, striker_right, fullback_left, fullback_right]
 
-    def get_closest_robot_to_ball(self):
+        fullback_left.pass_positions  = [striker_left, midfielder_center, fullback_right]
+        fullback_right.pass_positions = [striker_right, midfielder_center, fullback_left]
+
+        # Add them as subbehaviors
+        AddPositionSubbehavior = lambda position: self.add_subbehavior(position.move_behavior, position.name, position.required, position.priority)
+
+        AddPositionSubbehavior(striker_left)
+        AddPositionSubbehavior(striker_right)
+
+        AddPositionSubbehavior(midfielder_center)
+
+        AddPositionSubbehavior(fullback_left)
+        AddPositionSubbehavior(fullback_right)
+
+        # Add to global list
+        self.strikers = [striker_left, striker_right]
+        self.midfielders = [midfielder_center]
+        self.fullbacks = [fullback_left, fullback_right]
+        self.all_positions = [striker_left, striker_right, midfielder_center, fullback_left, fullback_right]
+
+    def update_formation(self):
+        for position in self.all_positions:
+            position.formation_center = self.formation_center
+            position.update_target_pos()
+            position.update_move_target()
+
+    def update_formation_center(self):
+        self.formation_center = robocup.Point(0, constants.Field.Length/2) - robocup.Point(0, 0.3)
+
+    def update_subbehaviors_settings(self):
+        for position in self.all_positions:
+            bhvr_info = self.subbehavior_info_with_behavior(position.move_behavior)
+            bhvr_info['required'] = position.required
+            bhvr_info['priority'] = lambda: position.priority
+
+    # Specify which robot has the ball
+    def set_special_roles(self):
         min_dist = float('inf')
         min_pos = None
 
-        for m in self.striker_moves:
-            dist = (main.ball().pos - m.pos).mag()
-            if (dist < min_dist):
-                min_pos = m.pos
-                min_dist = dist
+        for position in self.all_positions:
+            dist_to_ball = (position.target_pos - main.ball().pos).mag()
+            if (dist_to_ball < min_dist):
+                min_dist = dist_to_ball
+                min_pos = position
 
+        self.position_with_ball = min_pos
 
-        for m in self.midfield_moves:
-            dist = (main.ball().pos - m.pos).mag()
-            if (dist < min_dist):
-                min_pos = m.pos
-                min_dist = dist
+    #################################
+    ####                         ####
+    #### Pass Play State Machine ####
+    ####                         ####
+    #################################
 
+    def on_enter_passing(self):
+        # Will be called by parents class
+        self.passing_request_robots()
+
+        self.add_subbehavior(tactics.coordinated_pass.CoordinatedPass(self.passing_receiver_position.target_pos), 'simple_pass', True, 10)
+
+    # Standardized function rn to select which robots we want
+    def passing_request_robots(self):
+        # Find place to pass
+        # Take position control
+        possible_pass_targets = self.position_with_ball.pass_positions
+
+        # Save which two positions we steal
+        self.passing_kicker_position = self.position_with_ball
+        self.passing_receiver_position = random.choice(possible_pass_targets)
+
+        # Take control of them
+        self.passing_kicker_position.take_control()
+        self.passing_receiver_position.take_control()
+
+    def on_exit_passing(self):
+        self.remove_subbehavior('simple_pass')
+
+        self.passing_release_robots()
+
+        # Isn't needed for the specific passing thing, but used anyways
+        self.ctr = 0
+
+    # Should be called automatically when play finishes
+    def passing_release_robots(self):
+        self.passing_kicker_position.release_control()
+        self.passing_receiver_position.release_control()
+
+    #####################################
+    ####                             ####
+    #### Overtake Play State Machine ####
+    ####                             ####
+    #####################################
+
+    def on_enter_overtake(self):
+        # Will be called by parents class
+        self.overtake_request_robots()
+
+        self.add_subbehavior(tactics.coordinated_pass.CoordinatedPass(self.overtake_receiver_position.target_pos), 'overtake_first_pass', True, 10)
+
+    # Standardized function rn to select which robots we want
+    def overtake_request_robots(self):
+        # Find place to pass
+        # Take position control
+        possible_pass_targets = self.position_with_ball.pass_positions
+
+        is_fullback = self.position_with_ball in self.fullbacks
+        is_midfielder = self.position_with_ball in self.midfielders
+
+        # Assume is a midfielder if not a fullback
+        target_position_list = self.midfielders if is_fullback else self.strikers
+
+        final_pass_target = None
+
+        for pass_target in possible_pass_targets:
+            if (pass_target in target_position_list):
+                final_pass_target = pass_target
+                break
+
+        # Save which two positions we steal
+        self.overtake_kicker_position = self.position_with_ball
+        self.overtake_receiver_position = final_pass_target
+
+        # Take control of them
+        self.overtake_kicker_position.take_control()
+        self.overtake_receiver_position.take_control()
+
+    def on_exit_overtake(self):
+        self.remove_subbehavior('overtake_first_pass')
+
+    def on_enter_overtake_second_pass(self):
+        new_pass_target = self.overtake_receiver_position.target_pos + robocup.Point(-.5, .4)
         
-        for m in self.fullback_moves:
-            dist = (main.ball().pos - m.pos).mag()
-            if (dist < min_dist):
-                min_pos = m.pos
-                min_dist = dist
+        self.add_subbehavior(tactics.coordinated_pass.CoordinatedPass(new_pass_target), 'overtake_second_pass', True, 10)
 
-        if (min_pos is None):
-            print('No closest robot')
+    def on_exit_overtake_second_pass(self):
+        self.remove_subbehavior('overtake_second_pass')
 
-        return min_pos
+        self.overtake_release_robots()
 
-    def get_move_at_pos(self, pos):
-        for m in self.striker_moves:
-            dist = (pos - m.pos).mag()
-            if (dist < 0.01):
-                return m
+        self.ctr = 0
 
-        for m in self.midfield_moves:
-            dist = (pos - m.pos).mag()
-            if (dist < 0.01):
-                return m
-        
-        for m in self.fullback_moves:
-            dist = (pos - m.pos).mag()
-            if (dist < 0.01):
-                return m
+    # Should be called automatically when play finishes
+    def overtake_release_robots(self):
+        self.overtake_kicker_position.release_control()
+        self.overtake_receiver_position.release_control()
+    
+    ###################################
+    ####                           ####
+    #### Switch Play State Machine ####
+    ####                           ####
+    ###################################
+
+    def on_enter_switch(self):
+        # Will be called by parents class
+        self.switch_request_robots()
+
+        self.add_subbehavior(tactics.coordinated_pass.CoordinatedPass(self.switch_receiver_position.target_pos), 'switch_pass', True, 10)
+
+    # Standardized function rn to select which robots we want
+    def switch_request_robots(self):
+        # Get row in front of this one and see if it has two or more robots
+        # If so, pass to the furthest one
+        # Else, try current row, and pass to furthest one
+
+        is_striker = self.position_with_ball in self.strikers
+        is_midfielder = self.position_with_ball in self.midfielders
+        is_fullback = self.position_with_ball in self.fullbacks
+
+        rows = [self.strikers, self.midfielders, self.fullbacks]
+
+        row_to_check = 0
+        if (is_striker or is_midfielder):
+            row_to_check = 0
+        else: # is_fullback
+            row_to_check = 1
+
+        found_target = False
+        target = None
+
+        while (not found_target):
+            # Not more than one in that row
+            # SKip and find one with more than 1
+            if (len(rows[row_to_check]) <= 1):
+                row_to_check += 1
+
+            furthest_dist = 0
+            furthest_pos = None
+
+            for position in rows[row_to_check]:
+                dist = (position.target_pos - self.position_with_ball.target_pos).mag()
+
+                if (dist > furthest_dist):
+                    furthest_dist = dist
+                    furthest_pos = position
+                    found_target = True
+
+            target = furthest_pos
+
+        # Save which two positions we steal
+        self.switch_kicker_position = self.position_with_ball
+        self.switch_receiver_position = target
+
+        # Take control of them
+        self.switch_kicker_position.take_control()
+        self.switch_receiver_position.take_control()
+
+    def on_exit_switch(self):
+        self.remove_subbehavior('switch_pass')
+
+        self.switch_release_robots()
+
+        self.ctr = 0
+
+    # Should be called automatically when play finishes
+    def switch_release_robots(self):
+        self.switch_kicker_position.release_control()
+        self.switch_receiver_position.release_control()
 
     @classmethod
     def score(cls):

--- a/soccer/gameplay/plays/offense/static_formation.py
+++ b/soccer/gameplay/plays/offense/static_formation.py
@@ -11,7 +11,8 @@ import evaluation.passing_positioning
 import tactics.coordinated_pass
 import skills.move
 import skills.capture
-import tactics.positions.goalie
+from tactics.positions.goalie import Goalie
+
 
 class StaticFormation(standard_play.StandardPlay):
     # Contains the target robot position, move subehavior
@@ -104,7 +105,10 @@ class StaticFormation(standard_play.StandardPlay):
 
         # This is really the goalie, but naming it defense allows us not to have the defense automatically be added
         self.remove_all_subbehaviors()
-        self.add_subbehavior(skills.move.Move(robocup.Point(0,0)), 'defense', required=True, priority=100)
+        #self.add_subbehavior(skills.move.Move(robocup.Point(0,0)), 'defense', required=True, priority=100)
+        self.goalie = Goalie()
+        self.goalie.shell_id = main.system_state().game_state.get_goalie_id()
+        self.add_subbehavior(self.goalie, "Goalie", required=True, priority=100)
 
         self.width = constants.Field.Width
         self.length = constants.Field.Length
@@ -418,6 +422,8 @@ class StaticFormation(standard_play.StandardPlay):
 
     def execute_running(self):
         self.update_formation_center()
+        main.system_state().draw_circle(self.formation_center,.2,(255,255,255), "FORMATION CENTER")
+        #print(_game_state.get_goalie_id())
         self.update_formation()
         self.set_special_roles()
         self.update_subbehaviors_settings()


### PR DESCRIPTION
@ All the play people

We've had this challenge for a while where the main offensive plays have to control all the robots at once. This makes it really annoying to do small play like crosses or switches etc where we don't really care about where all the robots are. This is an approach to rectify that situation.

The idea is that in IRL soccer, anybody who's not in the general vicinity of the ball stays in some sort of formation. It's only when the ball gets near those players, that the player begins to do something. I took this and expanded it to our system. 

In the final form, you would just inherit from some parent class and build your play. The play itself would be some very "small" action like crossing the ball. Somewhere inside the play, you would select which positions from the formation you want to use. The rest will stay in their position while the ones you activated are under your control. The score functions for plays would describe what situations it should be used in.

I have a prototype of this system below. It's all in one file so I didn't have to deal with all the inheritance stuff, but it would get split out if actually implemented. It's not 100% perfect, but it's good enough to see what I'm talking about.
The implemented plays right now are:
 - Passing
 - Overtake
 - Switch
 - Cross
 - Shoot

Some interesting results and features that come from this:
 - We can actually define the [traingles used in soccer](http://outsideoftheboot.com/2016/11/23/geometry-in-football-understanding-the-triangle/). TL;DR: The pass lines between robots in a formation
 - Passes are usually quicker since the robots are already in a good position most of the time
 - We cover a larger section of the field in general so their passes are much easier to intercept
 - Things like through passes and that are much easier to setup for

Thoughts? Other features to add? Is this something that I should finish up?