### PR TITLE
Face command removed from mark to reduce lateral motion due to spin outs

### DIFF
--- a/soccer/gameplay/skills/mark.py
+++ b/soccer/gameplay/skills/mark.py
@@ -77,7 +77,7 @@ class Mark(single_robot_behavior.SingleRobotBehavior):
 
         #Move robot into position and face the ball
         self.robot.move_to(self._target_point)
-        self.robot.face(ball_pos)
+        #self.robot.face(ball_pos) #Commented out to reduce lateral motion
 
     #Ratio of distance to mark point v. distance to ball for target point
     @property


### PR DESCRIPTION
We are starting to test removing face commands from skills and tactics to reduce lateral motion, this is the most obvious case.