### PR TITLE
Added capture timeout

### DIFF
--- a/soccer/gameplay/skills/capture.py
+++ b/soccer/gameplay/skills/capture.py
@@ -213,7 +213,7 @@ class Capture(single_robot_composite_behavior.SingleRobotCompositeBehavior):
                 time_to_hit += delta_time
         
 
-        main.system_state().draw_text(str(time_to_hit), robot.pos + robocup.Point(0.1,0.1), (255,255,255), "test")
+        #main.system_state().draw_text(str(time_to_hit), robot.pos + robocup.Point(0.1,0.1), (255,255,255), "test")
 
         return time_to_hit * Capture.SETTLE_COST_MULTIPLIER
 

--- a/soccer/planning/CollectPathPlanner.cpp
+++ b/soccer/planning/CollectPathPlanner.cpp
@@ -192,7 +192,7 @@ void CollectPathPlanner::processStateTransition(const Ball& ball,
     // If we are in range to the slow dist
     if (dist < *_approachDistTarget + Robot_MouthRadius && currentState == CourseApproach) {
         currentState = FineApproach;
-        cout << "Transitioning to fine" << endl;
+        //cout << "Transitioning to fine" << endl;
     }
 
     // If we are close enough to the target point near the ball
@@ -200,7 +200,7 @@ void CollectPathPlanner::processStateTransition(const Ball& ball,
     // TODO: Check for ball sense?
     if (dist < *_distCutoffToControl && speedDiff < *_velCutoffToControl && currentState == FineApproach) {
         currentState = Control;
-	    cout << "Transitioning to control" << std::endl;
+	    //cout << "Transitioning to control" << std::endl;
     }
 }
 

--- a/soccer/planning/SettlePathPlanner.cpp
+++ b/soccer/planning/SettlePathPlanner.cpp
@@ -187,7 +187,7 @@ void SettlePathPlanner::processStateTransition(const Ball& ball,
             // Start the next section of the path from the end of our current path
             startInstant = pathSoFar->end().motion;
             currentState = Dampen;
-            std::cout << "Transitioned to dampen" << std::endl;
+            //std::cout << "Transitioned to dampen" << std::endl;
         }
     }
 }
@@ -339,7 +339,7 @@ std::unique_ptr<Path> SettlePathPlanner::intercept(const PlanRequest& planReques
     // to the target
     if ((pathInterceptTarget - avgInstantaneousInterceptTarget).mag() > Robot_Radius) {
         pathInterceptTarget = avgInstantaneousInterceptTarget;
-        std::cout << "Changing targets" << std::endl;
+        //std::cout << "Changing targets" << std::endl;
     }
 
     // Build a new path with the target


### PR DESCRIPTION
Should reset the collect behavior. It's explained in the comments, but long story short we dont have robot object access in the path planner so it's hard to know when the capture fully completes. We have to use raw dist to target. If we make no progress in 100 frames, it will restart the path planner which will go through all the states again