### PR TITLE
Aim timeout

### DIFF
--- a/soccer/gameplay/plays/offense/adaptive_formation.py
+++ b/soccer/gameplay/plays/offense/adaptive_formation.py
@@ -290,7 +290,7 @@ class AdaptiveFormation(standard_play.StandardPlay):
         self.kicker.aim_params['error_threshold'] = 0.3
         self.kicker.aim_params['max_steady_ang_vel'] = 10
         self.kicker.aim_params['min_steady_duration'] = 0.1
-        self.kicker.aim_params['desperate_timeout'] = 2.5
+        self.kicker.aim_params['desperate_timeout'] = 1
 
         self.kick.target = constants.Field.TheirGoalSegment
         #self.midfielders.kick = True
@@ -313,7 +313,7 @@ class AdaptiveFormation(standard_play.StandardPlay):
 
         clear = skills.pivot_kick.PivotKick()
         clear.target = self.pass_target
-        clear.aim_params['desperate_timeout'] = 3
+        clear.aim_params['desperate_timeout'] = 1
         clear.use_chipper = True
         self.add_subbehavior(clear, 'clear', required=False)
 

--- a/soccer/gameplay/plays/offense/basic_122.py
+++ b/soccer/gameplay/plays/offense/basic_122.py
@@ -30,7 +30,7 @@ class Basic122(standard_play.StandardPlay):
         striker.aim_params['error_threshold'] = 0.3
         striker.aim_params['max_steady_ang_vel'] = 10
         striker.aim_params['min_steady_duration'] = 0.1
-        striker.aim_params['desperate_timeout'] = 2.5
+        striker.aim_params['desperate_timeout'] = 1
 
         self.add_transition(behavior.Behavior.State.start,
                             behavior.Behavior.State.running, lambda: True,

--- a/soccer/gameplay/tactics/coordinated_pass.py
+++ b/soccer/gameplay/tactics/coordinated_pass.py
@@ -164,7 +164,7 @@ class CoordinatedPass(composite_behavior.CompositeBehavior):
         kicker.aim_params['error_threshold'] = 0.1
         kicker.aim_params['max_steady_ang_vel'] = 0.1
         kicker.aim_params['min_steady_duration'] = 0.15
-        kicker.aim_params['desperate_timeout'] = 4.0
+        kicker.aim_params['desperate_timeout'] = 2.0
         self.add_subbehavior(kicker, 'kicker', required=self.kicker_required)
 
         # receive point renegotiation


### PR DESCRIPTION
Added a timeout that only start when we are almost facing the target already. This allows more consistent tuning as a 180 forces a multi second timeout while if you come at it from the correct direction you only need one or two seconds.

Split into a course timeout which is the overall timeout from start and a fine timeout where it only starts when we are within 45 degrees of the target