### PR TITLE
Upgrade to C++17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,11 +103,10 @@ jobs:
       - <<: *load_compile_cache
       - run: make test-python
 
-  # FIXME: pylint is broken on 18.04
   pylint:
     <<: *dir
     docker:
-      - image: robojackets/robocup-software:16
+      - image: robojackets/robocup-software
     steps:
       - <<: *load_src_cache
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,10 +103,11 @@ jobs:
       - <<: *load_compile_cache
       - run: make test-python
 
+  # FIXME: pylint is broken on 18.04
   pylint:
     <<: *dir
     docker:
-      - image: robojackets/robocup-software
+      - image: robojackets/robocup-software:16
     steps:
       - <<: *load_src_cache
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,6 @@ defaults: &save_compile_cache
     key: ccache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/.ccache
-defaults: &save_compile_16_cache
-  save_cache:
-    key: ccache-16-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-    paths:
-      - ~/.ccache
 defaults: &save_compile_coverage_cache
   save_cache:
     key: ccache-cov-{{ arch }}-{{ .Branch }}-{{ .Revision }}
@@ -44,14 +39,6 @@ defaults: &load_compile_cache
       - ccache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
       - ccache-{{ arch }}-{{ .Branch }}
       - ccache-{{ arch }}
-      - ccache-
-defaults: &load_compile_16_cache
-  restore_cache:
-    keys:
-      - ccache-16-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-      - ccache-16-{{ arch }}-{{ .Branch }}
-      - ccache-16-{{ arch }}
-      - ccache-16-
       - ccache-
 defaults: &load_compile_coverage_cache
   restore_cache:
@@ -165,19 +152,6 @@ jobs:
       - run: make coverage
       - <<: *save_compile_coverage_cache
 
-  compile-16:
-    <<: *dir
-    docker:
-      - image: robojackets/robocup-software:16
-    steps:
-      - <<: *load_src_cache
-      - checkout
-      # Ensure latest deps are installed
-      - <<: *install_deps
-      - <<: *load_compile_16_cache
-      - run: make
-      - <<: *save_compile_16_cache
-
   gen-docs:
     <<: *dir
     <<: *image
@@ -195,7 +169,6 @@ workflows:
   build_and_test:
     jobs:
       - compile
-      - compile-16
       - coverage
       - test-soccer:
           requires:
@@ -203,9 +176,7 @@ workflows:
       - test-python:
           requires:
             - compile
-      - pylint:
-          requires:
-            - compile-16
+      - pylint
       - mypy:
           requires:
             - compile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.8)
 project("GT_RoboJackets_RoboCup")
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ include(SetupGTest)
 
 message("${TARGET}")
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON) # Don't fall back to older versions
 
 add_subdirectory(external/grSim)

--- a/soccer/radio/USBRadio.cpp
+++ b/soccer/radio/USBRadio.cpp
@@ -12,7 +12,6 @@
 // included for kicer status enum
 #include "status.h"
 
-using namespace std;
 using namespace Packet;
 
 // Timeout for control transfers, in milliseconds
@@ -145,7 +144,7 @@ void USBRadio::command(uint8_t cmd) {
                                 LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR,
                                 BaseControlCommand::RadioStrobe, 0, cmd,
                                 nullptr, 0, Control_Timeout)) {
-        throw runtime_error("USBRadio::command control write failed");
+        throw std::runtime_error("USBRadio::command control write failed");
     }
 }
 
@@ -154,7 +153,7 @@ void USBRadio::write(uint8_t reg, uint8_t value) {
                                 LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR,
                                 BaseControlCommand::RadioWriteRegister, value,
                                 reg, nullptr, 0, Control_Timeout)) {
-        throw runtime_error("USBRadio::write control write failed");
+        throw std::runtime_error("USBRadio::write control write failed");
     }
 }
 
@@ -164,7 +163,7 @@ uint8_t USBRadio::read(uint8_t reg) {
                                 LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR,
                                 BaseControlCommand::RadioReadRegister, 0, reg,
                                 &value, 1, Control_Timeout)) {
-        throw runtime_error("USBRadio::read control write failed");
+        throw std::runtime_error("USBRadio::read control write failed");
     }
 
     return value;
@@ -332,7 +331,7 @@ void USBRadio::channel(int n) {
                 _device, LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR,
                 BaseControlCommand::RadioSetChannel, n, 0, nullptr, 0,
                 Control_Timeout)) {
-            throw runtime_error("USBRadio::channel control write failed");
+            throw std::runtime_error("USBRadio::channel control write failed");
         }
     }
 


### PR DESCRIPTION
Now that GCC 7 is standard on Ubuntu 18.04, we can use newer versions of
C++.

This change does not actually take advantage of any new C++17 features.
New PRs will be coming shortly to take advantage of:
 - std::optional
 - New library functions
 - Probably some other features that I haven't run into yet (structured
   bindings are really nice, but I can't think of a specific place in
   our code that really needs them at the moment).