### PR TITLE
Use old checkstyle make target in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,10 +104,11 @@ jobs:
       - <<: *load_compile_cache
       - run: make test-python
 
+  # FIXME: pylint is broken on 18.04
   pylint:
     <<: *dir
     docker:
-      - image: robojackets/robocup-software
+      - image: robojackets/robocup-software:16
     steps:
       - <<: *load_src_cache
       - checkout
@@ -134,7 +135,7 @@ jobs:
       - <<: *install_deps
       - <<: *load_workspace
       - <<: *load_compile_cache
-      - run: git fetch origin && PATH=$PATH:$GOPATH/bin STYLIZE_DIFFBASE=origin/master make checkstyle-old
+      - run: git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle-old
       - store_artifacts:
           path: /tmp/clean.patch
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &image
     - image: robojackets/robocup-software:master
 
 defaults: &install_deps
-  run: export GOPATH=$HOME/go && sudo ./util/ubuntu-setup --yes && sudo ccache -M 100M
+  run: export GOPATH=$HOME/go && sudo GOPATH=$GOPATH ./util/ubuntu-setup --yes && sudo ccache -M 100M
 
 defaults: &save_src_cache
   save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
       - <<: *install_deps
       - <<: *load_workspace
       - <<: *load_compile_cache
-      - run: git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle
+      - run: git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle-old
       - store_artifacts:
           path: /tmp/clean.patch
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &image
     - image: robojackets/robocup-software:master
 
 defaults: &install_deps
-  run: export GOPATH=$HOME/go && sudo GOPATH=$GOPATH ./util/ubuntu-setup --yes && sudo ccache -M 100M
+  run: export GOPATH=$HOME/go && sudo ./util/ubuntu-setup --yes && sudo ccache -M 100M
 
 defaults: &save_src_cache
   save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ defaults: &image
     - image: robojackets/robocup-software:master
   environment:
     GOPATH: ~/go
-    PATH: ~/go/bin
 
 defaults: &install_deps
   run: sudo ./util/ubuntu-setup --yes && sudo ccache -M 100M
@@ -137,6 +136,11 @@ jobs:
       - <<: *install_deps
       - <<: *load_workspace
       - <<: *load_compile_cache
+      - run:
+          name: Set $PATH
+          command: |
+            echo 'export PATH="$PATH:~/go/bin"' >> $BASH_ENV
+            source $BASH_ENV
       - run: git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle
       - store_artifacts:
           path: /tmp/clean.patch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,9 @@ defaults: &image
     - image: robojackets/robocup-software:master
 
 defaults: &install_deps
+  run: export GOPATH=$HOME/go
   run: sudo ./util/ubuntu-setup --yes && sudo ccache -M 100M
+
 defaults: &save_src_cache
   save_cache:
     key: source-v1-{{ .Branch }}-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ defaults: &image
     GOPATH: ~/go
 
 defaults: &install_deps
-  run: sudo ./util/ubuntu-setup --yes && sudo ccache -M 100M
+  run: sudo env GOPATH=$GOPATH ./util/ubuntu-setup --yes && sudo ccache -M 100M
 defaults: &save_src_cache
   save_cache:
     key: source-v1-{{ .Branch }}-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,7 @@ defaults: &image
     - image: robojackets/robocup-software:master
 
 defaults: &install_deps
-  run: export GOPATH=$HOME/go
-  run: sudo ./util/ubuntu-setup --yes && sudo ccache -M 100M
+  run: export GOPATH=$HOME/go && sudo ./util/ubuntu-setup --yes && sudo ccache -M 100M
 
 defaults: &save_src_cache
   save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ defaults: &dir
 defaults: &image
   docker:
     - image: robojackets/robocup-software:master
+      environment:
+        GOPATH: ~/go
+        PATH: ~/go/bin
 
 defaults: &install_deps
   run: sudo ./util/ubuntu-setup --yes && sudo ccache -M 100M
@@ -134,7 +137,7 @@ jobs:
       - <<: *install_deps
       - <<: *load_workspace
       - <<: *load_compile_cache
-      - run: git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle-old
+      - run: git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle
       - store_artifacts:
           path: /tmp/clean.patch
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,9 @@ defaults: &dir
 defaults: &image
   docker:
     - image: robojackets/robocup-software:master
-      environment:
-        GOPATH: ~/go
-        PATH: ~/go/bin
+  environment:
+    GOPATH: ~/go
+    PATH: ~/go/bin
 
 defaults: &install_deps
   run: sudo ./util/ubuntu-setup --yes && sudo ccache -M 100M

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,17 @@
+defaults_env: &setup_env
+  run:
+    name: Set $PATH
+    command: |
+      echo 'export GOPATH="$HOME/go"' >> $BASH_ENV
+      echo 'export PATH="$PATH:$HOME/go/bin"' >> $BASH_ENV
+      source $BASH_ENV
+
 defaults_dir: &dir
   working_directory: ~/robocup-software
 
 defaults_image: &image
   docker:
     - image: robojackets/robocup-software:master
-  environment:
-    GOPATH: ~/go
 
 defaults_deps: &install_deps
   run: ./util/ubuntu-setup --yes && sudo ccache -M 100M
@@ -141,15 +147,12 @@ jobs:
     steps:
       - <<: *load_src_cache
       - checkout
+      # We need environment variables ($GOPATH and $PATH specifically)
+      - <<: *setup_env
       # Ensure latest deps are installed
       - <<: *install_deps
       - <<: *load_workspace
       - <<: *load_compile_cache
-      - run:
-          name: Set $PATH
-          command: |
-            echo 'export PATH="$PATH:~/go/bin"' >> $BASH_ENV
-            source $BASH_ENV
       - run: git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle
       - store_artifacts:
           path: /tmp/clean.patch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,67 +1,76 @@
-defaults: &dir
+defaults_dir: &dir
   working_directory: ~/robocup-software
 
-defaults: &image
+defaults_image: &image
   docker:
     - image: robojackets/robocup-software:master
   environment:
     GOPATH: ~/go
 
-defaults: &install_deps
-  run: sudo env GOPATH=$GOPATH ./util/ubuntu-setup --yes && sudo ccache -M 100M
-defaults: &save_src_cache
+defaults_deps: &install_deps
+  run: ./util/ubuntu-setup --yes && sudo ccache -M 100M
+
+defaults_ssc: &save_src_cache
   save_cache:
     key: source-v1-{{ .Branch }}-{{ .Revision }}
     paths:
       - ".git"
-defaults: &load_src_cache
+
+defaults_lsc: &load_src_cache
   restore_cache:
     keys:
       - source-v1-{{ .Branch }}-{{ .Revision }}
       - source-v1-{{ .Branch }}-
       - source-v1-
-defaults: &save_compile_cache
+defaults_scc: &save_compile_cache
   save_cache:
     key: ccache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/.ccache
-defaults: &save_compile_coverage_cache
+
+defaults_sccc: &save_compile_coverage_cache
   save_cache:
     key: ccache-cov-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/.ccache
-defaults: &save_compile_test_cache
+
+defaults_sctc: &save_compile_test_cache
   save_cache:
     key: ccache-test-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/.ccache
-defaults: &load_compile_cache
+
+defaults_lcc: &load_compile_cache
   restore_cache:
     keys:
       - ccache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
       - ccache-{{ arch }}-{{ .Branch }}
       - ccache-{{ arch }}
       - ccache-
-defaults: &load_compile_coverage_cache
+
+defaults_lccc: &load_compile_coverage_cache
   restore_cache:
     keys:
       - ccache-cov-{{ arch }}-{{ .Branch }}-{{ .Revision }}
       - ccache-cov-{{ arch }}-{{ .Branch }}
       - ccache-cov-{{ arch }}
       - ccache-cov-
-defaults: &load_compile_test_cache
+
+defaults_lctc: &load_compile_test_cache
   restore_cache:
     keys:
       - ccache-test-{{ arch }}-{{ .Branch }}-{{ .Revision }}
       - ccache-test-{{ arch }}-{{ .Branch }}
       - ccache-test-{{ arch }}
       - ccache-test-
-defaults: &save_workspace
+
+defaults_sw: &save_workspace
   persist_to_workspace:
     root: build
     paths:
       - ./*
-defaults: &load_workspace
+
+defaults_lw: &load_workspace
   attach_workspace:
     at: build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,11 +104,10 @@ jobs:
       - <<: *load_compile_cache
       - run: make test-python
 
-  # FIXME: pylint is broken on 18.04
   pylint:
     <<: *dir
     docker:
-      - image: robojackets/robocup-software:16
+      - image: robojackets/robocup-software
     steps:
       - <<: *load_src_cache
       - checkout
@@ -135,7 +134,7 @@ jobs:
       - <<: *install_deps
       - <<: *load_workspace
       - <<: *load_compile_cache
-      - run: git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle-old
+      - run: git fetch origin && PATH=$PATH:$GOPATH/bin STYLIZE_DIFFBASE=origin/master make checkstyle-old
       - store_artifacts:
           path: /tmp/clean.patch
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,8 @@ defaults: &image
     - image: robojackets/robocup-software:master
 
 defaults: &install_deps
-  run: export GOPATH=$HOME/go && sudo ./util/ubuntu-setup --yes && sudo ccache -M 100M
+  run: export GOPATH=$HOME/go
+  run: sudo ./util/ubuntu-setup --yes && sudo ccache -M 100M
 
 defaults: &save_src_cache
   save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,7 @@ defaults: &image
     - image: robojackets/robocup-software:master
 
 defaults: &install_deps
-  run: export GOPATH=$HOME/go
   run: sudo ./util/ubuntu-setup --yes && sudo ccache -M 100M
-
 defaults: &save_src_cache
   save_cache:
     key: source-v1-{{ .Branch }}-{{ .Revision }}

--- a/util/requirements3.txt
+++ b/util/requirements3.txt
@@ -8,3 +8,5 @@ pylint==1.6.5 # static checker for python
 mypy==0.510   # static arugment checker
 
 yapf==0.15.2 # python checker
+
+stylize>=0.3

--- a/util/requirements3.txt
+++ b/util/requirements3.txt
@@ -8,5 +8,3 @@ pylint==1.6.5 # static checker for python
 mypy==0.510   # static arugment checker
 
 yapf==0.15.2 # python checker
-
-stylize>=0.3


### PR DESCRIPTION
The new checkstyle make target is broken (I don't think stylize.v1
actually exists) so it's been breaking all of our CI builds for a while.
Until we put in the time to figure out what's wrong with it, this uses
the old target (make checkstyle-old) on CI builds.