### PR TITLE
Add Point<->Eigen conversions and Geometry2d tests

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 # build the 'common' static library (and include our protobuf messages in it)
+include_directories(SYSTEM ${EIGEN_INCLUDE_DIR})
 add_library(common STATIC ${COMMON_SRC})
 target_link_libraries(common proto_messages)
 
@@ -41,5 +42,3 @@ else()
     find_package(Qt5Widgets REQUIRED)
 endif()
 qt5_use_modules(common Core Network Widgets)
-
-

--- a/common/Geometry2d/Arc.hpp
+++ b/common/Geometry2d/Arc.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "Point.hpp"
 #include "Line.hpp"
+#include "Point.hpp"
 #include "Segment.hpp"
 
 namespace Geometry2d {
@@ -76,4 +76,4 @@ private:
     float _end_angle;
 };
 
-}
+}  // namespace Geometry2d

--- a/common/Geometry2d/Arc.hpp
+++ b/common/Geometry2d/Arc.hpp
@@ -9,14 +9,37 @@
 #include "Segment.hpp"
 
 namespace Geometry2d {
+
+/**
+ * An arc (a segment of a circle) specified by a center point, a radius and a
+ * starting and ending angle.
+ *
+ * @note: the starting and ending angles should be in the range [-M_PI, M_PI]
+ *      or intersection functions will not work as expected. In addition,
+ *      start should be less than or equal to end
+ */
 class Arc {
 public:
+    /**
+     * Default-initialze an arc to the empty arc.
+     */
     Arc() {
         _radius = -1;
         _start_angle = 0;
         _end_angle = 0;
     }
 
+    /**
+     * Initialize an arc with a given center, radius, and starting and ending
+     * angle (in radians).
+     *
+     * @param center: the center point of the characteristic circle
+     * @param radius: the radius of the characteristic circle
+     * @param start: the starting angle in radians in the range [-M_PI, M_PI]
+     * @param end: the ending angle in radians in the range [-M_PI, M_PI]
+     *
+     * @note angle 0 radians is aligned with the x axis.
+     */
     Arc(Point center, float radius, float start, float end) {
         _center = center;
         _radius = radius;
@@ -52,4 +75,5 @@ private:
     float _start_angle;
     float _end_angle;
 };
+
 }

--- a/common/Geometry2d/ArcTest.cpp
+++ b/common/Geometry2d/ArcTest.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "Geometry2d/Arc.hpp"
+#include "Geometry2d/Line.hpp"
+#include "Geometry2d/Point.hpp"
+#include "Geometry2d/Segment.hpp"
+
+namespace Geometry2d::Testing {
+
+TEST(Arc, Intersections) {
+    // Line-arc
+    auto check_all_near =
+        [](std::vector<Point> actual, std::vector<Point> expected,
+                std::string name) {
+            for (Point pt : expected) {
+                auto it = std::find_if(
+                    actual.begin(), actual.end(),
+                    [pt](Point ac) {
+                        return (pt - ac).mag() < 1e-6;
+                    });
+                if (it != actual.end()) {
+                    actual.erase(it);
+                } else {
+                    ADD_FAILURE() <<
+                        "Expected point " << pt << ", no match between " <<
+                        name << ".";
+                }
+            }
+
+            for (Point ac : actual) {
+                ADD_FAILURE() <<
+                    "Actual point " << ac << " matched no expected point, "
+                    "but all expected points were matched between " <<
+                    name << ".";
+            }
+        };
+
+    // Arc-Line
+    check_all_near(
+            Arc({0, 0}, 1.0, 0, M_PI).intersects(Line({0, 0}, {0, 2})),
+            {{0, 1}}, "Arc-Line 1");
+    check_all_near(
+            Arc({0, 0}, 1.0, -M_PI, M_PI).intersects(Line({0, -2}, {0, 2})),
+            {{0, 1}, {0, -1}}, "Arc-Line 2");
+    check_all_near(
+            Arc({0, 0}, 2.0, 0, M_PI).intersects(Line({0, 0}, {0, 1})),
+            {{0, 2}}, "Arc-Line 3");
+    check_all_near(
+            Arc({0, 0}, 1.0, M_PI / 4, 3 * M_PI / 4).intersects(Line({0, 0}, {0, 1})),
+            {{0, 1}}, "Arc-Line 4");
+
+    // Arc-Segment
+    check_all_near(
+            Arc({0, 0}, 2.0, 0, M_PI).intersects(Segment({0, 0}, {0, 1})),
+            {}, "Arc-Segment");
+
+}
+
+} // Geometry2d::Testing

--- a/common/Geometry2d/ArcTest.cpp
+++ b/common/Geometry2d/ArcTest.cpp
@@ -12,51 +12,44 @@ namespace Geometry2d::Testing {
 
 TEST(Arc, Intersections) {
     // Line-arc
-    auto check_all_near =
-        [](std::vector<Point> actual, std::vector<Point> expected,
-                std::string name) {
-            for (Point pt : expected) {
-                auto it = std::find_if(
-                    actual.begin(), actual.end(),
-                    [pt](Point ac) {
-                        return (pt - ac).mag() < 1e-6;
-                    });
-                if (it != actual.end()) {
-                    actual.erase(it);
-                } else {
-                    ADD_FAILURE() <<
-                        "Expected point " << pt << ", no match between " <<
-                        name << ".";
-                }
+    auto check_all_near = [](std::vector<Point> actual,
+                             std::vector<Point> expected, std::string name) {
+        for (Point pt : expected) {
+            auto it =
+                std::find_if(actual.begin(), actual.end(),
+                             [pt](Point ac) { return (pt - ac).mag() < 1e-6; });
+            if (it != actual.end()) {
+                actual.erase(it);
+            } else {
+                ADD_FAILURE() << "Expected point " << pt
+                              << ", no match between " << name << ".";
             }
+        }
 
-            for (Point ac : actual) {
-                ADD_FAILURE() <<
-                    "Actual point " << ac << " matched no expected point, "
-                    "but all expected points were matched between " <<
-                    name << ".";
-            }
-        };
+        for (Point ac : actual) {
+            ADD_FAILURE() << "Actual point " << ac
+                          << " matched no expected point, "
+                             "but all expected points were matched between "
+                          << name << ".";
+        }
+    };
 
     // Arc-Line
+    check_all_near(Arc({0, 0}, 1.0, 0, M_PI).intersects(Line({0, 0}, {0, 2})),
+                   {{0, 1}}, "Arc-Line 1");
     check_all_near(
-            Arc({0, 0}, 1.0, 0, M_PI).intersects(Line({0, 0}, {0, 2})),
-            {{0, 1}}, "Arc-Line 1");
-    check_all_near(
-            Arc({0, 0}, 1.0, -M_PI, M_PI).intersects(Line({0, -2}, {0, 2})),
-            {{0, 1}, {0, -1}}, "Arc-Line 2");
-    check_all_near(
-            Arc({0, 0}, 2.0, 0, M_PI).intersects(Line({0, 0}, {0, 1})),
-            {{0, 2}}, "Arc-Line 3");
-    check_all_near(
-            Arc({0, 0}, 1.0, M_PI / 4, 3 * M_PI / 4).intersects(Line({0, 0}, {0, 1})),
-            {{0, 1}}, "Arc-Line 4");
+        Arc({0, 0}, 1.0, -M_PI, M_PI).intersects(Line({0, -2}, {0, 2})),
+        {{0, 1}, {0, -1}}, "Arc-Line 2");
+    check_all_near(Arc({0, 0}, 2.0, 0, M_PI).intersects(Line({0, 0}, {0, 1})),
+                   {{0, 2}}, "Arc-Line 3");
+    check_all_near(Arc({0, 0}, 1.0, M_PI / 4, 3 * M_PI / 4)
+                       .intersects(Line({0, 0}, {0, 1})),
+                   {{0, 1}}, "Arc-Line 4");
 
     // Arc-Segment
     check_all_near(
-            Arc({0, 0}, 2.0, 0, M_PI).intersects(Segment({0, 0}, {0, 1})),
-            {}, "Arc-Segment");
-
+        Arc({0, 0}, 2.0, 0, M_PI).intersects(Segment({0, 0}, {0, 1})), {},
+        "Arc-Segment");
 }
 
-} // Geometry2d::Testing
+}  // namespace Geometry2d::Testing

--- a/common/Geometry2d/Point.hpp
+++ b/common/Geometry2d/Point.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Eigen/Dense>
 #include <cmath>
 #include <boost/functional/hash.hpp>
 #include <QtCore/QPointF>
@@ -46,6 +47,18 @@ public:
     Point(const double* other) : Point(other[0], other[1]) {}
 
     /**
+     * Implicit conversion from Eigen::Vector2d
+     */
+    Point(const Eigen::Vector2d& other) : Point(other(0), other(1)) {}
+
+    /**
+     * Implicit conversion to Eigen::Vector2d
+     */
+    operator Eigen::Vector2d() const {
+        return Eigen::Vector2d(x(), y());
+    }
+
+    /**
      * to draw stuff and interface with QT
      */
     QPointF toQPointF() const { return QPointF(x(), y()); }
@@ -56,6 +69,7 @@ public:
         out.set_y(y());
         return out;
     }
+
     /**
      * does vector addition
      * adds the + operator, shorthand

--- a/common/Geometry2d/Point.hpp
+++ b/common/Geometry2d/Point.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <Eigen/Dense>
-#include <cmath>
-#include <boost/functional/hash.hpp>
-#include <QtCore/QPointF>
 #include <protobuf/Point.pb.h>
+#include <Eigen/Dense>
+#include <QtCore/QPointF>
+#include <boost/functional/hash.hpp>
+#include <cmath>
 #include <sstream>
 #include <string>
 
@@ -54,9 +54,7 @@ public:
     /**
      * Implicit conversion to Eigen::Vector2d
      */
-    operator Eigen::Vector2d() const {
-        return Eigen::Vector2d(x(), y());
-    }
+    operator Eigen::Vector2d() const { return Eigen::Vector2d(x(), y()); }
 
     /**
      * to draw stuff and interface with QT
@@ -250,8 +248,8 @@ public:
     }
 
     /**
-    * rotates the point around the origin
-    */
+     * rotates the point around the origin
+     */
     Point& rotate(double angle) {
         double newX = x() * cos(angle) - y() * sin(angle);
         double newY = y() * cos(angle) + x() * sin(angle);
@@ -277,8 +275,8 @@ public:
     }
 
     /**
-    * static function to use rotate
-    */
+     * static function to use rotate
+     */
     static Point rotated(const Point& pt, const Point& origin, double angle) {
         Point newPt = pt;
         newPt.rotate(origin, angle);
@@ -296,11 +294,10 @@ public:
     }
 
     /**
-    * Returns a vector with the same direction as this vector but with magnitude
-    * given,
-    * unless this vector is zero.
-    * If the vector is (0,0), Point(0,0) is returned
-    */
+     * Returns a vector with the same direction as this vector but with
+     * magnitude given, unless this vector is zero. If the vector is (0,0),
+     * Point(0,0) is returned
+     */
     Point normalized(double magnitude = 1.0) const {
         double m = mag();
         if (m == 0) {
@@ -314,21 +311,21 @@ public:
     Point norm() const { return normalized(); }
 
     /**
-    * Returns true if this point is within the given distance (threshold) of
-    * (pt)
-    */
+     * Returns true if this point is within the given distance (threshold) of
+     * (pt)
+     */
     bool nearPoint(const Point& other, double threshold) const {
         return (*this - other).magsq() <= (threshold * threshold);
     }
 
     /**
-    * Returns the angle of this point in radians CCW from +X.
-    */
+     * Returns the angle of this point in radians CCW from +X.
+     */
     double angle() const { return atan2(y(), x()); }
 
     /**
-    * Returns a unit vector in the given direction (in radians)
-    */
+     * Returns a unit vector in the given direction (in radians)
+     */
     static Point direction(double theta) {
         return Point(cos(theta), sin(theta));
     }
@@ -386,4 +383,4 @@ private:
 inline Point operator*(const double& s, const Point& pt) {
     return Point(pt.x() * s, pt.y() * s);
 }
-}
+}  // namespace Geometry2d

--- a/common/Geometry2d/PointTest.cpp
+++ b/common/Geometry2d/PointTest.cpp
@@ -23,6 +23,18 @@ TEST(Point, constructors) {
     EXPECT_EQ(test, defaultConstructed);
 }
 
+TEST(Point, toEigen) {
+    Eigen::Vector2d p = Point(1.0, 2.0);
+    ASSERT_EQ(p(0), 1.0);
+    ASSERT_EQ(p(1), 2.0);
+}
+
+TEST(Point, fromEigen) {
+    Point p = Eigen::Vector2d(1.0, 2.0);
+    ASSERT_EQ(p.x(), 1.0);
+    ASSERT_EQ(p.y(), 2.0);
+}
+
 TEST(Point, operators) {
     // Test +, - operator
     Point expected;

--- a/common/Geometry2d/TransformMatrix.hpp
+++ b/common/Geometry2d/TransformMatrix.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Eigen/Dense>
+
 #include "Point.hpp"
 
 namespace Geometry2d {
@@ -31,6 +33,15 @@ public:
     TransformMatrix(Geometry2d::Point origin, float rotation = 0,
                     bool mirror = false, float scale = 1);
 
+    TransformMatrix(const Eigen::Matrix<double, 3, 3>& other) {
+        _m[0] = other(0, 0);
+        _m[1] = other(0, 1);
+        _m[2] = other(0, 2);
+        _m[3] = other(1, 0);
+        _m[4] = other(1, 1);
+        _m[5] = other(1, 2);
+    }
+
     TransformMatrix operator*(const TransformMatrix& other) const {
         float a = _m[0] * other._m[0] + _m[1] * other._m[3];
         float b = _m[0] * other._m[1] + _m[1] * other._m[4];
@@ -58,6 +69,12 @@ public:
         _m[5] = f;
 
         return *this;
+    }
+
+    operator Eigen::Matrix<double, 3, 3>() const {
+        Eigen::Matrix<double, 3, 3> result;
+        result << _m[0], _m[1], _m[2], _m[3], _m[4], _m[5], 0, 0, 1;
+        return result;
     }
 
     Point operator*(const Point& pt) const {

--- a/common/Geometry2d/TransformMatrix.hpp
+++ b/common/Geometry2d/TransformMatrix.hpp
@@ -166,4 +166,4 @@ protected:
     //    3 4 5]
     float _m[6];
 };
-}
+}  // namespace Geometry2d

--- a/common/Geometry2d/TransformMatrixTest.cpp
+++ b/common/Geometry2d/TransformMatrixTest.cpp
@@ -9,7 +9,8 @@ TEST(TransformMatrix, Convert) {
     // Test conversion to/from Eigen
     TransformMatrix transform(Point(0, 1), 1.0);
     Eigen::Matrix<double, 3, 3> transformEigen = transform;
-    EXPECT_EQ(transformEigen * Eigen::Vector3d(0, 0, 1), Eigen::Vector3d(0, 1, 1));
+    EXPECT_EQ(transformEigen * Eigen::Vector3d(0, 0, 1),
+              Eigen::Vector3d(0, 1, 1));
     TransformMatrix transformedBack = transformEigen;
     EXPECT_EQ(transform * Point(0, 1), transformedBack * Point(0, 1));
     EXPECT_EQ(transform * Point(1, 0), transformedBack * Point(1, 0));
@@ -21,22 +22,22 @@ TEST(TransformMatrix, Compose) {
     TransformMatrix transform1(Point(0, 1), M_PI / 2);
     TransformMatrix transform2(Point(1, 0), M_PI / 2);
 
-    EXPECT_LT(
-            ((transform1 * transform2) * Point(1, 0) -
-             transform1 * (transform2 * Point(1, 0))).mag(), 1e-6)
+    EXPECT_LT(((transform1 * transform2) * Point(1, 0) -
+               transform1 * (transform2 * Point(1, 0)))
+                  .mag(),
+              1e-6)
         << "Composition should be associative!";
 
-    EXPECT_LT(
-            ((transform2 * transform1) * Point(1, 0) -
-             transform2 * (transform1 * Point(1, 0))).mag(), 1e-6)
+    EXPECT_LT(((transform2 * transform1) * Point(1, 0) -
+               transform2 * (transform1 * Point(1, 0)))
+                  .mag(),
+              1e-6)
         << "Composition should be associative!";
 }
 
 TEST(TransformMatrix, Reconstruct) {
     Eigen::Matrix<double, 3, 3> transformEigen;
-    transformEigen << 0, 1, 0,
-                      -1, 0, 1,
-                      0, 0, 1;
+    transformEigen << 0, 1, 0, -1, 0, 1, 0, 0, 1;
     TransformMatrix transform = transformEigen;
     EXPECT_EQ(transform.origin(), Point(0, 1));
     EXPECT_NEAR(transform.rotation(), -M_PI / 2 + 2 * M_PI, 1e-6);

--- a/common/Geometry2d/TransformMatrixTest.cpp
+++ b/common/Geometry2d/TransformMatrixTest.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+#include "TransformMatrix.hpp"
+
+using namespace Geometry2d;
+
+TEST(TransformMatrix, Convert) {
+    // Test conversion to/from Eigen
+    TransformMatrix transform(Point(0, 1), 1.0);
+    Eigen::Matrix<double, 3, 3> transformEigen = transform;
+    EXPECT_EQ(transformEigen * Eigen::Vector3d(0, 0, 1), Eigen::Vector3d(0, 1, 1));
+    TransformMatrix transformedBack = transformEigen;
+    EXPECT_EQ(transform * Point(0, 1), transformedBack * Point(0, 1));
+    EXPECT_EQ(transform * Point(1, 0), transformedBack * Point(1, 0));
+}
+
+TEST(TransformMatrix, Compose) {
+    // Test composition: self-compose a 90-degree rotation with an offset from
+    // the origin
+    TransformMatrix transform1(Point(0, 1), M_PI / 2);
+    TransformMatrix transform2(Point(1, 0), M_PI / 2);
+
+    EXPECT_LT(
+            ((transform1 * transform2) * Point(1, 0) -
+             transform1 * (transform2 * Point(1, 0))).mag(), 1e-6)
+        << "Composition should be associative!";
+
+    EXPECT_LT(
+            ((transform2 * transform1) * Point(1, 0) -
+             transform2 * (transform1 * Point(1, 0))).mag(), 1e-6)
+        << "Composition should be associative!";
+}
+
+TEST(TransformMatrix, Reconstruct) {
+    Eigen::Matrix<double, 3, 3> transformEigen;
+    transformEigen << 0, 1, 0,
+                      -1, 0, 1,
+                      0, 0, 1;
+    TransformMatrix transform = transformEigen;
+    EXPECT_EQ(transform.origin(), Point(0, 1));
+    EXPECT_NEAR(transform.rotation(), -M_PI / 2 + 2 * M_PI, 1e-6);
+}

--- a/soccer/CMakeLists.txt
+++ b/soccer/CMakeLists.txt
@@ -209,6 +209,7 @@ set(SOCCER_TEST_SRC
     "${CMAKE_SOURCE_DIR}/common/Geometry2d/SegmentTest.cpp"
     "${CMAKE_SOURCE_DIR}/common/Geometry2d/CompositeShapeTest.cpp"
     "${CMAKE_SOURCE_DIR}/common/Geometry2d/ArcTest.cpp"
+    "${CMAKE_SOURCE_DIR}/common/Geometry2d/TransformMatrixTest.cpp"
     "BatteryProfileTest.cpp"
     "KickEvaluatorTest.cpp"
     "motion/TrapezoidalMotionTest.cpp"

--- a/soccer/CMakeLists.txt
+++ b/soccer/CMakeLists.txt
@@ -208,6 +208,7 @@ set(SOCCER_TEST_SRC
     "${CMAKE_SOURCE_DIR}/common/Geometry2d/RectTest.cpp"
     "${CMAKE_SOURCE_DIR}/common/Geometry2d/SegmentTest.cpp"
     "${CMAKE_SOURCE_DIR}/common/Geometry2d/CompositeShapeTest.cpp"
+    "${CMAKE_SOURCE_DIR}/common/Geometry2d/ArcTest.cpp"
     "BatteryProfileTest.cpp"
     "KickEvaluatorTest.cpp"
     "motion/TrapezoidalMotionTest.cpp"


### PR DESCRIPTION
I added a bit of documentation to Arc and wrote some quick tests for it - it looked like it was the biggest nontrivial class in geometry still lacking tests. More importantly, I added conversions between Eigen::Vector3d and Geometry2d::Point, which I'll be using a lot once we get down to business on refactoring motion planning (I'm also planning on adding Pose and possibly Twist to the Geometry2d library, which will end up as the interfaces that the rest of motion planning will use - but that's outside of the scope of this PR).