### PR TITLE
Move angle planning to the planning phase

### DIFF
--- a/soccer/gameplay/plays/testing/four_courners_pass.py
+++ b/soccer/gameplay/plays/testing/four_courners_pass.py
@@ -1,0 +1,229 @@
+import robocup
+import play
+import behavior
+import skills.move
+import skills.capture
+import tactics.coordinated_pass
+import constants
+import main
+import enum
+import copy
+
+
+## A testing play to demonstrate our ability to pass and recieve balls
+# One robot will pursue the ball while three other robots will pass the ball amongst themselves
+# they can only pass the ball at the corners and recieve at the corners and they cannot move
+# through the center of the square
+class FourCornerPass(play.Play):
+    class State(enum.Enum):
+        ## One robot goes captures the ball while the other two gets on corners
+        # pursuing robot does not move on the first instance
+        setup = 1
+
+        ## The robots pass to each other and begin setting up the next pass
+        # while the chasing robot goes for the ball.
+        passing = 2
+
+    def __init__(self):
+        super().__init__(continuous=True)
+
+        # register states - they're both substates of "running"
+        self.add_state(FourCornerPass.State.setup,
+                       behavior.Behavior.State.running)
+        self.add_state(FourCornerPass.State.passing,
+                       behavior.Behavior.State.running)
+
+        self.add_transition(behavior.Behavior.State.start,
+                            FourCornerPass.State.setup, lambda: True,
+                            'immediately')
+        #transition when ball is captured
+        self.add_transition(
+            FourCornerPass.State.setup,
+            FourCornerPass.State.passing, lambda: self.subbehavior_with_name(
+                'capture').state == behavior.Behavior.State.completed,
+            'captured ball')
+
+        #transition when ball is passed or failed to pass
+        self.add_transition(
+            FourCornerPass.State.passing, FourCornerPass.State.setup, lambda:
+            self.subbehavior_with_name('passer').state == behavior.Behavior.
+            State.completed or self.subbehavior_with_name('passer').state ==
+            behavior.Behavior.State.failed, 'passed ball')
+
+        #change this to adjust the square size
+        self.variable_square = 5.5
+
+        #NEVER CHANGE THIS
+        self.length = constants.Field.Length
+        self.width = constants.Field.Width
+
+        #if the square size is smaller than the width shrink it down otherwise
+        #max value is the width of the field.
+        self.variable_square = min(self.variable_square, self.width,
+                                   self.length)
+
+        #radius of robot
+        self.bot_buffer = constants.Robot.Radius * 3
+        # the largest and smallest x and y postion possible for the square
+        self.max_x = (self.variable_square / 2 - self.bot_buffer)
+        self.min_x = -self.max_x
+        self.max_y = self.length / 2 + self.max_x
+        self.min_y = self.length / 2 - self.max_x
+
+        # the four courners
+        self.square_points = [
+            robocup.Point(self.max_x, self.max_y),
+            robocup.Point(self.min_x, self.max_y),
+            robocup.Point(self.min_x, self.min_y),
+            robocup.Point(self.max_x, self.min_y)
+        ]
+
+        # speed of the hunting robots
+        #TODO Create python pull from Config values. Currently this breaks the world.
+        #tmp = robocup.Configuration.FromRegisteredConfigurables().nameLookup("MotionConstraints/Max Velocity").value
+        self.normal_speed = 1.0  #tmp 
+        # speed of the defending robots can decrease value to make it easier for offense
+        self.defense_speed = self.normal_speed * 2 / 3  #self.normal_speed/2.0
+
+        # picks the direction to pass to. TODO make actual smart pass selection
+        self.direction = 1
+
+    # constanly running changes and updates
+    def execute_running(self):
+        # checks if there is an offensive behavior for the various plays and set the normal speed
+        for sub in self.subbehaviors_by_name():
+            if (sub != 'passer'):
+                robo = self.subbehavior_with_name(sub).robot
+                # checks if there is a chasing robot and set their speed to defense speed
+                if (robo != None):
+                    if (sub == 'chasing'):
+                        robo.set_max_speed(self.defense_speed)
+                    # otherwise sets to the offensive normal speed rate
+                    else:
+                        robo.set_max_speed(self.normal_speed)
+
+        # chasing robot positon should always follow the ball within a smaller inside box of the
+        # four corners.
+        if (self.has_subbehavior_with_name('chasing')):
+            self.chaser.pos = self.cut_off_pos(main.ball().pos)
+
+        #draw the four courner field
+        # takes in the square points and form lines and create a square on the field
+        for i in range(len(self.square_points)):
+            main.debug_drawer().draw_line(
+                robocup.Line(self.square_points[i],
+                             self.square_points[(i + 1) % 4]), (135, 0, 255),
+                "Square")
+
+        # speed of the hunting robots
+        #TODO Create python pull from Config values. Currently this breaks the world.
+        #tmp = copy.deepcopy(robocup.Configuration.FromRegisteredConfigurables().nameLookup("MotionConstraints/Max Velocity").value)
+        self.normal_speed = 1.0  # tmp
+        #speed of the defending robots can decrease value to make it easier for offense
+        self.defense_speed = 2 * self.normal_speed / 3.0  #self.normal_speed/2.0#self.variable_square/(min(self.width,self.length) * 2) * self.normal_speed
+
+    def on_enter_start(self):
+        # if we have too many robots isolate one of the robots so they don't help in the play
+        goalie = main.root_play(
+        ).goalie_id  #.system_state().game_state.get_goalie_id()
+        print(goalie)
+        numRobots = len(main.our_robots()) - 4
+        if (goalie != None):
+            numRobots = numRobots - 1
+
+        for i in range(numRobots):
+            iso = skills.move.Move(
+                robocup.Point(-constants.Field.Width / 2 + self.bot_buffer * i,
+                              0))
+            self.add_subbehavior(
+                iso, 'iso' + str(i), required=True, priority=1)
+
+    def on_enter_setup(self):
+        # find where we will consider the ball is closest too and passing from
+        closestPt = min(self.square_points,
+                        key=lambda pt: pt.dist_to(main.ball().pos))
+
+        closestPtIdx = self.square_points.index(closestPt)
+
+        #points that the other robots can move to
+        self.otherPts = list(self.square_points)
+        self.otherPts.remove(closestPt)
+
+        # remove the point that's diagonal of the closest point
+        farthestPt = max(self.otherPts,
+                         key=lambda pt: pt.dist_to(main.ball().pos))
+
+        self.otherPts.remove(farthestPt)
+
+        # decide which direction you're passing to
+        self.direction = self.safer_pass()
+        # move the other two robots to the other point locations
+        self.add_subbehavior(
+            skills.move.Move(
+                self.square_points[(closestPtIdx + self.direction) % 4]),
+            'move',
+            required=False)
+        # send the closest robot to capture the ball
+        self.add_subbehavior(skills.capture.Capture(), 'capture')
+
+    def on_exit_setup(self):
+        self.remove_subbehavior('move')
+        self.remove_subbehavior('capture')
+
+    def on_enter_passing(self):
+        # get the point passing from
+        kickFrom = min(self.square_points,
+                       key=lambda pt: pt.dist_to(main.ball().pos))
+        # get the index of where you're passing from
+        kickFromIdx = self.square_points.index(kickFrom)
+        # based on which direction you're passing to pick that index
+        kickToIdx = (kickFromIdx + self.direction) % len(self.square_points)
+        # get that point
+        kickToPt = self.square_points[kickToIdx]
+
+        # get ready to pass the ball
+        passing_action = tactics.coordinated_pass.CoordinatedPass(kickToPt)
+        # while pass is preparing get ready for the next pass
+        premove = skills.move.Move(self.square_points[(
+            kickToIdx + self.direction) % len(self.square_points)])
+
+        self.add_subbehavior(
+            passing_action, 'passer', required=True, priority=10)
+        self.add_subbehavior(premove, 'premove', required=True, priority=2)
+
+        # add a robot to chase after the ball.
+        if (not self.has_subbehavior_with_name('chasing')):
+            self.chaser = skills.move.Move(self.cut_off_pos(main.ball().pos))
+            self.add_subbehavior(
+                self.chaser, 'chasing', required=True, priority=2)
+
+    # remove subbehaviors 
+    def on_exit_passing(self):
+        self.remove_subbehavior('passer')
+        self.remove_subbehavior('chasing')
+        self.remove_subbehavior('premove')
+
+    #Decide which the better direction to pass is
+    def safer_pass(self):
+        if (True):
+            return 1
+        else:
+            return -1
+
+    # if a point is outside of a smaller box that is the square points - 3 robot radius'
+    # return the closest point inside that box.
+    def cut_off_pos(self, point):
+        # Projects the point given onto the edge of the smaller rectangle
+        # Each coordinate is found independently so we don't have to project to each
+        # segment of the rectangle and choose the closest
+        segment_x = robocup.Segment(
+            robocup.Point(self.min_x + self.bot_buffer, 0),
+            robocup.Point(self.max_x - self.bot_buffer, 0))
+        segment_y = robocup.Segment(
+            robocup.Point(0, self.min_y + self.bot_buffer),
+            robocup.Point(0, self.max_y - self.bot_buffer))
+
+        x_pos = segment_x.nearest_point(point)
+        y_pos = segment_y.nearest_point(point)
+
+        return robocup.Point(x_pos.x, y_pos.y)

--- a/soccer/planning/InterpolatedPath.cpp
+++ b/soccer/planning/InterpolatedPath.cpp
@@ -12,13 +12,13 @@ using namespace Geometry2d;
 
 namespace Planning {
 
-InterpolatedPath::InterpolatedPath(Point p0) {
-    waypoints.emplace_back(MotionInstant(p0, Point()), RJ::Seconds::zero());
+InterpolatedPath::InterpolatedPath(RobotInstant p0) {
+    waypoints.emplace_back(p0, RJ::Seconds::zero());
 }
 
-InterpolatedPath::InterpolatedPath(Point p0, Point p1) {
-    waypoints.emplace_back(MotionInstant(p0, Point()), 0ms);
-    waypoints.emplace_back(MotionInstant(p1, Point()), 0ms);
+InterpolatedPath::InterpolatedPath(RobotInstant p0, RobotInstant p1) {
+    waypoints.emplace_back(p0, 0ms);
+    waypoints.emplace_back(p1, 0ms);
 }
 
 float InterpolatedPath::length(unsigned int start) const {
@@ -32,17 +32,17 @@ float InterpolatedPath::length(unsigned int start, unsigned int end) const {
 
     float length = 0;
     for (unsigned int i = start; i < end; ++i) {
-        length += (waypoints[i + 1].pos() - waypoints[i].pos()).mag();
+        length += (waypoints[i + 1].pose.position() - waypoints[i].pose.position()).mag();
     }
     return length;
 }
 
 RobotInstant InterpolatedPath::start() const {
-    return RobotInstant(waypoints.front().instant);
+    return RobotInstant(waypoints.front().instant());
 }
 
 RobotInstant InterpolatedPath::end() const {
-    return RobotInstant(waypoints.back().instant);
+    return RobotInstant(waypoints.back().instant());
 }
 
 // Returns the index of the point in this path nearest to pt.
@@ -52,10 +52,10 @@ int InterpolatedPath::nearestIndex(Point pt) const {
     }
 
     int index = 0;
-    float dist = pt.distTo(waypoints[0].pos());
+    float dist = pt.distTo(waypoints[0].pose.position());
 
     for (unsigned int i = 1; i < waypoints.size(); ++i) {
-        float d = pt.distTo(waypoints[i].pos());
+        float d = pt.distTo(waypoints[i].pose.position());
         if (d < dist) {
             dist = d;
             index = i;
@@ -85,11 +85,11 @@ bool InterpolatedPath::hit(const Geometry2d::ShapeSet& obstacles,
     // This code disregards obstacles which the robot starts in. This allows the
     // robot to move out a obstacle if it is already in one.
     std::set<std::shared_ptr<Shape>> startHitSet =
-        obstacles.hitSet(waypoints[start].pos());
+        obstacles.hitSet(waypoints[start].pose.position());
 
     for (size_t i = start; i < waypoints.size() - 1; i++) {
         std::set<std::shared_ptr<Shape>> newHitSet = obstacles.hitSet(
-            Segment(waypoints[i].pos(), waypoints[i + 1].pos()));
+            Segment(waypoints[i].pose.position(), waypoints[i + 1].pose.position()));
         if (!newHitSet.empty()) {
             for (std::shared_ptr<Shape> hit : newHitSet) {
                 // If it hits something, check if the hit was in the original
@@ -114,7 +114,7 @@ float InterpolatedPath::distanceTo(Point pt) const {
 
     float dist = -1;
     for (unsigned int i = 0; i < (waypoints.size() - 1); ++i) {
-        Segment s(waypoints[i].pos(), waypoints[i + 1].pos());
+        Segment s(waypoints[i].pose.position(), waypoints[i + 1].pose.position());
         const float d = s.distTo(pt);
 
         if (dist < 0 || d < dist) {
@@ -133,7 +133,7 @@ Segment InterpolatedPath::nearestSegment(Point pt) const {
     }
 
     for (unsigned int i = 0; i < (waypoints.size() - 1); ++i) {
-        Segment s(waypoints[i].pos(), waypoints[i + 1].pos());
+        Segment s(waypoints[i].pose.position(), waypoints[i + 1].pose.position());
         const float d = s.distTo(pt);
 
         if (dist < 0 || d < dist) {
@@ -153,7 +153,7 @@ float InterpolatedPath::length(Point pt) const {
     }
 
     for (unsigned int i = 0; i < (waypoints.size() - 1); ++i) {
-        Segment s(waypoints[i].pos(), waypoints[i + 1].pos());
+        Segment s(waypoints[i].pose.position(), waypoints[i + 1].pose.position());
 
         // add the segment length
         length += s.length();
@@ -190,69 +190,72 @@ void InterpolatedPath::draw(DebugDrawer* const debug_drawer,
 
     for (const Entry& entry : waypoints) {
         Packet::DebugRobotPath::DebugRobotPathPoint* pt = dbg->add_points();
-        *pt->mutable_pos() = entry.pos();
-        *pt->mutable_vel() = entry.vel();
+        *pt->mutable_pos() = entry.pose.position();
+        *pt->mutable_vel() = entry.vel.linear();
     }
 }
 
 std::optional<RobotInstant> InterpolatedPath::eval(RJ::Seconds t) const {
-    if (t < RJ::Seconds::zero()) {
-        return RobotInstant(waypoints.front().instant);
-    }
-    //    if (t < RJ::Seconds::zero()) {
-    //        debugThrow(
-    //            invalid_argument("A time less than 0 was entered for time t.
-    //            t=" + to_string(t)));
-    //    }
-    /*
-    float linearPos;
-    float linearSpeed;
-    bool pathIsValid = TrapezoidalMotion(
-        length(),
-        maxSpeed,
-        maxAcceleration,
-        t,
-        startSpeed,
-        endSpeed,
-        linearPos,      //  these are set by reference since C++ can't return
-    multiple values
-        linearSpeed);   //
-
-    Point direction;
-    if(!getPoint(linearPos, targetPosOut, direction)) {
-        return false;
-    }
-
-    targetVelOut = direction * linearSpeed;
-    */
-    if (waypoints.size() == 0 || waypoints.size() == 1) {
+    if (waypoints.size() < 2) {
         return std::nullopt;
-    }
-    if (t < waypoints[0].time) {
-        debugThrow(
-            invalid_argument("The start time should not be less than zero"));
+    } if (t <= waypoints.front().time) {
+        return waypoints.front().instant();
+    } else if (t > waypoints.back().time) {
+        return std::nullopt;
+    } else if (t == waypoints.back().time) {
+        return waypoints.back().instant();
     }
 
-    int i = 0;
-    while (waypoints[i].time <= t) {
-        if (waypoints[i].time == t) {
-            return RobotInstant(waypoints[i].instant);
-        }
-        i++;
-        if (i == size()) {
-            return std::nullopt;
-        }
-    }
-    RJ::Seconds deltaT = (waypoints[i].time - waypoints[i - 1].time);
-    if (deltaT == RJ::Seconds::zero()) {
-        return RobotInstant(waypoints[i].instant);
-    }
-    float constant = (t - waypoints[i - 1].time) / deltaT;
+    std::vector<Entry>::const_iterator prev_it = waypoints.begin();
+    std::vector<Entry>::const_iterator next_it = waypoints.begin();
+    while (next_it != waypoints.end()) {
+        prev_it = next_it;
+        next_it++;
 
-    return RobotInstant(MotionInstant(waypoints[i - 1].pos() * (1 - constant) +
-                                          waypoints[i].pos() * (constant),
-                                      waypoints[i - 1].vel() * (1 - constant) +
-                                          waypoints[i].vel() * (constant)));
+        if (next_it->time >= t) {
+            break;
+        }
+    }
+
+    assert(prev_it != waypoints.end());
+    assert(next_it != waypoints.end());
+
+    Entry prev_entry = *prev_it;
+    Entry next_entry = *next_it;
+
+    RJ::Seconds dt = next_entry.time - prev_entry.time;
+    if (dt == RJ::Seconds(0)) {
+        return next_entry.instant();
+    }
+    RJ::Seconds elapsed = t - prev_entry.time;
+
+    // s in [0, 1] is the interpolation factor.
+    double s = elapsed / dt;
+
+    Pose pose_0 = prev_entry.pose;
+    Pose pose_1 = next_entry.pose;
+    Twist tangent_0 = prev_entry.vel * RJ::numSeconds(dt);
+    Twist tangent_1 = next_entry.vel * RJ::numSeconds(dt);
+
+    // Cubic interpolation
+    Pose interpolated_pose = Pose(Eigen::Vector3d(pose_0) * (2 * s * s * s - 3 * s * s + 1) +
+                                  Eigen::Vector3d(tangent_0) * (s * s * s - 2 * s * s + s) +
+                                  Eigen::Vector3d(pose_1) * (-2 * s * s * s + 3 * s * s) +
+                                  Eigen::Vector3d(tangent_1) * (s * s * s - s * s));
+
+    Twist interpolated_twist = Twist(Eigen::Vector3d(pose_0) * (6 * s * s - 6 * s) +
+                                     Eigen::Vector3d(tangent_0) * (3 * s * s - 4 * s + 1) +
+                                     Eigen::Vector3d(pose_1) * (-6 * s * s + 6 * s) +
+                                     Eigen::Vector3d(tangent_1) * (3 * s * s - 2 * s)) /
+                                             RJ::numSeconds(dt);
+
+    // Create a new MotionInstant
+    RobotInstant instant;
+    instant.motion.pos = interpolated_pose.position();
+    instant.motion.vel = interpolated_twist.linear();
+    instant.angle = AngleInstant(interpolated_pose.heading(), interpolated_twist.angular());
+
+    return instant;
 }
 
 size_t InterpolatedPath::size() const { return waypoints.size(); }
@@ -263,7 +266,7 @@ RJ::Seconds InterpolatedPath::getTime(int index) const {
 
 RJ::Seconds InterpolatedPath::getDuration() const {
     if (waypoints.size() > 0) {
-        return waypoints.back().time;
+        return waypoints.back().time - waypoints.front().time;
     } else {
         return RJ::Seconds::zero();
     }
@@ -306,75 +309,25 @@ unique_ptr<Path> InterpolatedPath::subPath(RJ::Seconds startTime,
 
     auto subpath = make_unique<InterpolatedPath>();
 
-    subpath->setStartTime(this->startTime() + startTime);
+    subpath->addInstant(0s, *eval(startTime));
 
     // Bound the endTime to a reasonable time.
-    endTime = min(endTime, getDuration());
+    endTime = min(endTime, waypoints.back().time);
 
     // Find the first point in the vector of points which will be included in
-    // the subPath
-    size_t start = 0;
-    while (waypoints[start].time <= startTime) {
-        start++;
-    }
-    start--;
-
-    // Add the first points to the InterpolatedPath
-    if (waypoints[start].time == startTime) {
-        subpath->waypoints.emplace_back(waypoints[start].instant,
-                                        RJ::Seconds::zero());
-    } else {
-        RJ::Seconds deltaT =
-            (waypoints[start + 1].time - waypoints[start].time);
-        float constant = (waypoints[start + 1].time - startTime) / deltaT;
-        Point startPos = waypoints[start + 1].pos() * (1 - constant) +
-                         waypoints[start].pos() * (constant);
-        Point vi = waypoints[start + 1].vel() * (1 - constant) +
-                   waypoints[start].vel() * (constant);
-
-        subpath->waypoints.emplace_back(MotionInstant(startPos, vi),
-                                        RJ::Seconds::zero());
+    // the subPath. Noninclusive because we always copy eval(startTime)
+    auto entry_it = waypoints.begin();
+    while (entry_it->time <= startTime) {
+        entry_it++;
     }
 
-    // Find the last point in the InterpolatedPath
-    Point vf;
-    Point endPos;
-    size_t end;
-    if (endTime >= getDuration()) {
-        end = size() - 1;
-        vf = waypoints[end].vel();
-        endPos = waypoints[end].pos();
-    } else {
-        end = start + 1;
-        while (waypoints[end].time < endTime) {
-            end++;
-        }
-        RJ::Seconds deltaT = (waypoints[end].time - waypoints[end - 1].time);
-        float constant = (waypoints[end].time - endTime) / deltaT;
-        vf = waypoints[end].vel() * (1 - constant) +
-             waypoints[end - 1].vel() * (constant);
-        endPos = waypoints[end].pos() * (1 - constant) +
-                 waypoints[end - 1].pos() * constant;
+    // Copy until the time is greater than or equal to endTime. Noninclusive because we always copy eval(endTime)
+    while (entry_it != waypoints.end() && entry_it->time < endTime) {
+        subpath->waypoints.emplace_back(entry_it->instant(), entry_it->time - startTime);
+        entry_it++;
     }
 
-    // Add all the points in the middle
-    size_t i = start + 1;
-    while (i < end) {
-        subpath->waypoints.emplace_back(waypoints[i].instant,
-                                        waypoints[i].time - startTime);
-        i++;
-    }
-
-    // Add the last point
-    subpath->waypoints.emplace_back(MotionInstant(endPos, vf),
-                                    endTime - startTime);
-
-    debugThrowIf(
-        to_string(subpath->getDuration()) +
-            to_string(std::min(getDuration() - startTime, endTime - startTime)),
-        (subpath->getDuration() -
-         std::min(getDuration() - startTime, endTime - startTime)).count() >
-            0.00001);
+    subpath->addInstant(endTime - startTime, *eval(endTime));
 
     return std::move(subpath);
 }

--- a/soccer/planning/InterpolatedPath.cpp
+++ b/soccer/planning/InterpolatedPath.cpp
@@ -32,7 +32,9 @@ float InterpolatedPath::length(unsigned int start, unsigned int end) const {
 
     float length = 0;
     for (unsigned int i = start; i < end; ++i) {
-        length += (waypoints[i + 1].pose.position() - waypoints[i].pose.position()).mag();
+        length +=
+            (waypoints[i + 1].pose.position() - waypoints[i].pose.position())
+                .mag();
     }
     return length;
 }
@@ -88,8 +90,8 @@ bool InterpolatedPath::hit(const Geometry2d::ShapeSet& obstacles,
         obstacles.hitSet(waypoints[start].pose.position());
 
     for (size_t i = start; i < waypoints.size() - 1; i++) {
-        std::set<std::shared_ptr<Shape>> newHitSet = obstacles.hitSet(
-            Segment(waypoints[i].pose.position(), waypoints[i + 1].pose.position()));
+        std::set<std::shared_ptr<Shape>> newHitSet = obstacles.hitSet(Segment(
+            waypoints[i].pose.position(), waypoints[i + 1].pose.position()));
         if (!newHitSet.empty()) {
             for (std::shared_ptr<Shape> hit : newHitSet) {
                 // If it hits something, check if the hit was in the original
@@ -114,7 +116,8 @@ float InterpolatedPath::distanceTo(Point pt) const {
 
     float dist = -1;
     for (unsigned int i = 0; i < (waypoints.size() - 1); ++i) {
-        Segment s(waypoints[i].pose.position(), waypoints[i + 1].pose.position());
+        Segment s(waypoints[i].pose.position(),
+                  waypoints[i + 1].pose.position());
         const float d = s.distTo(pt);
 
         if (dist < 0 || d < dist) {
@@ -133,7 +136,8 @@ Segment InterpolatedPath::nearestSegment(Point pt) const {
     }
 
     for (unsigned int i = 0; i < (waypoints.size() - 1); ++i) {
-        Segment s(waypoints[i].pose.position(), waypoints[i + 1].pose.position());
+        Segment s(waypoints[i].pose.position(),
+                  waypoints[i + 1].pose.position());
         const float d = s.distTo(pt);
 
         if (dist < 0 || d < dist) {
@@ -153,7 +157,8 @@ float InterpolatedPath::length(Point pt) const {
     }
 
     for (unsigned int i = 0; i < (waypoints.size() - 1); ++i) {
-        Segment s(waypoints[i].pose.position(), waypoints[i + 1].pose.position());
+        Segment s(waypoints[i].pose.position(),
+                  waypoints[i + 1].pose.position());
 
         // add the segment length
         length += s.length();
@@ -198,7 +203,8 @@ void InterpolatedPath::draw(DebugDrawer* const debug_drawer,
 std::optional<RobotInstant> InterpolatedPath::eval(RJ::Seconds t) const {
     if (waypoints.size() < 2) {
         return std::nullopt;
-    } if (t <= waypoints.front().time) {
+    }
+    if (t <= waypoints.front().time) {
         return waypoints.front().instant();
     } else if (t > waypoints.back().time) {
         return std::nullopt;
@@ -238,22 +244,25 @@ std::optional<RobotInstant> InterpolatedPath::eval(RJ::Seconds t) const {
     Twist tangent_1 = next_entry.vel * RJ::numSeconds(dt);
 
     // Cubic interpolation
-    Pose interpolated_pose = Pose(Eigen::Vector3d(pose_0) * (2 * s * s * s - 3 * s * s + 1) +
-                                  Eigen::Vector3d(tangent_0) * (s * s * s - 2 * s * s + s) +
-                                  Eigen::Vector3d(pose_1) * (-2 * s * s * s + 3 * s * s) +
-                                  Eigen::Vector3d(tangent_1) * (s * s * s - s * s));
+    Pose interpolated_pose =
+        Pose(Eigen::Vector3d(pose_0) * (2 * s * s * s - 3 * s * s + 1) +
+             Eigen::Vector3d(tangent_0) * (s * s * s - 2 * s * s + s) +
+             Eigen::Vector3d(pose_1) * (-2 * s * s * s + 3 * s * s) +
+             Eigen::Vector3d(tangent_1) * (s * s * s - s * s));
 
-    Twist interpolated_twist = Twist(Eigen::Vector3d(pose_0) * (6 * s * s - 6 * s) +
-                                     Eigen::Vector3d(tangent_0) * (3 * s * s - 4 * s + 1) +
-                                     Eigen::Vector3d(pose_1) * (-6 * s * s + 6 * s) +
-                                     Eigen::Vector3d(tangent_1) * (3 * s * s - 2 * s)) /
-                                             RJ::numSeconds(dt);
+    Twist interpolated_twist =
+        Twist(Eigen::Vector3d(pose_0) * (6 * s * s - 6 * s) +
+              Eigen::Vector3d(tangent_0) * (3 * s * s - 4 * s + 1) +
+              Eigen::Vector3d(pose_1) * (-6 * s * s + 6 * s) +
+              Eigen::Vector3d(tangent_1) * (3 * s * s - 2 * s)) /
+        RJ::numSeconds(dt);
 
     // Create a new MotionInstant
     RobotInstant instant;
     instant.motion.pos = interpolated_pose.position();
     instant.motion.vel = interpolated_twist.linear();
-    instant.angle = AngleInstant(interpolated_pose.heading(), interpolated_twist.angular());
+    instant.angle =
+        AngleInstant(interpolated_pose.heading(), interpolated_twist.angular());
 
     return instant;
 }
@@ -321,9 +330,11 @@ unique_ptr<Path> InterpolatedPath::subPath(RJ::Seconds startTime,
         entry_it++;
     }
 
-    // Copy until the time is greater than or equal to endTime. Noninclusive because we always copy eval(endTime)
+    // Copy until the time is greater than or equal to endTime. Noninclusive
+    // because we always copy eval(endTime)
     while (entry_it != waypoints.end() && entry_it->time < endTime) {
-        subpath->waypoints.emplace_back(entry_it->instant(), entry_it->time - startTime);
+        subpath->waypoints.emplace_back(entry_it->instant(),
+                                        entry_it->time - startTime);
         entry_it++;
     }
 

--- a/soccer/planning/InterpolatedPath.hpp
+++ b/soccer/planning/InterpolatedPath.hpp
@@ -26,8 +26,10 @@ public:
     struct Entry {
         Entry(RobotInstant inst, RJ::Seconds t) : time(t) {
             if (inst.angle) {
-                pose = Geometry2d::Pose(inst.motion.pos, inst.angle->angle.value_or(0));
-                vel = Geometry2d::Twist(inst.motion.vel, inst.angle->angleVel.value_or(0));
+                pose = Geometry2d::Pose(inst.motion.pos,
+                                        inst.angle->angle.value_or(0));
+                vel = Geometry2d::Twist(inst.motion.vel,
+                                        inst.angle->angleVel.value_or(0));
             } else {
                 pose = Geometry2d::Pose(inst.motion.pos, 0);
                 vel = Geometry2d::Twist(inst.motion.vel, 0);
@@ -37,7 +39,8 @@ public:
         Entry(Geometry2d::Pose pose, Geometry2d::Twist twist, RJ::Seconds t)
             : pose(pose), vel(twist), time(t) {}
 
-        Entry(MotionInstant inst, RJ::Seconds t) : Entry(RobotInstant(inst), t) {}
+        Entry(MotionInstant inst, RJ::Seconds t)
+            : Entry(RobotInstant(inst), t) {}
 
         Geometry2d::Pose pose;
         Geometry2d::Twist vel;
@@ -139,7 +142,8 @@ public:
     RJ::Seconds getTime(int index) const;
 
     static std::unique_ptr<Path> emptyPath(Geometry2d::Point position) {
-        auto path = std::make_unique<InterpolatedPath>(RobotInstant(MotionInstant(position)));
+        auto path = std::make_unique<InterpolatedPath>(
+            RobotInstant(MotionInstant(position)));
         path->setDebugText("Empty Path");
         return std::move(path);
     }

--- a/soccer/planning/InterpolatedPath.hpp
+++ b/soccer/planning/InterpolatedPath.hpp
@@ -34,6 +34,9 @@ public:
             }
         }
 
+        Entry(Geometry2d::Pose pose, Geometry2d::Twist twist, RJ::Seconds t)
+            : pose(pose), vel(twist), time(t) {}
+
         Entry(MotionInstant inst, RJ::Seconds t) : Entry(RobotInstant(inst), t) {}
 
         Geometry2d::Pose pose;

--- a/soccer/planning/MotionInstant.hpp
+++ b/soccer/planning/MotionInstant.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <optional>
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/Pose.hpp>
+#include <optional>
 
 namespace Planning {
 

--- a/soccer/planning/MotionInstant.hpp
+++ b/soccer/planning/MotionInstant.hpp
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <Geometry2d/Point.hpp>
+#include <Geometry2d/Pose.hpp>
 
 namespace Planning {
 
@@ -49,6 +50,22 @@ struct RobotInstant {
         : motion(motion), angle(angle) {}
     MotionInstant motion;
     std::optional<AngleInstant> angle;
+
+    Geometry2d::Pose pose() {
+        if (angle && angle->angle) {
+            return Geometry2d::Pose(motion.pos, angle->angle.value());
+        } else {
+            return Geometry2d::Pose(motion.pos, 0);
+        }
+    }
+
+    Geometry2d::Twist twist() {
+        if (angle && angle->angleVel) {
+            return Geometry2d::Twist(motion.vel, angle->angleVel.value());
+        } else {
+            return Geometry2d::Twist(motion.vel, 0);
+        }
+    }
 
     // TODO ashaw596  implement stream operator
 };

--- a/soccer/planning/PathTest.cpp
+++ b/soccer/planning/PathTest.cpp
@@ -12,10 +12,10 @@ TEST(Path, nearestSegment) {
     Point p0, p1(1.0, 0.0), p2(2.0, 0.0), p3(3.0, 0.0);
 
     InterpolatedPath path;
-    path.waypoints.emplace_back(MotionInstant(p0, Point()), 0s);
-    path.waypoints.emplace_back(MotionInstant(p1, Point()), 0s);
-    path.waypoints.emplace_back(MotionInstant(p2, Point()), 0s);
-    path.waypoints.emplace_back(MotionInstant(p3, Point()), 0s);
+    path.waypoints.emplace_back(RobotInstant{Pose(p0, 0), Twist::Zero()}, 0s);
+    path.waypoints.emplace_back(RobotInstant{Pose(p1, 0), Twist::Zero()}, 0s);
+    path.waypoints.emplace_back(RobotInstant{Pose(p2, 0), Twist::Zero()}, 0s);
+    path.waypoints.emplace_back(RobotInstant{Pose(p3, 0), Twist::Zero()}, 0s);
 
     Segment actSeg = path.nearestSegment(Point(0.5, -0.5));
     EXPECT_FLOAT_EQ(p0.x(), actSeg.pt[0].x());
@@ -28,9 +28,59 @@ TEST(InterpolatedPath, evaluate) {
     Point p0(1, 1), p1(1, 2), p2(2, 2);
 
     InterpolatedPath path;
-    path.waypoints.emplace_back(MotionInstant(p0, Point()), 0s);
-    path.waypoints.emplace_back(MotionInstant(p1, p1), 3s);
-    path.waypoints.emplace_back(MotionInstant(p2, Point()), 6s);
+    path.waypoints.emplace_back(RobotInstant{Pose(p0, 0), Twist::Zero()}, 0s);
+    path.waypoints.emplace_back(RobotInstant{Pose(p1, 0), Twist(p1, 0)}, 3s);
+    path.waypoints.emplace_back(RobotInstant{Pose(p2, 0), Twist::Zero()}, 6s);
+
+    // Pose and velocity should take on correct values at and near waypoints
+    {
+        auto pt = path.evaluate(0s);
+        ASSERT_TRUE(pt);
+        EXPECT_FLOAT_EQ(pt->pose.position().x(), p0.x());
+        EXPECT_FLOAT_EQ(pt->pose.position().y(), p0.y());
+        EXPECT_FLOAT_EQ(pt->velocity.linear().x(), 0);
+        EXPECT_FLOAT_EQ(pt->velocity.linear().y(), 0);
+    }
+
+    {
+        auto pt = path.evaluate(1e-6s);
+        ASSERT_TRUE(pt);
+        EXPECT_NEAR(pt->pose.position().x(), p0.x(), 1e-3);
+        EXPECT_NEAR(pt->pose.position().y(), p0.y(), 1e-3);
+        EXPECT_NEAR(pt->velocity.linear().x(), 0, 1e-3);
+        EXPECT_NEAR(pt->velocity.linear().y(), 0, 1e-3);
+    }
+
+    {
+        auto pt = path.evaluate(3s);
+        ASSERT_TRUE(pt);
+        EXPECT_FLOAT_EQ(pt->pose.position().x(), p1.x());
+        EXPECT_FLOAT_EQ(pt->pose.position().y(), p1.y());
+        EXPECT_FLOAT_EQ(pt->velocity.linear().x(), p1.x());
+        EXPECT_FLOAT_EQ(pt->velocity.linear().y(), p2.y());
+    }
+
+    {
+        auto pt = path.evaluate(3s + 1e-6s);
+        ASSERT_TRUE(pt);
+        EXPECT_NEAR(pt->pose.position().x(), p1.x(), 1e-3);
+        EXPECT_NEAR(pt->pose.position().y(), p1.y(), 1e-3);
+        EXPECT_NEAR(pt->velocity.linear().x(), p1.x(), 1e-3);
+        EXPECT_NEAR(pt->velocity.linear().y(), p2.y(), 1e-3);
+    }
+
+    // Check that velocity matches expected
+    for (RJ::Seconds t = 0s; t + 1e-6s < 6s; t += 5ms)
+    {
+        auto dt = 1e-6s;
+        auto pt = path.evaluate(t);
+        auto pt2 = path.evaluate(t + dt);
+        ASSERT_TRUE(pt);
+        ASSERT_TRUE(pt2);
+        auto velocity = (pt->velocity + pt2->velocity) / 2;
+        Twist finite_difference(Eigen::Vector3d(pt2->pose - pt->pose) / RJ::numSeconds(dt));
+        ASSERT_LT(Eigen::Vector3d(velocity - finite_difference).lpNorm<Eigen::Infinity>(), 1e-3);
+    }
 
     // path should be invalid and at end state when t > duration
     auto out = path.evaluate(1000s);
@@ -39,9 +89,9 @@ TEST(InterpolatedPath, evaluate) {
 
 TEST(InterpolatedPath, subPath1) {
     InterpolatedPath path;
-    path.waypoints.emplace_back(MotionInstant(Point(1, 1), Point(0, 0)), 0s);
-    path.waypoints.emplace_back(MotionInstant(Point(1, 2), Point(1, 1)), 3s);
-    path.waypoints.emplace_back(MotionInstant(Point(1, 3), Point(0, 0)), 6s);
+    path.waypoints.emplace_back(RobotInstant{Pose(1, 1, 0), Twist(0, 0, 0)}, 0s);
+    path.waypoints.emplace_back(RobotInstant{Pose(1, 2, 0), Twist(1, 1, 0)}, 3s);
+    path.waypoints.emplace_back(RobotInstant{Pose(1, 3, 0), Twist(0, 0, 0)}, 6s);
 
     //  test invalid parameters to subPath()
     EXPECT_THROW(path.subPath(-1s, 5s), invalid_argument);
@@ -55,13 +105,13 @@ TEST(InterpolatedPath, subPath1) {
     RJ::Seconds midTime((5 - 1) / 2.0);
     auto mid = subPath->evaluate(midTime);
     ASSERT_TRUE(mid);
-    EXPECT_FLOAT_EQ(Point(1, 1).x(), mid->motion.vel.x());
+    EXPECT_FLOAT_EQ(Point(1, 1).x(), mid->velocity.linear().x());
 
     //  mid velocity of subpath should be the same as velocity of original path
-    EXPECT_FLOAT_EQ(Point(1, 1).y(), mid->motion.vel.y());
+    EXPECT_FLOAT_EQ(Point(1, 1).y(), mid->velocity.linear().y());
 
-    EXPECT_FLOAT_EQ(1, mid->motion.pos.x());
-    EXPECT_FLOAT_EQ(2, mid->motion.pos.y());
+    EXPECT_FLOAT_EQ(1, mid->pose.position().x());
+    EXPECT_FLOAT_EQ(2, mid->pose.position().y());
 
     //  test the subpath at t = 0
     auto start = subPath->evaluate(0s);
@@ -69,22 +119,22 @@ TEST(InterpolatedPath, subPath1) {
 
     //  the starting velocity of the subpath should be somewhere between the 0
     //  and the velocity at the middle
-    EXPECT_GT(start->motion.vel.mag(), 0);
-    EXPECT_LT(start->motion.vel.mag(), Point(1, 1).mag());
+    EXPECT_GT(start->velocity.linear().mag(), 0);
+    EXPECT_LT(start->velocity.linear().mag(), Point(1, 1).mag());
 
     //  the starting position of the subpath should be somewhere between the
     //  start pos of the original path and the middle point
-    EXPECT_GT(start->motion.pos.y(), 1);
-    EXPECT_LT(start->motion.pos.x(), 2);
+    EXPECT_GT(start->pose.position().y(), 1);
+    EXPECT_LT(start->pose.position().x(), 2);
 }
 
 TEST(InterpolatedPath, subpath2) {
     // Create a test path
     InterpolatedPath path;
-    path.waypoints.emplace_back(MotionInstant(Point(1, 0), Point(0, 0)), 0s);
-    path.waypoints.emplace_back(MotionInstant(Point(1, 2), Point(-1, -1)), 1s);
-    path.waypoints.emplace_back(MotionInstant(Point(-2, 19), Point(1, 1)), 3s);
-    path.waypoints.emplace_back(MotionInstant(Point(1, 6), Point(0, 0)), 9s);
+    path.waypoints.emplace_back(RobotInstant{Pose(1, 0, 0), Twist(0, 0, 0)}, 0s);
+    path.waypoints.emplace_back(RobotInstant{Pose(1, 2, 0), Twist(-1, -1, 0)}, 1s);
+    path.waypoints.emplace_back(RobotInstant{Pose(-2, 19, 0), Twist(1, 1, 0)}, 3s);
+    path.waypoints.emplace_back(RobotInstant{Pose(1, 6, 0), Twist(0, 0, 0)}, 9s);
 
     // Create 6 subPaths of length 1.5
     vector<unique_ptr<Path>> subPaths;
@@ -93,7 +143,9 @@ TEST(InterpolatedPath, subpath2) {
         subPaths.push_back(path.subPath(i, i + diff));
     }
 
-    // Compare the subPaths to the origional path and check that the results of
+    auto x = path.evaluate(4.5s);
+
+    // Compare the subPaths to the original path and check that the results of
     // evaluating the paths are close enough
     for (int i = 0; i < 6; i++) {
         for (auto j = 0ms; j < 1500ms; j += 1ms) {
@@ -103,13 +155,13 @@ TEST(InterpolatedPath, subpath2) {
 
             ASSERT_TRUE(org);
             ASSERT_TRUE(sub);
-            EXPECT_NEAR(org->motion.vel.x(), sub->motion.vel.x(), 0.000001)
+            EXPECT_NEAR(org->velocity.linear().x(), sub->velocity.linear().x(), 0.000001)
                 << "i+j=" << to_string(time);
-            EXPECT_NEAR(org->motion.vel.y(), sub->motion.vel.y(), 0.000001)
+            EXPECT_NEAR(org->velocity.linear().y(), sub->velocity.linear().y(), 0.000001)
                 << "i+j=" << to_string(time);
-            EXPECT_NEAR(org->motion.pos.x(), sub->motion.pos.x(), 0.000001)
+            EXPECT_NEAR(org->pose.position().x(), sub->pose.position().x(), 0.000001)
                 << "i+j=" << to_string(time);
-            EXPECT_NEAR(org->motion.pos.y(), sub->motion.pos.y(), 0.00001)
+            EXPECT_NEAR(org->pose.position().y(), sub->pose.position().y(), 0.00001)
                 << "i+j=" << to_string(time);
         }
     }
@@ -118,10 +170,10 @@ TEST(InterpolatedPath, subpath2) {
 TEST(CompositePath, CompositeSubPath) {
     // Create a test path
     InterpolatedPath path;
-    path.waypoints.emplace_back(MotionInstant(Point(1, 0), Point(0, 0)), 0s);
-    path.waypoints.emplace_back(MotionInstant(Point(1, 2), Point(-1, -1)), 1s);
-    path.waypoints.emplace_back(MotionInstant(Point(-2, 19), Point(1, 1)), 3s);
-    path.waypoints.emplace_back(MotionInstant(Point(1, 6), Point(0, 0)), 9s);
+    path.waypoints.emplace_back(RobotInstant{Pose(1, 0, 0), Twist(0, 0, 0)}, 0s);
+    path.waypoints.emplace_back(RobotInstant{Pose(1, 2, 0), Twist(-1, -1, 0)}, 1s);
+    path.waypoints.emplace_back(RobotInstant{Pose(-2, 19, 0), Twist(1, 1, 0)}, 3s);
+    path.waypoints.emplace_back(RobotInstant{Pose(1, 6, 0), Twist(0, 0, 0)}, 9s);
 
     // Create 6 subPaths and rejoin them together into one compositePath
     CompositePath compositePath;
@@ -139,13 +191,13 @@ TEST(CompositePath, CompositeSubPath) {
 
         ASSERT_TRUE(org);
         ASSERT_TRUE(sub);
-        EXPECT_NEAR(org->motion.vel.x(), sub->motion.vel.x(), 0.000001)
+        EXPECT_NEAR(org->velocity.linear().x(), sub->velocity.linear().x(), 0.000001)
             << "i=" << to_string(i);
-        EXPECT_NEAR(org->motion.vel.y(), sub->motion.vel.y(), 0.000001)
+        EXPECT_NEAR(org->velocity.linear().y(), sub->velocity.linear().y(), 0.000001)
             << "i=" << to_string(i);
-        EXPECT_NEAR(org->motion.pos.x(), sub->motion.pos.x(), 0.000001)
+        EXPECT_NEAR(org->pose.position().x(), sub->pose.position().x(), 0.000001)
             << "i=" << to_string(i);
-        EXPECT_NEAR(org->motion.pos.y(), sub->motion.pos.y(), 0.00001)
+        EXPECT_NEAR(org->pose.position().y(), sub->pose.position().y(), 0.00001)
             << "i=" << to_string(i);
     }
 
@@ -166,13 +218,13 @@ TEST(CompositePath, CompositeSubPath) {
             auto sub = subPaths[i]->evaluate(j);
             ASSERT_TRUE(org);
             ASSERT_TRUE(sub);
-            EXPECT_NEAR(org->motion.vel.x(), sub->motion.vel.x(), 0.000001)
+            EXPECT_NEAR(org->velocity.linear().x(), sub->velocity.linear().x(), 0.000001)
                 << "newPathTime=" << to_string(time);
-            EXPECT_NEAR(org->motion.vel.y(), sub->motion.vel.y(), 0.000001)
+            EXPECT_NEAR(org->velocity.linear().y(), sub->velocity.linear().y(), 0.000001)
                 << "newPathTime=" << to_string(time);
-            EXPECT_NEAR(org->motion.pos.x(), sub->motion.pos.x(), 0.000001)
+            EXPECT_NEAR(org->pose.position().x(), sub->pose.position().x(), 0.000001)
                 << "newPathTime=" << to_string(time);
-            EXPECT_NEAR(org->motion.pos.y(), sub->motion.pos.y(), 0.00001)
+            EXPECT_NEAR(org->pose.position().y(), sub->pose.position().y(), 0.00001)
                 << "newPathTime=" << to_string(time);
         }
     }

--- a/soccer/planning/PathTest.cpp
+++ b/soccer/planning/PathTest.cpp
@@ -70,16 +70,18 @@ TEST(InterpolatedPath, evaluate) {
     }
 
     // Check that velocity matches expected
-    for (RJ::Seconds t = 0s; t + 1e-6s < 6s; t += 5ms)
-    {
+    for (RJ::Seconds t = 0s; t + 1e-6s < 6s; t += 5ms) {
         auto dt = 1e-6s;
         auto pt = path.evaluate(t);
         auto pt2 = path.evaluate(t + dt);
         ASSERT_TRUE(pt);
         ASSERT_TRUE(pt2);
         auto velocity = (pt->twist() + pt2->twist()) / 2;
-        Twist finite_difference(Eigen::Vector3d(pt2->pose() - pt->pose()) / RJ::numSeconds(dt));
-        ASSERT_LT(Eigen::Vector3d(velocity - finite_difference).lpNorm<Eigen::Infinity>(), 1e-3);
+        Twist finite_difference(Eigen::Vector3d(pt2->pose() - pt->pose()) /
+                                RJ::numSeconds(dt));
+        ASSERT_LT(Eigen::Vector3d(velocity - finite_difference)
+                      .lpNorm<Eigen::Infinity>(),
+                  1e-3);
     }
 
     // path should be invalid and at end state when t > duration

--- a/soccer/ui/StyleSheetManager.cpp
+++ b/soccer/ui/StyleSheetManager.cpp
@@ -6,10 +6,10 @@
 // To add a new style sheet, declare the static variable
 std::map<QString, QString> filePaths = {
     // Add new entries here:
-    {"DARK", "../soccer/ui/themes/QTDark.stylesheet"},
-    {"DARCULIZED", "../soccer/ui/themes/darculized.stylesheet"},
-    {"1337H4X0R", "../soccer/ui/themes/1337h4x0r.stylesheet"},
-    {"NYAN", "../soccer/ui/themes/nyan.stylesheet"}};
+    {"DARK", "../soccer/ui/qt/themes/QTDark.stylesheet"},
+    {"DARCULIZED", "../soccer/ui/qt/themes/darculized.stylesheet"},
+    {"1337H4X0R", "../soccer/ui/qt/themes/1337h4x0r.stylesheet"},
+    {"NYAN", "../soccer/ui/qt/themes/nyan.stylesheet"}};
 
 void StyleSheetManager::changeStyleSheet(QMainWindow* window, QString name) {
     if (filePaths.count(name)) {


### PR DESCRIPTION
## Description
Currently, we effectively do angle planning at the "control" phase, because the angles from `AngleFunctionPath` are not evaluated until path execution time.

Instead, we want to allow `InterpolatedPath` to directly plan for angles, and the RRT planner to calculate angles.

Use cubic interpolation on paths (Hermite splines between position/velocity waypoints) for a properly smooth velocity profile.

This also allows us to interpolate over angles at the `InterpolatedPath` level. Currently this is not being used (we wrap the `InterpolatedPath` in an `AngleFunctionPath` in order to plan angles).

## Associated Issue
Issue #1323

## Design Documents
[Link](https://docs.google.com/document/d/1mveM6Q6uNT5T8Q3a5pQVPb19Xi-JDAWUPn6O1HKcsyc/edit#)

## Steps to test
### Automated testing
(Run on CI)
Expected result: CI pass

### Soccer test
1. Run soccer
2. Select the `comp` playbook
3. There should be no measurable difference between this and the original.

### Motion benchmark
There should be no measurable difference on the motion benchmark before and after this PR. @liquidmetal9015's benchmark is a prerequisite for testing this.