### PR TITLE
Vision receiver module

### DIFF
--- a/common/multicast.cpp
+++ b/common/multicast.cpp
@@ -4,9 +4,13 @@
 #include <arpa/inet.h>
 
 bool multicast_add(QAbstractSocket* socket, const char* addr) {
+    return multicast_add_native(socket->socketDescriptor(), addr);
+}
+
+bool multicast_add_native(int socket, const char* addr) {
     struct ip_mreqn mreq;
     memset(&mreq, 0, sizeof(mreq));
     mreq.imr_multiaddr.s_addr = inet_addr(addr);
-    return setsockopt(socket->socketDescriptor(), IPPROTO_IP, IP_ADD_MEMBERSHIP,
-                      &mreq, sizeof(mreq)) == 0;
+    return setsockopt(socket, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq,
+                      sizeof(mreq)) == 0;
 }

--- a/common/multicast.hpp
+++ b/common/multicast.hpp
@@ -3,3 +3,4 @@
 #include <QAbstractSocket>
 
 bool multicast_add(QAbstractSocket* socket, const char* addr);
+bool multicast_add_native(int socket, const char* addr);

--- a/soccer/Context.hpp
+++ b/soccer/Context.hpp
@@ -3,8 +3,8 @@
 #include "DebugDrawer.hpp"
 #include "GameState.hpp"
 #include "SystemState.hpp"
-#include "vision/VisionPacket.hpp"
 #include "WorldState.hpp"
+#include "vision/VisionPacket.hpp"
 
 struct Context {
     Context() : state(this), debug_drawer(this) {}

--- a/soccer/Context.hpp
+++ b/soccer/Context.hpp
@@ -3,6 +3,7 @@
 #include "DebugDrawer.hpp"
 #include "GameState.hpp"
 #include "SystemState.hpp"
+#include "vision/VisionPacket.hpp"
 
 struct Context {
     Context() : state(this), debug_drawer(this) {}
@@ -17,4 +18,6 @@ struct Context {
     SystemState state;
     GameState game_state;
     DebugDrawer debug_drawer;
+
+    std::vector<std::unique_ptr<VisionPacket>> vision_packets;
 };

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -917,7 +917,11 @@ void Processor::defendPlusX(bool value) {
 void Processor::changeVisionChannel(int port) {
     _loopMutex.lock();
 
-    _visionReceiver->port = port;
+    // If we're in simulation, the vision channel should never change
+    // from `SimVisionPort`.
+    if (!_simulation) {
+        _visionReceiver->setPort(port);
+    }
 
     _loopMutex.unlock();
 }

--- a/soccer/Processor.hpp
+++ b/soccer/Processor.hpp
@@ -265,8 +265,10 @@ private:
     std::shared_ptr<NewRefereeModule> _refereeModule;
     std::shared_ptr<Gameplay::GameplayModule> _gameplayModule;
     std::unique_ptr<Planning::MultiRobotPathPlanner> _pathPlanner;
+    std::unique_ptr<VisionReceiver> _visionReceiver;
+    std::unique_ptr<MotionControlNode> _motionControl;
 
-    std::vector<std::unique_ptr<Node>> _modules;
+    std::vector<Node*> _nodes;
 
     // joystick control
     std::vector<Joystick*> _joysticks;
@@ -280,8 +282,6 @@ private:
     // If true, rotates robot commands from the joystick based on its
     // orientation on the field
     bool _useFieldOrientedManualDrive = false;
-
-    VisionReceiver vision;
 
     VisionChannel _visionChannel;
 

--- a/soccer/VisionReceiver.cpp
+++ b/soccer/VisionReceiver.cpp
@@ -8,89 +8,77 @@
 #include <stdexcept>
 
 using namespace std;
+using boost::asio::ip::udp;
 
-VisionReceiver::VisionReceiver(bool sim, int port)
-    : simulation(sim), _running(false), port(port) {}
-
-void VisionReceiver::stop() {
-    if (isRunning()) {
-        // Handle Case where start has been called, but _running has not been
-        // set to true yet.
-        while (!_running) {
-        }
-        _running = false;
-        wait();
-    }
-}
-
-void VisionReceiver::getPackets(std::vector<VisionPacket*>& packets) {
-    _mutex.lock();
-    packets = _packets;
-    _packets.clear();
-    _mutex.unlock();
-}
-
-void VisionReceiver::run() {
-    _running = true;
-    QUdpSocket socket;
-
-    // Create vision socket
-    if (simulation) {
-        if (!socket.bind(SimVisionPort, QUdpSocket::ShareAddress)) {
-            throw runtime_error("Can't bind to shared vision port");
-        }
-
-        multicast_add(&socket, SharedVisionAddress);
-    } else {
-        // Receive multicast packets from shared vision.
-        if (!socket.bind(port, QUdpSocket::ShareAddress)) {
-            throw runtime_error("Can't bind to shared vision port");
-        }
-
-        multicast_add(&socket, SharedVisionAddress);
-    }
+VisionReceiver::VisionReceiver(Context* context, bool sim, int port)
+    : simulation(sim), port(port), _context(context), _socket(_io_context) {
+    _recv_buffer.resize(65536);
 
     // There should be at most four packets: one for each camera on each of two
     // frames, assuming some clock skew between this
     // computer and the vision computer.
     _packets.reserve(4);
-    while (_running) {
-        char buf[65536];
 
-        // Wait for a UDP packet
-        if (!socket.waitForReadyRead(500)) {
-            // Time out once in a while so the thread has a chance to exit
-            continue;
-        }
-
-        QHostAddress host;
-        quint16 portNumber = 0;
-        qint64 size = socket.readDatagram(buf, sizeof(buf), &host, &portNumber);
-        if (size < 1) {
-            fprintf(stderr, "VisionReceiver: %s\n",
-                    (const char*)socket.errorString().toLatin1());
-            // See Processor for why we can't use QThread::msleep()
-            ::usleep(100 * 1000);
-            continue;
-        }
-
-        // FIXME - Verify that it is from the right host, in case there are
-        // multiple visions on the network
-
-        // Parse the protobuf message
-        VisionPacket* packet = new VisionPacket;
-        packet->receivedTime = RJ::now();
-        if (!packet->wrapper.ParseFromArray(buf, size)) {
-            fprintf(stderr,
-                    "VisionReceiver: got bad packet of %d bytes from %s:%d\n",
-                    (int)size, (const char*)host.toString().toLatin1(),
-                    portNumber);
-            continue;
-        }
-
-        // Add to the vector of packets
-        _mutex.lock();
-        _packets.push_back(packet);
-        _mutex.unlock();
+    // TODO(Kyle): Make sure we don't need to use SimVisionPort
+    boost::system::error_code bind_error;
+    _socket.open(udp::v4());
+    _socket.set_option(udp::socket::reuse_address(true));
+    _socket.bind(udp::endpoint(udp::v4(), port), bind_error);
+    if (!multicast_add_native(_socket.native_handle(), SharedVisionAddress)) {
+        std::cerr << "Multicast add failed" << std::endl;
     }
+
+    if (bind_error) {
+        std::cerr << "Vision port bind failed with error: "
+                  << bind_error.message() << std::endl;
+    }
+
+    startReceive();
+}
+
+void VisionReceiver::run() {
+    // Let boost::asio check for new packets
+    _io_context.poll();
+
+    // Move new packets into Context
+    _context->vision_packets.insert(_context->vision_packets.begin(),
+                                    std::make_move_iterator(_packets.begin()),
+                                    std::make_move_iterator(_packets.end()));
+    _packets.clear();
+}
+
+void VisionReceiver::startReceive() {
+    // Set a receive callback
+    _socket.async_receive_from(
+        boost::asio::buffer(_recv_buffer), _sender_endpoint,
+        [this](const boost::system::error_code& error, std::size_t num_bytes) {
+            receivePacket(error, num_bytes);
+        });
+}
+
+void VisionReceiver::receivePacket(const boost::system::error_code& error,
+                                   std::size_t num_bytes) {
+    // Check for error
+    if (error) {
+        std::cerr << "Vision receive failed with error: " << error.message()
+                  << std::endl;
+        return;
+    }
+
+    static int num = 0;
+
+    // Parse the protobuf message
+    std::unique_ptr<VisionPacket> packet = std::make_unique<VisionPacket>();
+    packet->receivedTime = RJ::now();
+    if (!packet->wrapper.ParseFromArray(&_recv_buffer[0], num_bytes)) {
+        std::cerr << "VisionReceiver: got bad packet of " << num_bytes
+                  << " bytes from " << _sender_endpoint.address() << ":"
+                  << _sender_endpoint.port() << std::endl;
+        return;
+    }
+
+    // Put the message into the list
+    _packets.push_back(std::move(packet));
+
+    startReceive();
 }

--- a/soccer/VisionReceiver.hpp
+++ b/soccer/VisionReceiver.hpp
@@ -36,12 +36,13 @@ public:
     /// returns.
     void getPackets(std::vector<VisionPacket*>& packets);
 
-    bool simulation;
-    int port;
-
     virtual void run() override;
 
+    void setPort(int port);
+
 protected:
+    int port;
+
     void startReceive();
     void receivePacket(const boost::system::error_code& error,
                        std::size_t num_bytes);

--- a/soccer/VisionReceiver.hpp
+++ b/soccer/VisionReceiver.hpp
@@ -3,22 +3,13 @@
 #include <protobuf/messages_robocup_ssl_wrapper.pb.h>
 #include <Network.hpp>
 #include <Utils.hpp>
+#include <boost/asio.hpp>
 
-#include <QThread>
-#include <QMutex>
-#include <vector>
 #include <stdint.h>
-
-class QUdpSocket;
-
-class VisionPacket {
-public:
-    /// Local time when the packet was received
-    RJ::Time receivedTime;
-
-    /// protobuf message from the vision system
-    SSL_WrapperPacket wrapper;
-};
+#include <vector>
+#include "Context.hpp"
+#include "Node.hpp"
+#include "vision/VisionPacket.hpp"
 
 /**
  * @brief Receives vision packets over UDP and places them in a buffer until
@@ -32,11 +23,10 @@ public:
  * into an SSL_WrapperPacket and placed onto the circular buffer @_packets.
  * They remain there until they are retrieved with getPackets().
  */
-class VisionReceiver : public QThread {
+class VisionReceiver : public Node {
 public:
-    VisionReceiver(bool sim = false, int port = SharedVisionPortSinglePrimary);
-
-    void stop();
+    explicit VisionReceiver(Context* context, bool sim = false,
+                            int port = SharedVisionPortSinglePrimary);
 
     /// Copies the vector of packets and then clears it. The vector contains
     /// only packets received since the last time this was called (or since the
@@ -49,11 +39,21 @@ public:
     bool simulation;
     int port;
 
-protected:
     virtual void run() override;
 
-    volatile bool _running;
-    /// This mutex protects the vector of packets
-    QMutex _mutex;
-    std::vector<VisionPacket*> _packets;
+protected:
+    void startReceive();
+    void receivePacket(const boost::system::error_code& error,
+                       std::size_t num_bytes);
+
+    Context* _context;
+
+    std::vector<uint8_t> _recv_buffer;
+
+    boost::asio::io_service _io_context;
+    boost::asio::ip::udp::socket _socket;
+
+    boost::asio::ip::udp::endpoint _sender_endpoint;
+
+    std::vector<std::unique_ptr<VisionPacket>> _packets;
 };

--- a/soccer/ui/MainWindow.cpp
+++ b/soccer/ui/MainWindow.cpp
@@ -477,6 +477,7 @@ void MainWindow::updateViews() {
                                        .arg(QString::number(frameNumber()))
                                        .arg(QString::number(frameNum)));
 
+        /*
         // Update non-message tree items
         _frameNumberItem->setData(ProtobufTree::Column_Value, Qt::DisplayRole,
                                   frameNumber());
@@ -494,6 +495,7 @@ void MainWindow::updateViews() {
             _ui.logTree->sortItems(ProtobufTree::Column_Tag,
                                    Qt::AscendingOrder);
         }
+        */
 
         // update the behavior tree view
         QString behaviorStr =

--- a/soccer/vision/VisionPacket.hpp
+++ b/soccer/vision/VisionPacket.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+/**
+ * An unfiltered vision packet from SSL vision.
+ *
+ * Only the vision filter should attempt to use this directly.
+ */
+class VisionPacket {
+public:
+    /// Local time when the packet was received
+    RJ::Time receivedTime;
+
+    /// protobuf message from the vision system
+    SSL_WrapperPacket wrapper;
+};


### PR DESCRIPTION
## Description
Refactor vision receiver into a new node and refactor to use boost::asio instead of a separate thread. ~Currently marked as draft until #1330 (which includes the Node base class) is merged.~

## Associated Issue
Issue #1329.

## Design Documents
[Link](https://docs.google.com/document/d/13LJ-HotI7wjp8G1xqDhcK5y4MAMSmWZyr55kbajW1qw/edit#heading=h.3vz8rotbuhas)

## Steps to test
This is a non-functional change. It needs QA to make sure it didn't break any of the following functionality:
 - Vision on actual field
 - Using specific vision channels on the field