### PR TITLE
Fix referee receiver to not change teams when no team name matches

### DIFF
--- a/soccer/NewRefereeModule.hpp
+++ b/soccer/NewRefereeModule.hpp
@@ -137,7 +137,7 @@ public:
  */
 class NewRefereeModule : public QThread {
 public:
-    NewRefereeModule(Context* const ctx);
+    NewRefereeModule(Context* const ctx, bool isBlue = false);
     ~NewRefereeModule();
 
     void stop();
@@ -150,9 +150,16 @@ public:
 
     bool useExternalReferee() { return _useExternalRef; }
 
-    void blueTeam(bool value) { _blueTeam = value; }
+    /**
+     * Set the team color only if it is not already being controlled by the
+     * refbox. This will set the team color in the event that none of the
+     * names in the referee packet match our team name.
+     *
+     * @param isBlue
+     */
+    void overrideTeam(bool isBlue);
 
-    bool blueTeam() { return _blueTeam; }
+    bool isBlueTeam() { return _blueTeam; }
 
     NewRefereeModuleEnums::Stage stage;
     NewRefereeModuleEnums::Command command;
@@ -194,6 +201,9 @@ public:
 protected:
     virtual void run() override;
 
+    // Unconditional setter for the team color.
+    void blueTeam(bool value) { _blueTeam = value; }
+
     volatile bool _running;
 
     void ready();
@@ -220,6 +230,12 @@ protected:
     NewRefereeModuleEnums::Stage prev_stage;
 
     bool _useExternalRef = false;
+
+    // Whether or not WE are currently controlled by the ref. This is not the
+    // same as whether the referee is connected, because it will still be false
+    // if the ref is connected but our team name doesn't match either of the
+    // team names in the packet.
+    bool _isRefControlled = false;
 
     bool _blueTeam = false;
 

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -82,7 +82,7 @@ Processor::Processor(bool sim, bool defendPlus, VisionChannel visionChannel,
     QMetaObject::connectSlotsByName(this);
 
     _vision = std::make_shared<VisionFilter>();
-    _refereeModule = std::make_shared<NewRefereeModule>(&_context);
+    _refereeModule = std::make_shared<NewRefereeModule>(&_context, _blueTeam);
     _refereeModule->start();
     _gameplayModule = std::make_shared<Gameplay::GameplayModule>(&_context);
     _pathPlanner = std::unique_ptr<Planning::MultiRobotPathPlanner>(
@@ -191,7 +191,10 @@ void Processor::blueTeam(bool value) {
     if (_blueTeam != value) {
         _blueTeam = value;
         if (_radio) _radio->switchTeam(_blueTeam);
-        if (!externalReferee()) _refereeModule->blueTeam(value);
+
+        // Try to set the team in the referee module.
+        // Note: this will not update if we are being referee controlled.
+        _refereeModule->overrideTeam(value);
     }
 }
 

--- a/soccer/ui/MainWindow.cpp
+++ b/soccer/ui/MainWindow.cpp
@@ -288,7 +288,7 @@ void MainWindow::updateFromRefPacket(bool haveExternalReferee) {
                 _processor->context()->game_state.getGoalieId() + 1);
         }
 
-        bool blueTeam = _processor->refereeModule()->blueTeam();
+        bool blueTeam = _processor->refereeModule()->isBlueTeam();
         if (_processor->blueTeam() != blueTeam) {
             blueTeam ? _ui.actionTeamBlue->trigger()
                      : _ui.actionTeamYellow->trigger();
@@ -1127,7 +1127,7 @@ void MainWindow::on_actionStopRobots_triggered() {
         if (robot->visible) {
             SimCommand::Robot* r = cmd.add_robots();
             r->set_shell(robot->shell());
-            r->set_blue_team(!_processor->blueTeam());
+            r->set_blue_team(!_processor->isBlueTeam());
             Geometry2d::Point newPos =
                 _ui.fieldView->getTeamToWorld() * robot->pos;
             r->mutable_pos()->set_x(newPos.x());
@@ -1163,7 +1163,7 @@ void MainWindow::on_actionQuicksaveRobotLocations_triggered() {
         if (robot->visible) {
             SimCommand::Robot* r = _quickLoadCmd.add_robots();
             r->set_shell(robot->shell());
-            r->set_blue_team(!_processor->blueTeam());
+            r->set_blue_team(!_processor->isBlueTeam());
             Geometry2d::Point newPos =
                 _ui.fieldView->getTeamToWorld() * robot->pos;
             r->mutable_pos()->set_x(newPos.x());


### PR DESCRIPTION
## Description
Previously, soccer would always switch to a new team color immediately when it received a ref packet, even if our team name did not match the team name sent over in the packet.

This caused conflicts when running two instances of soccer on the same machine because:
1) When refbox is run, it defaults to both team names empty
2) When we received an empty string, we would switch to the blue team
3) When there is already an instance of soccer binding to the blue team's port, a new instance cannot bind to that port.

This created a crashing situtation.

I fixed it by:
 - Ignoring empty names
 - Only switching if names match exactly

## Associated Issue
Issue #1335

## Design Documents
N/A, bugfix

## Steps to test
### Test Case 1
1. Run refbox
2. `make run-sim2play`

Expected result: One instance should remain blue and the other should remain yellow. You should be able to control the game from refbox.
