### PR TITLE
Copy ball pos/vel when reading from python instead of by ref

### DIFF
--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -90,8 +90,6 @@ std::string Point_repr(Geometry2d::Point* self) { return self->toString(); }
 
 std::string Robot_repr(Robot* self) { return self->toString(); }
 
-Geometry2d::Point Robot_pos(Robot* self) { return self->pos; }
-
 // Sets a robot's position - this should never be used in gameplay code, but
 // is useful for testing.
 void Robot_set_pos_for_testing(Robot* self, Geometry2d::Point pos) {
@@ -108,11 +106,17 @@ void Ball_set_pos_for_testing(Ball* self, Geometry2d::Point pos) {
     self->pos = pos;
 }
 
+Geometry2d::Point Robot_pos(Robot* self) { return self->pos; }
+
 Geometry2d::Point Robot_vel(Robot* self) { return self->vel; }
 
 float Robot_angle(Robot* self) { return self->angle; }
 
 float Robot_angle_vel(Robot* self) { return self->angleVel; }
+
+Geometry2d::Point Ball_pos(Ball* self) { return self->pos; }
+
+Geometry2d::Point Ball_vel(Ball* self) { return self->vel; }
 
 void OurRobot_move_to_direct(OurRobot* self, Geometry2d::Point* to) {
     if (to == nullptr) throw NullArgumentException("to");
@@ -892,8 +896,8 @@ BOOST_PYTHON_MODULE(robocup) {
 
     class_<Ball, std::shared_ptr<Ball>>("Ball", init<>())
         .def("set_pos_for_testing", &Ball_set_pos_for_testing)
-        .def_readonly("pos", &Ball::pos)
-        .def_readonly("vel", &Ball::vel)
+        .add_property("pos", &Ball_pos)
+        .add_property("vel", &Ball_vel)
         .def_readonly("valid", &Ball::valid)
         .def("predict_pos", &Ball::predictPosition)
         .def("estimate_seconds_to", &Ball::estimateSecondsTo)


### PR DESCRIPTION
## Description
It was returning a reference to the position object, which then allowed direct changing on the x and y member variables. Since it was read only, you could not change the location of where the position object point thought, so that worked as intended. There were a few different ways to do this, but all required a function wrapper. This just treats the pos as a getter only that passes a copy back to python. Conviently, while making sure the robot class doesn't have this problem as well, I came across this commit [b78cefa](https://github.com/RoboJackets/robocup-software/commit/b78cefa588b0aa888c0304ab53e9844fdb26a042)

## Associated Issue
Issue #1350

## Design Documents
[Link](link-to-design-doc)

## Steps to test
### Test Case 1
1. Try to set .x and .y of ball pos object
2. See if ball moves
3. ???

Expected result: It doesn't
