### PR TITLE
Enable ball sense -- Use OurRobot.has_ball() over evaluation.ball.robot_has_ball(OurRobot) where possible

### DIFF
--- a/soccer/gameplay/plays/offense/adaptive_formation.py
+++ b/soccer/gameplay/plays/offense/adaptive_formation.py
@@ -210,8 +210,7 @@ class AdaptiveFormation(standard_play.StandardPlay):
         return True
 
     def dribbler_has_ball(self):
-        return any(
-            r.has_ball() for r in main.our_robots())
+        return any(r.has_ball() for r in main.our_robots())
 
     def on_enter_collecting(self):
         self.remove_all_subbehaviors()

--- a/soccer/gameplay/plays/offense/adaptive_formation.py
+++ b/soccer/gameplay/plays/offense/adaptive_formation.py
@@ -211,7 +211,7 @@ class AdaptiveFormation(standard_play.StandardPlay):
 
     def dribbler_has_ball(self):
         return any(
-            robot.has_ball() for r in main.our_robots())
+            r.has_ball() for r in main.our_robots())
 
     def on_enter_collecting(self):
         self.remove_all_subbehaviors()

--- a/soccer/gameplay/plays/offense/adaptive_formation.py
+++ b/soccer/gameplay/plays/offense/adaptive_formation.py
@@ -211,7 +211,7 @@ class AdaptiveFormation(standard_play.StandardPlay):
 
     def dribbler_has_ball(self):
         return any(
-            evaluation.ball.robot_has_ball(r) for r in main.our_robots())
+            robot.has_ball() for r in main.our_robots())
 
     def on_enter_collecting(self):
         self.remove_all_subbehaviors()

--- a/soccer/gameplay/skills/angle_receive.py
+++ b/soccer/gameplay/skills/angle_receive.py
@@ -144,8 +144,7 @@ class AngleReceive(skills.pass_receive.PassReceive):
 
         self.ball_kicked = True
         # Kick the ball!
-        if (self.robot is not None and evaluation.ball.robot_has_ball(
-                self.robot)):  #self.robot.has_ball()): #
+        if (self.robot is not None and self.robot.has_ball()):
             self.robot.kick(self.kick_power)
             self.robot.kick_immediately()
 

--- a/soccer/gameplay/skills/capture.py
+++ b/soccer/gameplay/skills/capture.py
@@ -76,17 +76,14 @@ class Capture(single_robot_composite_behavior.SingleRobotCompositeBehavior):
 
         # By default, move into the settle state since we almost never start with ball
         self.add_transition(
-            behavior.Behavior.State.start,
-            Capture.State.settle,
-            lambda: self.robot is not None and not self.robot.has_ball(),
-            'dont have ball')
+            behavior.Behavior.State.start, Capture.State.settle, lambda: self.
+            robot is not None and not self.robot.has_ball(), 'dont have ball')
 
         # On the offchance we start with ball, double check it's not a blip on the sensor
-        self.add_transition(
-            behavior.Behavior.State.start,
-            Capture.State.captured,
-            lambda: self.robot is not None and self.robot.has_ball(),
-            'may already have ball')
+        self.add_transition(behavior.Behavior.State.start,
+                            Capture.State.captured, lambda: self.robot is
+                            not None and self.robot.has_ball(),
+                            'may already have ball')
 
         # We actually don't have the ball, either 50% register rate (faulty sensor?) or we just got a blip
         self.add_transition(

--- a/soccer/gameplay/skills/capture.py
+++ b/soccer/gameplay/skills/capture.py
@@ -78,16 +78,14 @@ class Capture(single_robot_composite_behavior.SingleRobotCompositeBehavior):
         self.add_transition(
             behavior.Behavior.State.start,
             Capture.State.settle,
-            lambda: self.robot is not None and not evaluation.ball.
-            robot_has_ball(self.robot),  #self.robot.has_ball(),
+            lambda: self.robot is not None and not self.robot.has_ball(),
             'dont have ball')
 
         # On the offchance we start with ball, double check it's not a blip on the sensor
         self.add_transition(
             behavior.Behavior.State.start,
             Capture.State.captured,
-            lambda: self.robot is not None and evaluation.ball.robot_has_ball(
-                self.robot),  #self.robot.has_ball(),
+            lambda: self.robot is not None and self.robot.has_ball(),
             'may already have ball')
 
         # We actually don't have the ball, either 50% register rate (faulty sensor?) or we just got a blip
@@ -163,8 +161,7 @@ class Capture(single_robot_composite_behavior.SingleRobotCompositeBehavior):
 
         # If we hold the ball, increment up to max
         # if not, decrement to 0
-        if (evaluation.ball.robot_has_ball(
-                self.robot)):  #self.robot.has_ball()):
+        if (self.robot.has_ball()):
             self.probably_held_cnt = min(self.probably_held_cnt + 1,
                                          Capture.PROBABLY_HELD_HISTORY_LENGTH)
         else:

--- a/soccer/gameplay/skills/collect.py
+++ b/soccer/gameplay/skills/collect.py
@@ -47,15 +47,14 @@ class Collect(single_robot_behavior.SingleRobotBehavior):
         self.add_transition(
             behavior.Behavior.State.running,
             behavior.Behavior.State.start, lambda: self.is_bot_ball_stopped(
-            ) and not evaluation.ball.robot_has_ball(
-                self.robot) and self.probably_held_cnt < Collect.
+            ) and not self.robot.has_ball() and self.probably_held_cnt < Collect.
             PROBABLY_HELD_CUTOFF and self.timeout == 0, 'restart')
 
         # Complete when we have the ball
         self.add_transition(
             behavior.Behavior.State.running,
             behavior.Behavior.State.completed, lambda: self.robot is not None
-            and evaluation.ball.robot_has_ball(self.robot) and self.
+            and self.robot.has_ball() and self.
             probably_held_cnt > Collect.PROBABLY_HELD_CUTOFF, 'ball collected')
 
         # Go back if we loose the ball
@@ -88,7 +87,7 @@ class Collect(single_robot_behavior.SingleRobotBehavior):
             # and it's not in the mouth
             # increase timeout
             if (self.is_bot_ball_stopped() and
-                    not evaluation.ball.robot_has_ball(self.robot)):
+                    not self.robot.has_ball()):
 
                 self.timeout = min(self.timeout + 1, Collect.RESTART_TIMEOUT)
             else:
@@ -105,7 +104,7 @@ class Collect(single_robot_behavior.SingleRobotBehavior):
     def update_held_cnt(self):
         # If we see the ball, increment up to max
         # if not, drop to 0
-        if (evaluation.ball.robot_has_ball(self.robot) or
+        if (self.robot.has_ball() or
                 not main.ball().valid):  #self.robot.has_ball()):
             self.probably_held_cnt = min(self.probably_held_cnt + 1,
                                          Collect.PROBABLY_HELD_MAX)

--- a/soccer/gameplay/skills/collect.py
+++ b/soccer/gameplay/skills/collect.py
@@ -47,14 +47,13 @@ class Collect(single_robot_behavior.SingleRobotBehavior):
         self.add_transition(
             behavior.Behavior.State.running,
             behavior.Behavior.State.start, lambda: self.is_bot_ball_stopped(
-            ) and not self.robot.has_ball() and self.probably_held_cnt < Collect.
-            PROBABLY_HELD_CUTOFF and self.timeout == 0, 'restart')
+            ) and not self.robot.has_ball() and self.probably_held_cnt <
+            Collect.PROBABLY_HELD_CUTOFF and self.timeout == 0, 'restart')
 
         # Complete when we have the ball
         self.add_transition(
-            behavior.Behavior.State.running,
-            behavior.Behavior.State.completed, lambda: self.robot is not None
-            and self.robot.has_ball() and self.
+            behavior.Behavior.State.running, behavior.Behavior.State.completed,
+            lambda: self.robot is not None and self.robot.has_ball() and self.
             probably_held_cnt > Collect.PROBABLY_HELD_CUTOFF, 'ball collected')
 
         # Go back if we loose the ball
@@ -86,8 +85,7 @@ class Collect(single_robot_behavior.SingleRobotBehavior):
             # If the ball and robot are both stopped
             # and it's not in the mouth
             # increase timeout
-            if (self.is_bot_ball_stopped() and
-                    not self.robot.has_ball()):
+            if (self.is_bot_ball_stopped() and not self.robot.has_ball()):
 
                 self.timeout = min(self.timeout + 1, Collect.RESTART_TIMEOUT)
             else:

--- a/soccer/gameplay/skills/line_kick.py
+++ b/soccer/gameplay/skills/line_kick.py
@@ -84,8 +84,7 @@ class LineKick(skills._kick._Kick,
 
         # For when ball sense isn't great, kick when vision
         # thinks we have the ball
-        if (self.robot is not None and
-                self.robot.has_ball()):
+        if (self.robot is not None and self.robot.has_ball()):
             self.robot.kick_immediately()
 
     # TODO Figure out how to renable role requirements for this however it needs to be done

--- a/soccer/gameplay/skills/line_kick.py
+++ b/soccer/gameplay/skills/line_kick.py
@@ -85,7 +85,7 @@ class LineKick(skills._kick._Kick,
         # For when ball sense isn't great, kick when vision
         # thinks we have the ball
         if (self.robot is not None and
-                evaluation.ball.robot_has_ball(self.robot)):
+                self.robot.has_ball()):
             self.robot.kick_immediately()
 
     # TODO Figure out how to renable role requirements for this however it needs to be done

--- a/soccer/gameplay/skills/pass_receive.py
+++ b/soccer/gameplay/skills/pass_receive.py
@@ -83,8 +83,8 @@ class PassReceive(single_robot_composite_behavior.SingleRobotCompositeBehavior
                                 lambda: self.ball_kicked, 'ball kicked')
 
         self.add_transition(
-            PassReceive.State.receiving,
-            behavior.Behavior.State.completed, lambda: self.robot.has_ball() and self.subbehavior_with_name(
+            PassReceive.State.receiving, behavior.Behavior.State.completed,
+            lambda: self.robot.has_ball() and self.subbehavior_with_name(
                 'capture').state == behavior.Behavior.State.completed,
             'ball received!')
 

--- a/soccer/gameplay/skills/pass_receive.py
+++ b/soccer/gameplay/skills/pass_receive.py
@@ -84,8 +84,7 @@ class PassReceive(single_robot_composite_behavior.SingleRobotCompositeBehavior
 
         self.add_transition(
             PassReceive.State.receiving,
-            behavior.Behavior.State.completed, lambda: evaluation.ball.
-            robot_has_ball(self.robot) and self.subbehavior_with_name(
+            behavior.Behavior.State.completed, lambda: self.robot.has_ball() and self.subbehavior_with_name(
                 'capture').state == behavior.Behavior.State.completed,
             'ball received!')
 

--- a/soccer/gameplay/skills/pivot_kick.py
+++ b/soccer/gameplay/skills/pivot_kick.py
@@ -269,7 +269,7 @@ class PivotKick(single_robot_composite_behavior.SingleRobotCompositeBehavior,
             self.robot.chip(self.chip_power)
         else:
             self.robot.kick(self.kick_power)
-        if (evaluation.ball.robot_has_ball(self.robot)):
+        if (self.robot.has_ball()):
             self.robot.kick_immediately()
 
     def on_exit_running(self):

--- a/soccer/gameplay/tactics/defensive_forward.py
+++ b/soccer/gameplay/tactics/defensive_forward.py
@@ -62,7 +62,7 @@ class DefensiveForward(composite_behavior.CompositeBehavior):
             behavior.Behavior.State.completed,
             lambda: self.collector is not None and \
                     self.collector.robot is not None and \
-                    evaluation.ball.robot_has_ball(self.collector.robot),
+                    self.collector.robot.has_ball,
             'Ball collected')
 
         # Create list of defenders and start the marking
@@ -126,4 +126,4 @@ class DefensiveForward(composite_behavior.CompositeBehavior):
 
     def we_have_ball(self):
         return any(
-            evaluation.ball.robot_has_ball(r) for r in main.our_robots())
+            r.has_ball() for r in main.our_robots())

--- a/soccer/gameplay/tactics/defensive_forward.py
+++ b/soccer/gameplay/tactics/defensive_forward.py
@@ -125,5 +125,4 @@ class DefensiveForward(composite_behavior.CompositeBehavior):
             self.defenders[i].mark_robot = self.mark_bots[i]
 
     def we_have_ball(self):
-        return any(
-            r.has_ball() for r in main.our_robots())
+        return any(r.has_ball() for r in main.our_robots())

--- a/soccer/gameplay/tactics/defensive_forward.py
+++ b/soccer/gameplay/tactics/defensive_forward.py
@@ -62,7 +62,7 @@ class DefensiveForward(composite_behavior.CompositeBehavior):
             behavior.Behavior.State.completed,
             lambda: self.collector is not None and \
                     self.collector.robot is not None and \
-                    self.collector.robot.has_ball,
+                    self.collector.robot.has_ball(),
             'Ball collected')
 
         # Create list of defenders and start the marking


### PR DESCRIPTION
 I've gone in and replaced everywhere that I could find that uses evaluation.ball.robot_has_ball on our robots with robot.has_ball, which will rely on ball sense. This should mostly be undoing what was done as a band-aid before comp since our ball sense was broken although its possible I might have changed it in a few more places and we should look to see if it makes sense in those 

I think that in the future we should possibly have a centralized way to change which is used. Possibly by using an evaluation function everywhere and checking to see if the robot is ours, combined with possibly a dict of which robots have functioning ball sense so that we can quickly disable one if we have a ball sense wire get ripped out at comp. Realistically it shouldn't be that hard to have an auto-disable on some basic logic. Although I think that is something to discuss later.

For right now this just re-enables ball sense, I can add that functionality or make an issue in a later pull request.
