### PR TITLE
Change play selection for gameplay tests

### DIFF
--- a/soccer/gameplay/gameplay_test.py
+++ b/soccer/gameplay/gameplay_test.py
@@ -53,7 +53,12 @@ class GameplayTest():
         self.ballVelocity = robocup.Point(0, 0)
 
         # List of plays to enable e.g. ["stopped", "offense/basic_122"]
+        # You can also add the name of a playbook file i.e. 
+        # ["comp2019.pbk", "testing/test_pivot_kick"]
+        # If the list is empty, the enabled play list will remain as it was 
+        # before the test was run
         self.play_list = []
+
         # List of referee commands to run at the start (will run 1 each frame)
         # Default value is seen here
         self.start_commands = [

--- a/soccer/gameplay/gameplay_tests/example.py
+++ b/soccer/gameplay/gameplay_tests/example.py
@@ -11,7 +11,12 @@ class Example(gameplay_test.GameplayTest):
 
         self.name = "Simple Example Test"
 
-        self.play_list = ["offense/basic_122", "testing/test_pivot_kick"]
+        # List of plays to enable e.g. ["stopped", "offense/basic_122"]
+        # You can also add the name of a playbook file i.e. 
+        # ["comp2019.pbk", "testing/test_pivot_kick"]
+        # If the list is empty, the enabled play list will remain as it was 
+        # before the test was run
+        self.play_list = ["comp2019.pbk", "testing/test_pivot_kick"]
 
         self.ourRobots = [testRobot(2, -.5), testRobot(2, .5)]
         self.theirRobots = [testRobot(-2, -.5), testRobot(-2, .5)]

--- a/soccer/gameplay/test_system.py
+++ b/soccer/gameplay/test_system.py
@@ -1,6 +1,7 @@
 from PyQt5 import QtCore, QtWidgets
 import logging
 import test_list
+from playbook import load_from_file
 
 
 class TestSystem:
@@ -60,7 +61,11 @@ class TestSystem:
 
         # Set required plays to selected in the play registry
         plays = self.parsePlayList(self._testNode.test.play_list)
-        self._play_registry.load_playbook(plays)
+        print("final: ", plays)
+
+        # If there are any plays in the play list, set them as the current playbook
+        if(len(plays) > 0):
+            self._play_registry.load_playbook(plays)
 
         self._testNode.status = test_list.Status.running
         self._testList.selectIndex(self._testIndex)
@@ -108,10 +113,17 @@ class TestSystem:
 
     def parsePlayList(self, play_list):
         plays = []
+        
         for play in play_list:
             play = play.strip()
 
             if play:
-                plays.append(play.split('/'))
-        print("final: ", plays)
+                #Check to see if the entry is a playbook file
+                if(".pbk" in play):
+                    plays.extend(load_from_file("./soccer/gameplay/playbooks/" + play))
+                else:
+                    plays.append(play.split('/'))
+       
+        #Currently duplicates are allowed and it dosen't seem to cause any problems
+
         return plays


### PR DESCRIPTION
## Description
I want to be able to run tests with more flexibility as to which plays are activated without having to go through and change the play list in each of the tests I want to run. So I've done two things here. One, made it so that running the test only changes which plays are enabled if there is at least one play in the play_list. Two, made it so that you can add a .pbk file to the list of plays and they will all be added. This will help with making sure the tests are running with the correct plays and allow a little bit more flexibility if you just want to note out the play_list line to run with a custom combination of plays.

Eventually we want to do this with a UI element checkbox that will toggle using the current plays or the plays listed in the test file.

## Steps to test
1. Set different play and playbook combinations in example.py
2. See if the expected plays are enabled correctly when the test is ran

Expected result: When the list is empty, the play list remains as it was before the test was run. When a playbook file is added to list, all the plays from it are activated in addition to any other plays in the list. Multiple overlapping playbooks should work as well.
