### PR TITLE
Change test robots to use points

### DIFF
--- a/soccer/gameplay/gameplay_test.py
+++ b/soccer/gameplay/gameplay_test.py
@@ -5,9 +5,8 @@ import robocup
 
 # Class to define robot locations/velocities
 class testRobot():
-    def __init__(self, x=0, y=0, angle=0):
-        self.x = x
-        self.y = y
+    def __init__(self, pos=robocup.Point(0,0), angle=0):
+        self.pos = pos
         self.angle = angle
 
 

--- a/soccer/gameplay/gameplay_test.py
+++ b/soccer/gameplay/gameplay_test.py
@@ -53,7 +53,12 @@ class GameplayTest():
         self.ballVelocity = robocup.Point(0, 0)
 
         # List of plays to enable e.g. ["stopped", "offense/basic_122"]
+        # You can also add the name of a playbook file i.e. 
+        # ["comp2019.pbk", "testing/test_pivot_kick"]
+        # If the list is empty, the enabled play list will remain as it was 
+        # before the test was run
         self.play_list = []
+
         # List of referee commands to run at the start (will run 1 each frame)
         # Default value is seen here
         self.start_commands = [

--- a/soccer/gameplay/gameplay_tests/example.py
+++ b/soccer/gameplay/gameplay_tests/example.py
@@ -18,5 +18,5 @@ class Example(gameplay_test.GameplayTest):
         # before the test was run
         self.play_list = ["comp2019.pbk", "testing/test_pivot_kick"]
 
-        self.ourRobots = [testRobot(2, -.5), testRobot(2, .5)]
-        self.theirRobots = [testRobot(-2, -.5), testRobot(-2, .5)]
+        self.ourRobots = [testRobot(robocup.Point(2, -.5)), testRobot(robocup.Point(2, .5))]
+        self.theirRobots = [testRobot(robocup.Point(-2, -.5)), testRobot(robocup.Point(-2, .5))]

--- a/soccer/gameplay/gameplay_tests/example.py
+++ b/soccer/gameplay/gameplay_tests/example.py
@@ -11,7 +11,12 @@ class Example(gameplay_test.GameplayTest):
 
         self.name = "Simple Example Test"
 
-        self.play_list = ["offense/basic_122", "testing/test_pivot_kick"]
+        # List of plays to enable e.g. ["stopped", "offense/basic_122"]
+        # You can also add the name of a playbook file i.e. 
+        # ["comp2019.pbk", "testing/test_pivot_kick"]
+        # If the list is empty, the enabled play list will remain as it was 
+        # before the test was run
+        self.play_list = ["comp2019.pbk", "testing/test_pivot_kick"]
 
         self.ourRobots = [testRobot(2, -.5), testRobot(2, .5)]
         self.theirRobots = [testRobot(-2, -.5), testRobot(-2, .5)]

--- a/soccer/gameplay/test_system.py
+++ b/soccer/gameplay/test_system.py
@@ -1,6 +1,7 @@
 from PyQt5 import QtCore, QtWidgets
 import logging
 import test_list
+from playbook import load_from_file
 
 
 class TestSystem:
@@ -60,7 +61,11 @@ class TestSystem:
 
         # Set required plays to selected in the play registry
         plays = self.parsePlayList(self._testNode.test.play_list)
-        self._play_registry.load_playbook(plays)
+        print("final: ", plays)
+
+        # If there are any plays in the play list, set them as the current playbook
+        if(len(plays) > 0):
+            self._play_registry.load_playbook(plays)
 
         self._testNode.status = test_list.Status.running
         self._testList.selectIndex(self._testIndex)
@@ -108,10 +113,17 @@ class TestSystem:
 
     def parsePlayList(self, play_list):
         plays = []
+        
         for play in play_list:
             play = play.strip()
 
             if play:
-                plays.append(play.split('/'))
-        print("final: ", plays)
+                #Check to see if the entry is a playbook file
+                if(".pbk" in play):
+                    plays.extend(load_from_file("./soccer/gameplay/playbooks/" + play))
+                else:
+                    plays.append(play.split('/'))
+       
+        #Currently duplicates are allowed and it dosen't seem to cause any problems
+
         return plays

--- a/soccer/gameplay/test_system.py
+++ b/soccer/gameplay/test_system.py
@@ -94,14 +94,14 @@ class TestSystem:
     def getTestOurRobots(self):
         rtrn = []
         for robot in self._testNode.test.ourRobots:
-            rtrn.append([robot.x, robot.y, robot.angle])
+            rtrn.append([robot.pos.x, robot.pos.y, robot.angle])
 
         return rtrn
 
     def getTestTheirRobots(self):
         rtrn = []
         for robot in self._testNode.test.theirRobots:
-            rtrn.append([robot.x, robot.y, robot.angle])
+            rtrn.append([robot.pos.x, robot.pos.y, robot.angle])
 
         return rtrn
 


### PR DESCRIPTION
## Description
This should be considered after #1393, as it is branched off of that branch and is a minor change after that. I'm not exactly sure how to handle dependent/sequential pull requests as it seems there is really no good solution for it aside from just adding changes to the previous pull request. I guess I'm just doing this for now.

Currently the testRobot object the gameplay tests system uses x and y as values, where it is seeming like using robocup.Point to be more ergonomic for quickly defining points and offsets

## Steps to test
Basically just make sure that the gameplay test system works as intended.