### PR TITLE
Fix segfault when clicking on field when running real robots

### DIFF
--- a/soccer/Context.hpp
+++ b/soccer/Context.hpp
@@ -35,4 +35,6 @@ struct Context {
 
     std::optional<QPointF> ball_command;
     std::optional<Geometry2d::TransformMatrix> screen_to_world_command;
+
+    bool is_simulation;
 };

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -81,6 +81,8 @@ Processor::Processor(bool sim, bool defendPlus, VisionChannel visionChannel,
 
     QMetaObject::connectSlotsByName(this);
 
+    _context.is_simulation = _simulation;
+
     _vision = std::make_shared<VisionFilter>();
     _refereeModule = std::make_shared<NewRefereeModule>(&_context, _blueTeam);
     _refereeModule->start();

--- a/soccer/ui/MainWindow.cpp
+++ b/soccer/ui/MainWindow.cpp
@@ -166,12 +166,13 @@ MainWindow::MainWindow(Processor* processor, QWidget* parent)
     setWindowTitle(windowTitle() + " @ " + git_version_short_hash +
                    (git_version_dirty ? "*" : ""));
 
+    // Pass context into fieldview
+    // (apparently simfieldview is used even outside of simulation)
+    _ui.fieldView->setContext(_processor->context());
+
     if (!_processor->simulation()) {
         _ui.menu_Simulator->setEnabled(false);
     } else {
-        // Pass context into the simFieldView
-        _ui.fieldView->setContext(_processor->context());
-
         // reset the field initially, grSim will start out in some weird
         // pattern and we want to keep it consistent
         on_actionResetField_triggered();

--- a/soccer/ui/SimFieldView.cpp
+++ b/soccer/ui/SimFieldView.cpp
@@ -22,6 +22,11 @@ SimFieldView::SimFieldView(QWidget* parent) : FieldView(parent) {
 void SimFieldView::setContext(Context* context) { this->_context = context; }
 
 void SimFieldView::mousePressEvent(QMouseEvent* me) {
+    // Ignore mouse events in the field if not in sim
+    if (!_context->is_simulation){
+        return;
+    }
+
     Geometry2d::Point pos = _worldToTeam * _screenToWorld * me->pos();
 
     std::shared_ptr<LogFrame> frame = currentFrame();

--- a/soccer/ui/SimFieldView.cpp
+++ b/soccer/ui/SimFieldView.cpp
@@ -23,7 +23,7 @@ void SimFieldView::setContext(Context* context) { this->_context = context; }
 
 void SimFieldView::mousePressEvent(QMouseEvent* me) {
     // Ignore mouse events in the field if not in sim
-    if (!_context->is_simulation){
+    if (!_context->is_simulation) {
         return;
     }
 


### PR DESCRIPTION
## Description
Fixes the segfault when clicking on the field while running for real robots

## Steps to test
### Test Case 1
1. `make run`
2. Click the field
3. ???
4. Profit

Expected result: Soccer should not segfault