### PR TITLE
Fix stylize on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,7 @@ jobs:
       - <<: *install_deps
       - <<: *load_workspace
       - <<: *load_compile_cache
+      - run: pip3 install -r util/requirements3.txt
       - run: git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle-lines
       - store_artifacts:
           path: /tmp/clean.patch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
       - <<: *install_deps
       - <<: *load_workspace
       - <<: *load_compile_cache
-      - run: pip3 install -r util/requirements3.txt
+      - run: pip3 install --upgrade -r util/requirements3.txt
       - run: git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle-lines
       - store_artifacts:
           path: /tmp/clean.patch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
       - <<: *load_workspace
       - <<: *load_compile_cache
       - run: pip3 install --upgrade -r util/requirements3.txt
-      - run: git fetch origin && STYLIZE_DIFFBASE=origin/master make checkstyle-lines
+      - run: git fetch origin && STYLIZE_DIFFBASE=origin/staging make checkstyle-lines
       - store_artifacts:
           path: /tmp/clean.patch
 

--- a/makefile
+++ b/makefile
@@ -156,11 +156,11 @@ checkstyle:
 	@stylize.v1 --git_diffbase=$(STYLIZE_DIFFBASE) --patch_output "$${CIRCLE_ARTIFACTS:-.}/clean.patch"
 
 pretty-lines:
-	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -i -p1
+	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -binary clang-format -i -p1
 	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/yapf-diff.py -style .style.yapf -i -p1
 
 checkstyle-lines:
-	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -p1 | tee /tmp/checkstyle.patch
+	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -binary clang-format -p1 | tee /tmp/checkstyle.patch
 	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/yapf-diff.py -style .style.yapf -p1 | tee -a /tmp/checkstyle.patch
 	@bash -c '[[ ! "$$(cat /tmp/checkstyle.patch)" ]] || (echo "****************************** Checkstyle errors *******************************" && exit 1)'
 


### PR DESCRIPTION
Previously we were using the default installed version of yapf for
`make pretty-lines`. This installs the latest version.

## Description
This fixes `make checkstyle-lines` which was failing on CI, i.e. in #1388.

## Associated Issue
N/A

## Design Documents
N/A

## Steps to test
### CI
1. Pull in this change on a branch that is in PR (i.e. #1388)
2. Make a pull request / push updates to a PR

Expected result: CI should pass