### PR TITLE
Network radio rewrite

### DIFF
--- a/soccer/radio/NetworkRadio.cpp
+++ b/soccer/radio/NetworkRadio.cpp
@@ -9,8 +9,8 @@ using ip::udp;
 
 NetworkRadio::NetworkRadio(int server_port)
     : _socket(_context, udp::endpoint(udp::v4(), server_port)),
-      _send_buffers(Robots_Per_Team) {
-    _connections.resize(Robots_Per_Team);
+      _send_buffers(Num_Shells) {
+    _connections.resize(Num_Shells);
     startReceive();
 }
 

--- a/soccer/radio/NetworkRadio.cpp
+++ b/soccer/radio/NetworkRadio.cpp
@@ -105,7 +105,7 @@ void NetworkRadio::receivePacket(const boost::system::error_code& error,
         // to both this ID and this IP address.
         _connections.at(iter->second) = std::nullopt;
         _robot_ip_map.erase(iter);
-        _connections.at(msg->uid) = std::nullopt;
+        _connections.at(robot_id) = std::nullopt;
     }
 
     // Update assignments.

--- a/soccer/radio/NetworkRadio.cpp
+++ b/soccer/radio/NetworkRadio.cpp
@@ -10,6 +10,7 @@ using ip::udp;
 NetworkRadio::NetworkRadio(int server_port)
     : _socket(_context, udp::endpoint(udp::v4(), server_port)),
       _send_buffers(Robots_Per_Team) {
+    _connections.resize(Robots_Per_Team);
     startReceive();
 }
 
@@ -43,30 +44,37 @@ void NetworkRadio::send(Packet::RadioTx& radioTx) {
 
         from_robot_tx_proto(radioTx.robots(robot_idx), body);
 
-        // Fetch the IP address
-        auto range = _robot_ip_map.left.equal_range(robot_id);
+        // Fetch the connection
+        auto maybe_connection = _connections.at(robot_id);
 
-        // Loop over all addresses for this robot; we want to send multiple
-        // copies.
-        for (auto it = range.first; it != range.second; it++) {
-            // Send to the given IP address
-            const udp::endpoint& robot_endpoint = it->second;
-            _socket.async_send_to(
-                boost::asio::buffer(forward_packet_buffer), robot_endpoint,
-                [](const boost::system::error_code& error,
-                   std::size_t num_bytes) {
-                    // Handle errors.
-                    if (error) {
-                        std::cerr << "Error sending: " << error
-                                  << " in " __FILE__ << std::endl;
-                    }
-                });
+        // If there exists a connection, we can send.
+        if (maybe_connection) {
+            const RobotConnection& connection = maybe_connection.value();
+            // Check if we've timed out.
+            if (RJ::now() + kTimeout < connection.last_received) {
+                // Remove the endpoint from the IP map and the connection list
+                assert(_robot_ip_map.erase(connection.endpoint) == 1);
+                _connections.at(robot_id) = std::nullopt;
+            } else {
+                // Send to the given IP address
+                const udp::endpoint& robot_endpoint = connection.endpoint;
+                _socket.async_send_to(
+                    boost::asio::buffer(forward_packet_buffer), robot_endpoint,
+                    [](const boost::system::error_code& error,
+                       std::size_t num_bytes) {
+                        // Handle errors.
+                        if (error) {
+                            std::cerr << "Error sending: " << error
+                                      << " in " __FILE__ << std::endl;
+                        }
+                    });
+            }
         }
     }
 }
 
 void NetworkRadio::receive() {
-    // Let boost::asio handles callbacks
+    // Let boost::asio handle callbacks
     _context.poll();
 }
 
@@ -88,27 +96,25 @@ void NetworkRadio::receivePacket(const boost::system::error_code& error,
     _robot_endpoint.port(25566);
 
     // Find out which robot this corresponds to.
-    auto ip_iter = _robot_ip_map.right.find(_robot_endpoint);
-
     int robot_id = msg->uid;
 
-    // We already have this robot registered; this is a reverse packet
-    if (ip_iter == _robot_ip_map.right.end()) {
-        // This is a new robot, so we need to register this robot's UID
-        std::cout << "Adding robot with endpoint " << _robot_endpoint
-                  << std::endl;
-        registerRobot(msg->uid, _robot_endpoint);
-    } else if (ip_iter->second != robot_id) {
-        // This robot has been reassigned. Re-registering it sets the IP->ID
-        // map correctly, but we still need to remove it from the ID->IP map.
-        std::cerr << "Warning: UID of robot assigned IP " << ip_iter->first
-                  << " changed to " << ip_iter->second << ". Reassigning."
-                  << std::endl;
-        ;
+    auto iter = _robot_ip_map.find(_robot_endpoint);
+    if (iter != _robot_ip_map.end() && iter->second != robot_id) {
+        // Make sure this IP address isn't mapped to another robot ID.
+        // If it is, remove the entry and the connections corresponding
+        // to both this ID and this IP address.
+        _connections.at(iter->second) = std::nullopt;
+        _robot_ip_map.erase(iter);
+        _connections.at(msg->uid) = std::nullopt;
+    }
 
-        // Erase the IP address and re-register the robot.
-        _robot_ip_map.right.erase(ip_iter->first);
-        registerRobot(msg->uid, _robot_endpoint);
+    // Update assignments.
+    if (!_connections.at(robot_id)) {
+        _connections.at(robot_id) = RobotConnection{_robot_endpoint, RJ::now()};
+        _robot_ip_map.insert({_robot_endpoint, robot_id});
+    } else {
+        // Update the timeout watchdog
+        _connections.at(robot_id)->last_received = RJ::now();
     }
 
     // Extract the protobuf form
@@ -125,8 +131,3 @@ void NetworkRadio::receivePacket(const boost::system::error_code& error,
 }
 
 void NetworkRadio::switchTeam(bool) {}
-
-void NetworkRadio::registerRobot(int robot, udp::endpoint endpoint) {
-    // Insert the robot into the bimap, going both directions
-    _robot_ip_map.insert({robot, endpoint});
-}

--- a/soccer/radio/NetworkRadio.hpp
+++ b/soccer/radio/NetworkRadio.hpp
@@ -34,21 +34,22 @@ public:
     virtual void switchTeam(bool) override;
 
 protected:
-    // Bidrectional mapping from IP address <-> robot ID
-    // TODO(Kyle): Add a timeout to remove robots from this once they're no
-    // longer communicating with soccer
-    using RobotIpMap = boost::bimaps::bimap<
-        boost::bimaps::multiset_of<int>,
-        boost::bimaps::set_of<boost::asio::ip::udp::endpoint>>;
-    RobotIpMap _robot_ip_map;
+    struct RobotConnection {
+        boost::asio::ip::udp::endpoint endpoint;
+        RJ::Time last_received;
+    };
+
+    // Connections to the robots, indexed by robot ID.
+    std::vector<std::optional<RobotConnection>> _connections;
+
+    // Map from IP address to robot ID.
+    std::map<boost::asio::ip::udp::endpoint, int> _robot_ip_map;
 
     bool open();
     void receivePacket(const boost::system::error_code& error,
                        std::size_t num_bytes);
 
     void startReceive();
-
-    void registerRobot(int robot, boost::asio::ip::udp::endpoint ip);
 
     boost::asio::io_service _context;
     boost::asio::ip::udp::socket _socket;
@@ -61,4 +62,6 @@ protected:
     std::vector<
         std::array<uint8_t, rtp::HeaderSize + sizeof(rtp::RobotTxMessage)>>
         _send_buffers;
+
+    constexpr static std::chrono::duration kTimeout = std::chrono::milliseconds(250);
 };

--- a/soccer/radio/NetworkRadio.hpp
+++ b/soccer/radio/NetworkRadio.hpp
@@ -63,5 +63,6 @@ protected:
         std::array<uint8_t, rtp::HeaderSize + sizeof(rtp::RobotTxMessage)>>
         _send_buffers;
 
-    constexpr static std::chrono::duration kTimeout = std::chrono::milliseconds(250);
+    constexpr static std::chrono::duration kTimeout =
+        std::chrono::milliseconds(250);
 };


### PR DESCRIPTION
## Description
Rewrite the radio code soccer-side. This is necessary because the old code was written with multi-radio support in mind, but also had few robustness features. This improves upon that by cleaning up old code and adding a timeout after which a robot's IP address will be removed from the connections list.

## Associated Issue
N/A

## Design Documents
N/A

## Steps to test
### Basic test
1. Run robots on field
Expected result: No regressions should be experienced

### Stress test
1. Run many robots on field
2. Disconnect robots and change their IDs at random, repeatedly.
Expected result: No slowdowns soccer-side should be experienced