### PR TITLE
Consolidate CI Jobs and Disable Caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,27 +16,9 @@ defaults_image: &image
 defaults_deps: &install_deps
   run: ./util/ubuntu-setup --yes && sudo ccache -M 100M
 
-defaults_ssc: &save_src_cache
-  save_cache:
-    key: source-v1-{{ .Branch }}-{{ .Revision }}
-    paths:
-      - ".git"
-
-defaults_lsc: &load_src_cache
-  restore_cache:
-    keys:
-      - source-v1-{{ .Branch }}-{{ .Revision }}
-      - source-v1-{{ .Branch }}-
-      - source-v1-
 defaults_scc: &save_compile_cache
   save_cache:
     key: ccache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-    paths:
-      - ~/.ccache
-
-defaults_sccc: &save_compile_coverage_cache
-  save_cache:
-    key: ccache-cov-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/.ccache
 
@@ -53,14 +35,6 @@ defaults_lcc: &load_compile_cache
       - ccache-{{ arch }}-{{ .Branch }}
       - ccache-{{ arch }}
       - ccache-
-
-defaults_lccc: &load_compile_coverage_cache
-  restore_cache:
-    keys:
-      - ccache-cov-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-      - ccache-cov-{{ arch }}-{{ .Branch }}
-      - ccache-cov-{{ arch }}
-      - ccache-cov-
 
 defaults_lctc: &load_compile_test_cache
   restore_cache:
@@ -82,62 +56,27 @@ defaults_lw: &load_workspace
 
 version: 2
 jobs:
-  compile:
+  test-all:
     <<: *dir
     <<: *image
     steps:
-      - <<: *load_src_cache
-      - checkout
-      # Ensure latest deps are installed
-      - <<: *install_deps
-      - <<: *load_compile_cache
-      - run: make
-      - <<: *save_compile_cache
-      - <<: *save_workspace
-
-  test-soccer:
-    <<: *dir
-    <<: *image
-    steps:
-      - <<: *load_src_cache
       - checkout
       # Ensure latest deps are installed
       - <<: *install_deps
       - <<: *load_workspace
-      - <<: *load_compile_test_cache
+      - <<: *load_compile_cache
       - run: make test-soccer
-      - <<: *save_compile_test_cache
-
-  test-python:
-    <<: *dir
-    <<: *image
-    steps:
-      - <<: *load_src_cache
-      - checkout
-      # Ensure latest deps are installed
-      - <<: *install_deps
-      - <<: *load_workspace
-      - <<: *load_compile_cache
       - run: make test-python
 
   # FIXME: pylint is broken on 18.04
-  pylint:
+  python-static:
     <<: *dir
     docker:
       - image: robojackets/robocup-software:16
     steps:
-      - <<: *load_src_cache
       - checkout
       - <<: *install_deps
       - run: make pylint
-
-  mypy:
-    <<: *dir
-    docker:
-      - image: python:3
-    steps:
-      - <<: *load_src_cache
-      - checkout
       - run: pip3 install -r util/requirements3.txt
       - run: make mypy
 
@@ -145,7 +84,6 @@ jobs:
     <<: *dir
     <<: *image
     steps:
-      - <<: *load_src_cache
       - checkout
       # We need environment variables ($GOPATH and $PATH specifically)
       - <<: *setup_env
@@ -158,25 +96,10 @@ jobs:
       - store_artifacts:
           path: /tmp/clean.patch
 
-  coverage:
-    <<: *dir
-    <<: *image
-    steps:
-      - <<: *load_src_cache
-      - checkout
-      # Ensure latest deps are installed
-      - <<: *install_deps
-      # save src cache in coverage task as nothing depends on it, we can take our time.
-      - <<: *save_src_cache
-      - <<: *load_compile_coverage_cache
-      - run: make coverage
-      - <<: *save_compile_coverage_cache
-
   gen-docs:
     <<: *dir
     <<: *image
     steps:
-      - <<: *load_src_cache
       - checkout
       # Ensure latest deps are installed
       - <<: *install_deps
@@ -188,30 +111,15 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - compile
-      - coverage
-      - test-soccer:
-          requires:
-            - compile
-      - test-python:
-          requires:
-            - compile
-      - pylint
-      - mypy:
-          requires:
-            - compile
-      - style:
-          requires:
-            - compile
+      - test-all
+      - python-static
+      - style
 
       - gen-docs:
           requires:
-            - test-soccer
-            - test-python
-            - pylint
-            - mypy
+            - test-all
+            - python-static
             - style
-            - compile
 
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ defaults_image: &image
     - image: robojackets/robocup-software:master
 
 defaults_deps: &install_deps
-  run: ./util/ubuntu-setup --yes && sudo ccache -M 100M
+  run: ./util/ubuntu-setup --yes
 
 defaults_scc: &save_compile_cache
   save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,7 @@ jobs:
       - checkout
       # Ensure latest deps are installed
       - <<: *install_deps
-      - <<: *load_compile_cache
       - run: make
-      - <<: *save_compile_cache
       - run: make test-soccer
       - run: make test-python
 
@@ -52,7 +50,6 @@ jobs:
       - <<: *setup_env
       # Ensure latest deps are installed
       - <<: *install_deps
-      - <<: *load_compile_cache
       - run: pip3 install --upgrade -r util/requirements3.txt
       - run: git fetch origin && STYLIZE_DIFFBASE=origin/staging make checkstyle-lines
       - store_artifacts:
@@ -65,7 +62,6 @@ jobs:
       - checkout
       # Ensure latest deps are installed
       - <<: *install_deps
-      - <<: *load_compile_test_cache
       - run: ./autoupdate-docs.sh
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
       - <<: *load_workspace
       - <<: *load_compile_cache
       - run: make
+      - <<: *save_compile_cache
       - run: make test-soccer
       - run: make test-python
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,13 @@ defaults_scc: &save_compile_cache
   save_cache:
     key: ccache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
-      - ~/.ccache
+      - build
 
 defaults_sctc: &save_compile_test_cache
   save_cache:
     key: ccache-test-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
-      - ~/.ccache
+      - build
 
 defaults_lcc: &load_compile_cache
   restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
       - <<: *install_deps
       - <<: *load_workspace
       - <<: *load_compile_cache
+      - run: make
       - run: make test-soccer
       - run: make test-python
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,44 +16,6 @@ defaults_image: &image
 defaults_deps: &install_deps
   run: ./util/ubuntu-setup --yes
 
-defaults_scc: &save_compile_cache
-  save_cache:
-    key: ccache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-    paths:
-      - build
-
-defaults_sctc: &save_compile_test_cache
-  save_cache:
-    key: ccache-test-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-    paths:
-      - build
-
-defaults_lcc: &load_compile_cache
-  restore_cache:
-    keys:
-      - ccache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-      - ccache-{{ arch }}-{{ .Branch }}
-      - ccache-{{ arch }}
-      - ccache-
-
-defaults_lctc: &load_compile_test_cache
-  restore_cache:
-    keys:
-      - ccache-test-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-      - ccache-test-{{ arch }}-{{ .Branch }}
-      - ccache-test-{{ arch }}
-      - ccache-test-
-
-defaults_sw: &save_workspace
-  persist_to_workspace:
-    root: build
-    paths:
-      - ./*
-
-defaults_lw: &load_workspace
-  attach_workspace:
-    at: build
-
 version: 2
 jobs:
   test-all:
@@ -63,7 +25,6 @@ jobs:
       - checkout
       # Ensure latest deps are installed
       - <<: *install_deps
-      - <<: *load_workspace
       - <<: *load_compile_cache
       - run: make
       - <<: *save_compile_cache
@@ -91,7 +52,6 @@ jobs:
       - <<: *setup_env
       # Ensure latest deps are installed
       - <<: *install_deps
-      - <<: *load_workspace
       - <<: *load_compile_cache
       - run: pip3 install --upgrade -r util/requirements3.txt
       - run: git fetch origin && STYLIZE_DIFFBASE=origin/staging make checkstyle-lines
@@ -105,7 +65,6 @@ jobs:
       - checkout
       # Ensure latest deps are installed
       - <<: *install_deps
-      - <<: *load_workspace
       - <<: *load_compile_test_cache
       - run: ./autoupdate-docs.sh
 


### PR DESCRIPTION
## Description
Caching wasn't working properly, so the builds were taking 10m each (so >20m total). I just added the `test-python` and `test-soccer` targets in the regular `compile` job. I also made style not depend on the rest of the targets.

If anyone knows what was wrong with caching, I'd love to hear thoughts. The ccache was being generated properly, the compiler just wasn't getting a speedup from it (so I assume it was being ignored). I also tried setting `CMAKE_CXX_COMPILER=/usr/lib/ccache/g++` to no avail.

Regardless, as a temporary solution I'm fine with just disabling it.

## Associated Issue
N/A

## Design Documents
N/A

## Steps to test
### CI
1. Run CI

Expected result: CI doesn't take 20+ minutes to run.