### PR TITLE
Refactor Referee Module for pub/sub architecture + small refactor

### DIFF
--- a/logging/log_converter.cpp
+++ b/logging/log_converter.cpp
@@ -194,7 +194,7 @@ int main(int argc, char* argv[]) {
         if (currentFrame->raw_refbox_size() > 0) {
             SSL_Referee referee = currentFrame->raw_refbox(0);
 
-            using namespace RefreeModuleEnums;
+            using namespace RefereeModuleEnums;
             stage = stringFromStage((Stage)referee.stage());
             command = stringFromCommand((Command)referee.command());
 

--- a/logging/log_converter.cpp
+++ b/logging/log_converter.cpp
@@ -1,4 +1,4 @@
-#include <NewRefereeModule.cpp>
+#include <Referee.cpp>
 
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <protobuf/LogFrame.pb.h>
@@ -194,7 +194,7 @@ int main(int argc, char* argv[]) {
         if (currentFrame->raw_refbox_size() > 0) {
             SSL_Referee referee = currentFrame->raw_refbox(0);
 
-            using namespace NewRefereeModuleEnums;
+            using namespace RefreeModuleEnums;
             stage = stringFromStage((Stage)referee.stage());
             command = stringFromCommand((Command)referee.command());
 

--- a/soccer/CMakeLists.txt
+++ b/soccer/CMakeLists.txt
@@ -21,7 +21,7 @@ set(ROBOCUP_LIB_SRC
     "motion/MotionControl.cpp"
     "motion/MotionControlNode.cpp"
     "motion/TrapezoidalMotion.cpp"
-    "NewRefereeModule.cpp"
+    "Referee.cpp"
     "optimization/GradientAscent1D.cpp"
     "optimization/ParallelGradientAscent1D.cpp"
     "optimization/NelderMead2D.cpp"

--- a/soccer/GameState.hpp
+++ b/soccer/GameState.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include "TeamInfo.hpp"
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/TransformMatrix.hpp>
+
 #include "Constants.hpp"
+#include "TeamInfo.hpp"
 
 /**
  * @brief Holds the state of the game according to the referee
@@ -56,15 +57,36 @@ public:
 
     Geometry2d::Point ballPlacementPoint;
 
-    GameState() {
-        period = FirstHalf;
-        state = Halt;
-        restart = None;
-        ourRestart = false;
-        ourScore = 0;
-        theirScore = 0;
-        secondsRemaining = 0;
-    }
+    GameState()
+        : period{FirstHalf},
+          state{Halt},
+          restart{None},
+          ourRestart{false},
+          ourScore{0},
+          theirScore{0},
+          secondsRemaining{0},
+          OurInfo{},
+          TheirInfo{},
+          blueTeam{false},
+          ballPlacementPoint{},
+          defendPlusX{false} {}
+
+    GameState(Period period, State state, Restart restart, bool ourRestart,
+              int ourScore, int theirScore, int secondsRemaining,
+              TeamInfo our_info, TeamInfo their_info, bool blueTeam,
+              Geometry2d::Point ballPlacementPoint, bool defendPlusX)
+        : period{period},
+          state{state},
+          restart{restart},
+          ourRestart{ourRestart},
+          ourScore{ourScore},
+          theirScore{theirScore},
+          secondsRemaining{secondsRemaining},
+          OurInfo{our_info},
+          TheirInfo{their_info},
+          blueTeam{blueTeam},
+          ballPlacementPoint{ballPlacementPoint},
+          defendPlusX{defendPlusX} {}
 
     bool defendPlusX;
 
@@ -154,6 +176,15 @@ public:
             0, Field_Dimensions::Current_Dimensions.Length() / 2.0f);
         ballPlacementPoint =
             _worldToTeam * Geometry2d::Point(x / 1000, y / 1000);
+    }
+
+    static Geometry2d::Point getBallPlacementPoint(float x, float y) {
+        Geometry2d::TransformMatrix world_to_team =
+            Geometry2d::TransformMatrix();
+        world_to_team *= Geometry2d::TransformMatrix::translate(
+            0, Field_Dimensions::Current_Dimensions.Length() / 2.0f);
+
+        return world_to_team * Geometry2d::Point(x / 1000, y / 1000);
     }
 
     Geometry2d::Point getBallPlacementPoint() const {

--- a/soccer/GameState.hpp
+++ b/soccer/GameState.hpp
@@ -178,7 +178,7 @@ public:
             _worldToTeam * Geometry2d::Point(x / 1000, y / 1000);
     }
 
-    static Geometry2d::Point getBallPlacementPoint(float x, float y) {
+    static Geometry2d::Point convertToBallPlacementPoint(float x, float y) {
         Geometry2d::TransformMatrix world_to_team =
             Geometry2d::TransformMatrix();
         world_to_team *= Geometry2d::TransformMatrix::translate(

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -87,7 +87,7 @@ Processor::Processor(bool sim, bool defendPlus, VisionChannel visionChannel,
     _context.field_dimensions = *currentDimensions;
 
     _vision = std::make_shared<VisionFilter>();
-    _refereeModule = std::make_shared<NewRefereeModule>(&_context, _blueTeam);
+    _refereeModule = std::make_shared<Referee>(&_context, _blueTeam);
     _refereeModule->start();
     _gameplayModule = std::make_shared<Gameplay::GameplayModule>(
         &_context, _refereeModule.get());
@@ -352,9 +352,9 @@ void Processor::run() {
         _context.vision_packets.clear();
 
         // Log referee data
-        vector<NewRefereePacket*> refereePackets;
+        vector<RefereePacket*> refereePackets;
         _refereeModule.get()->getPackets(refereePackets);
-        for (NewRefereePacket* packet : refereePackets) {
+        for (RefereePacket* packet : refereePackets) {
             SSL_Referee* log = _context.state.logFrame->add_raw_refbox();
             log->CopyFrom(packet->wrapper);
             curStatus.lastRefereeTime =
@@ -363,8 +363,8 @@ void Processor::run() {
         }
 
         // Update gamestate w/ referee data
-        _refereeModule->updateGameState(blueTeam());
-        _refereeModule->spinKickWatcher();
+        _refereeModule->update();
+        _refereeModule->spin();
 
         string yellowname, bluename;
 

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -87,7 +87,7 @@ Processor::Processor(bool sim, bool defendPlus, VisionChannel visionChannel,
     _context.field_dimensions = *currentDimensions;
 
     _vision = std::make_shared<VisionFilter>();
-    _refereeModule = std::make_shared<Referee>(&_context, _blueTeam);
+    _refereeModule = std::make_shared<Referee>(&_context);
     _refereeModule->start();
     _gameplayModule = std::make_shared<Gameplay::GameplayModule>(
         &_context, _refereeModule.get());
@@ -363,7 +363,6 @@ void Processor::run() {
         }
 
         // Update gamestate w/ referee data
-        _refereeModule->update();
         _refereeModule->spin();
 
         string yellowname, bluename;

--- a/soccer/Processor.hpp
+++ b/soccer/Processor.hpp
@@ -17,7 +17,7 @@
 #include <Geometry2d/Pose.hpp>
 #include <Geometry2d/TransformMatrix.hpp>
 #include <Logger.hpp>
-#include <NewRefereeModule.hpp>
+#include <Referee.hpp>
 #include <SystemState.hpp>
 #include "GrSimCommunicator.hpp"
 #include "Node.hpp"
@@ -25,8 +25,6 @@
 #include "motion/MotionControlNode.hpp"
 #include "radio/Radio.hpp"
 #include "radio/RadioNode.hpp"
-
-#include "Context.hpp"
 #include "rc-fshare/rtp.hpp"
 
 class Configuration;
@@ -134,9 +132,7 @@ public:
         return _gameplayModule;
     }
 
-    std::shared_ptr<NewRefereeModule> refereeModule() const {
-        return _refereeModule;
-    }
+    std::shared_ptr<Referee> refereeModule() const { return _refereeModule; }
 
     SystemState* state() { return &_context.state; }
 
@@ -263,7 +259,7 @@ private:
 
     // modules
     std::shared_ptr<VisionFilter> _vision;
-    std::shared_ptr<NewRefereeModule> _refereeModule;
+    std::shared_ptr<Referee> _refereeModule;
     std::shared_ptr<Gameplay::GameplayModule> _gameplayModule;
     std::unique_ptr<Planning::MultiRobotPathPlanner> _pathPlanner;
     std::unique_ptr<VisionReceiver> _visionReceiver;

--- a/soccer/Processor.hpp
+++ b/soccer/Processor.hpp
@@ -4,21 +4,21 @@
 
 #pragma once
 
-#include <vector>
-#include <optional>
+#include <protobuf/LogFrame.pb.h>
 #include <string.h>
 
-#include <QMutex>
-#include <QMutexLocker>
-#include <QThread>
-
-#include <protobuf/LogFrame.pb.h>
 #include <Geometry2d/Point.hpp>
 #include <Geometry2d/Pose.hpp>
 #include <Geometry2d/TransformMatrix.hpp>
 #include <Logger.hpp>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QThread>
 #include <Referee.hpp>
 #include <SystemState.hpp>
+#include <optional>
+#include <vector>
+
 #include "GrSimCommunicator.hpp"
 #include "Node.hpp"
 #include "VisionReceiver.hpp"

--- a/soccer/Referee.cpp
+++ b/soccer/Referee.cpp
@@ -111,12 +111,9 @@ Referee::Referee(Context* const context)
     : stage_(NORMAL_FIRST_HALF_PRE),
       command_(HALT),
       _running(false),
-      _context(context) {
-}
+      _context(context) {}
 
-Referee::~Referee() {
-    stop();
-}
+Referee::~Referee() { stop(); }
 
 void Referee::stop() {
     _running = false;
@@ -213,9 +210,7 @@ void Referee::run() {
     }
 }
 
-void Referee::overrideTeam(bool isBlue) {
-    _game_state.blueTeam = isBlue;
-}
+void Referee::overrideTeam(bool isBlue) { _game_state.blueTeam = isBlue; }
 
 void Referee::spin() {
     spinKickWatcher(_context->state);

--- a/soccer/Referee.cpp
+++ b/soccer/Referee.cpp
@@ -328,7 +328,9 @@ GameState Referee::updateGameState(const GameState& game_state) const {
                 return GameState::PenaltyShootout;
             case Stage::POST_GAME:
                 return GameState::Overtime2;
-        }
+            default:
+                return GameState::FirstHalf;
+        };
     }();
 
     GameState::State state = game_state.state;
@@ -405,14 +407,14 @@ GameState Referee::updateGameState(const GameState& game_state) const {
             state = GameState::Stop;
             restart = GameState::Placement;
             our_restart = !_blueTeam;
-            ball_placement_point = GameState::getBallPlacementPoint(
+            ball_placement_point = GameState::convertToBallPlacementPoint(
                 ballPlacementx, ballPlacementy);
             break;
         case Command::BALL_PLACEMENT_BLUE:
             state = GameState::Stop;
             restart = GameState::Placement;
             our_restart = _blueTeam;
-            ball_placement_point = GameState::getBallPlacementPoint(
+            ball_placement_point = GameState::convertToBallPlacementPoint(
                 ballPlacementx, ballPlacementy);
             break;
     }
@@ -426,8 +428,6 @@ GameState Referee::updateGameState(const GameState& game_state) const {
 
     auto our_info = _blueTeam ? blue_info : yellow_info;
     auto their_info = _blueTeam ? yellow_info : blue_info;
-
-    auto blueTeam = _blueTeam;
 
     return GameState{period,
                      state,

--- a/soccer/Referee.hpp
+++ b/soccer/Referee.hpp
@@ -138,18 +138,18 @@ public:
  */
 class Referee : public QThread {
 public:
-    Referee(Context* const ctx, bool isBlue = false);
-    ~Referee();
+    explicit Referee(Context* const ctx);
+    ~Referee() override;
 
     void stop();
 
     void getPackets(std::vector<RefereePacket*>& packets);
 
-    bool kicked() const { return _kickDetectState == Kicked; }
+    [[nodiscard]] bool kicked() const { return _kickDetectState == Kicked; }
 
     void useExternalReferee(bool value) { _useExternalRef = value; }
 
-    bool useExternalReferee() const { return _useExternalRef; }
+    [[nodiscard]] bool useExternalReferee() const { return _useExternalRef; }
 
     /**
      * Set the team color only if it is not already being controlled by the
@@ -160,7 +160,7 @@ public:
      */
     void overrideTeam(bool isBlue);
 
-    bool isBlueTeam() const { return _blueTeam; }
+    [[nodiscard]] bool isBlueTeam() const { return _context->game_state.blueTeam; }
 
     RefreeModuleEnums::Stage stage;
     RefreeModuleEnums::Command command;
@@ -195,17 +195,17 @@ public:
     TeamInfo yellow_info;
     TeamInfo blue_info;
 
-    void update();
-    GameState updateGameState(const GameState& game_state) const;
+    [[nodiscard]] GameState updateGameState(const GameState& game_state) const;
 
     void spin();
 
 protected:
-    virtual void run() override;
+    void run() override;
+    void update();
 
     // Unconditional setter for the team color.
-    void blueTeam(bool value) { _blueTeam = value; }
-    void spinKickWatcher();
+    void blueTeam(bool value) { _context->game_state.blueTeam = value; }
+    void spinKickWatcher(const SystemState& system_state);
 
     volatile bool _running;
 
@@ -237,8 +237,6 @@ protected:
     // if the ref is connected but our team name doesn't match either of the
     // team names in the packet.
     bool _isRefControlled = false;
-
-    bool _blueTeam = false;
 
     float ballPlacementx;
     float ballPlacementy;

--- a/soccer/Referee.hpp
+++ b/soccer/Referee.hpp
@@ -160,7 +160,9 @@ public:
      */
     void overrideTeam(bool isBlue);
 
-    [[nodiscard]] bool isBlueTeam() const { return _context->game_state.blueTeam; }
+    [[nodiscard]] bool isBlueTeam() const {
+        return _context->game_state.blueTeam;
+    }
 
     RefreeModuleEnums::Stage stage;
     RefreeModuleEnums::Command command;

--- a/soccer/Referee.hpp
+++ b/soccer/Referee.hpp
@@ -147,7 +147,9 @@ public:
 
     [[nodiscard]] bool kicked() const { return _kickDetectState == Kicked; }
 
-    void useExternalReferee(bool value) { _useExternalRef = value; }
+    void useExternalReferee(bool value) {
+        _useExternalRef = value;
+    }
 
     [[nodiscard]] bool useExternalReferee() const { return _useExternalRef; }
 

--- a/soccer/Referee.hpp
+++ b/soccer/Referee.hpp
@@ -17,7 +17,7 @@
 
 class QUdpSocket;
 
-namespace RefreeModuleEnums {
+namespace RefereeModuleEnums {
 // These are the "coarse" stages of the game.
 enum Stage {
     // The first half is about to start.
@@ -105,7 +105,7 @@ enum Command {
 };
 
 std::string stringFromCommand(Command c);
-}  // namespace RefreeModuleEnums
+}  // namespace RefereeModuleEnums
 
 /**
  * @brief A packet we received over the network from ssl-refbox
@@ -166,8 +166,8 @@ public:
         return _context->game_state.blueTeam;
     }
 
-    RefreeModuleEnums::Stage stage;
-    RefreeModuleEnums::Command command;
+    RefereeModuleEnums::Stage stage_;
+    RefereeModuleEnums::Command command_;
 
     // The UNIX timestamp when the packet was sent, in microseconds.
     // Divide by 1,000,000 to get a time_t.
@@ -199,7 +199,8 @@ public:
     TeamInfo yellow_info;
     TeamInfo blue_info;
 
-    [[nodiscard]] GameState updateGameState(const GameState& game_state) const;
+    [[nodiscard]] GameState updateGameState(
+        RefereeModuleEnums::Command command) const;
 
     void spin();
 
@@ -231,8 +232,8 @@ protected:
     std::vector<RefereePacket*> _packets;
     Context* const _context;
 
-    RefreeModuleEnums::Command prev_command;
-    RefreeModuleEnums::Stage prev_stage;
+    RefereeModuleEnums::Command prev_command_;
+    RefereeModuleEnums::Stage prev_stage_;
 
     bool _useExternalRef = false;
 
@@ -244,4 +245,7 @@ protected:
 
     float ballPlacementx;
     float ballPlacementy;
+
+private:
+    GameState _game_state;
 };

--- a/soccer/gameplay/GameplayModule.cpp
+++ b/soccer/gameplay/GameplayModule.cpp
@@ -1,4 +1,5 @@
 #include <protobuf/LogFrame.pb.h>
+
 #include <Constants.hpp>
 #include <Network.hpp>
 #include <Referee.hpp>
@@ -20,7 +21,7 @@ using namespace boost;
 using namespace boost::python;
 
 using namespace Geometry2d;
-using namespace RefreeModuleEnums;
+using namespace RefereeModuleEnums;
 
 ConfigDouble* GameplayModule::_fieldEdgeInset;
 
@@ -391,7 +392,7 @@ void Gameplay::GameplayModule::run() {
 
                 if (rtrn.ptr() != Py_None) {
                     Command cmd = extract<Command>(rtrn);
-                    _refereeModule->command = cmd;
+                    _refereeModule->command_ = cmd;
                 }
             }
 
@@ -538,7 +539,7 @@ void Gameplay::GameplayModule::loadTest() {
             runningTests = extract<bool>(rtrn);
 
             if (runningTests) {
-                _refereeModule->command = Command::HALT;
+                _refereeModule->command_ = Command::HALT;
 
                 // Place robots and ball
                 grSim_Packet simPacket;

--- a/soccer/gameplay/GameplayModule.cpp
+++ b/soccer/gameplay/GameplayModule.cpp
@@ -1,19 +1,11 @@
 #include <protobuf/LogFrame.pb.h>
 #include <Constants.hpp>
 #include <Network.hpp>
-#include <NewRefereeModule.hpp>
+#include <Referee.hpp>
 #include <Robot.hpp>
 #include <SystemState.hpp>
 #include <gameplay/GameplayModule.hpp>
 #include <planning/MotionInstant.hpp>
-
-#include <stdio.h>
-#include <iostream>
-#include <cmath>
-
-#include <protobuf/grSim_Commands.pb.h>
-#include <protobuf/grSim_Packet.pb.h>
-#include <protobuf/grSim_Replacement.pb.h>
 
 // for python stuff
 #include "DebugDrawer.hpp"
@@ -28,7 +20,7 @@ using namespace boost;
 using namespace boost::python;
 
 using namespace Geometry2d;
-using namespace NewRefereeModuleEnums;
+using namespace RefreeModuleEnums;
 
 ConfigDouble* GameplayModule::_fieldEdgeInset;
 
@@ -52,7 +44,7 @@ bool GameplayModule::hasFieldEdgeInsetChanged() const {
 
 // TODO: Replace this whole file when we move to ROS2
 Gameplay::GameplayModule::GameplayModule(Context* const context,
-                                         NewRefereeModule* const refereeModule)
+                                         Referee* const refereeModule)
     : _mutex(QMutex::Recursive),
       _context(context),
       _refereeModule(refereeModule) {

--- a/soccer/gameplay/GameplayModule.hpp
+++ b/soccer/gameplay/GameplayModule.hpp
@@ -18,7 +18,7 @@
 #include <Configuration.hpp>
 #include <Context.hpp>
 #include <GrSimCommunicator.hpp>
-#include <NewRefereeModule.hpp>
+#include <Referee.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
 
 class OurRobot;
@@ -45,7 +45,7 @@ namespace Gameplay {
  */
 class GameplayModule {
 public:
-    GameplayModule(Context* const context, NewRefereeModule* refereeModule);
+    GameplayModule(Context* const context, Referee* refereeModule);
     virtual ~GameplayModule();
 
     SystemState* state() const { return &_context->state; }
@@ -151,7 +151,7 @@ private:
     double _oldFieldEdgeInset;
 
     Context* const _context;
-    NewRefereeModule* const _refereeModule;
+    Referee* const _refereeModule;
 
     std::set<OurRobot*> _playRobots;
 

--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -23,7 +23,7 @@ using namespace boost::python;
 #include <motion/MotionControl.hpp>
 #include <rc-fshare/pid.hpp>
 #include "KickEvaluator.hpp"
-#include "NewRefereeModule.hpp"
+#include "Referee.hpp"
 #include "WindowEvaluator.hpp"
 #include "motion/TrapezoidalMotion.hpp"
 #include "optimization/NelderMead2D.hpp"
@@ -1071,33 +1071,32 @@ BOOST_PYTHON_MODULE(robocup) {
         .def_readonly("MaxRobotSpeed", &MotionConstraints::_max_speed)
         .def_readonly("MaxRobotAccel", &MotionConstraints::_max_acceleration);
 
-    enum_<NewRefereeModuleEnums::Command>("Command")
-        .value("halt", NewRefereeModuleEnums::Command::HALT)
-        .value("stop", NewRefereeModuleEnums::Command::STOP)
-        .value("normal_start", NewRefereeModuleEnums::Command::NORMAL_START)
-        .value("force_start", NewRefereeModuleEnums::Command::FORCE_START)
+    enum_<RefreeModuleEnums::Command>("Command")
+        .value("halt", RefreeModuleEnums::Command::HALT)
+        .value("stop", RefreeModuleEnums::Command::STOP)
+        .value("normal_start", RefreeModuleEnums::Command::NORMAL_START)
+        .value("force_start", RefreeModuleEnums::Command::FORCE_START)
         .value("prepare_kickoff_yellow",
-               NewRefereeModuleEnums::Command::PREPARE_KICKOFF_YELLOW)
+               RefreeModuleEnums::Command::PREPARE_KICKOFF_YELLOW)
         .value("prepare_kickoff_blue",
-               NewRefereeModuleEnums::Command::PREPARE_KICKOFF_BLUE)
+               RefreeModuleEnums::Command::PREPARE_KICKOFF_BLUE)
         .value("prepare_penalty_yellow",
-               NewRefereeModuleEnums::Command::PREPARE_PENALTY_YELLOW)
+               RefreeModuleEnums::Command::PREPARE_PENALTY_YELLOW)
         .value("prepare_penalty_blue",
-               NewRefereeModuleEnums::Command::PREPARE_PENALTY_BLUE)
+               RefreeModuleEnums::Command::PREPARE_PENALTY_BLUE)
         .value("direct_free_yellow",
-               NewRefereeModuleEnums::Command::DIRECT_FREE_YELLOW)
-        .value("direct_free_blue",
-               NewRefereeModuleEnums::Command::DIRECT_FREE_BLUE)
+               RefreeModuleEnums::Command::DIRECT_FREE_YELLOW)
+        .value("direct_free_blue", RefreeModuleEnums::Command::DIRECT_FREE_BLUE)
         .value("indirect_free_yellow",
-               NewRefereeModuleEnums::Command::INDIRECT_FREE_YELLOW)
+               RefreeModuleEnums::Command::INDIRECT_FREE_YELLOW)
         .value("indirect_free_blue",
-               NewRefereeModuleEnums::Command::INDIRECT_FREE_BLUE)
-        .value("timeout_yellow", NewRefereeModuleEnums::Command::TIMEOUT_YELLOW)
-        .value("timeout_blue", NewRefereeModuleEnums::Command::TIMEOUT_BLUE)
-        .value("goal_yellow", NewRefereeModuleEnums::Command::GOAL_YELLOW)
-        .value("goal_blue", NewRefereeModuleEnums::Command::GOAL_BLUE)
+               RefreeModuleEnums::Command::INDIRECT_FREE_BLUE)
+        .value("timeout_yellow", RefreeModuleEnums::Command::TIMEOUT_YELLOW)
+        .value("timeout_blue", RefreeModuleEnums::Command::TIMEOUT_BLUE)
+        .value("goal_yellow", RefreeModuleEnums::Command::GOAL_YELLOW)
+        .value("goal_blue", RefreeModuleEnums::Command::GOAL_BLUE)
         .value("ball_placement_yellow",
-               NewRefereeModuleEnums::Command::BALL_PLACEMENT_YELLOW)
+               RefreeModuleEnums::Command::BALL_PLACEMENT_YELLOW)
         .value("ball_placement_blue",
-               NewRefereeModuleEnums::Command::BALL_PLACEMENT_BLUE);
+               RefreeModuleEnums::Command::BALL_PLACEMENT_BLUE);
 }

--- a/soccer/gameplay/robocup-py.cpp
+++ b/soccer/gameplay/robocup-py.cpp
@@ -9,6 +9,8 @@
 using namespace boost::python;
 
 #include <protobuf/LogFrame.pb.h>
+
+#include <Configuration.hpp>
 #include <Constants.hpp>
 #include <Context.hpp>
 #include <Geometry2d/Arc.hpp>
@@ -20,24 +22,22 @@ using namespace boost::python;
 #include <Geometry2d/Rect.hpp>
 #include <Robot.hpp>
 #include <SystemState.hpp>
+#include <boost/python/exception_translator.hpp>
+#include <boost/version.hpp>
+#include <exception>
 #include <motion/MotionControl.hpp>
 #include <rc-fshare/pid.hpp>
+
+#include "DebugDrawer.hpp"
 #include "KickEvaluator.hpp"
 #include "Referee.hpp"
+#include "RobotConfig.hpp"
 #include "WindowEvaluator.hpp"
 #include "motion/TrapezoidalMotion.hpp"
 #include "optimization/NelderMead2D.hpp"
 #include "optimization/NelderMead2DConfig.hpp"
 #include "optimization/PythonFunctionWrapper.hpp"
 #include "planning/MotionConstraints.hpp"
-
-#include <boost/python/exception_translator.hpp>
-#include <boost/version.hpp>
-#include <exception>
-
-#include <Configuration.hpp>
-#include "DebugDrawer.hpp"
-#include "RobotConfig.hpp"
 
 /**
  * These functions make sure errors on the c++
@@ -1071,32 +1071,33 @@ BOOST_PYTHON_MODULE(robocup) {
         .def_readonly("MaxRobotSpeed", &MotionConstraints::_max_speed)
         .def_readonly("MaxRobotAccel", &MotionConstraints::_max_acceleration);
 
-    enum_<RefreeModuleEnums::Command>("Command")
-        .value("halt", RefreeModuleEnums::Command::HALT)
-        .value("stop", RefreeModuleEnums::Command::STOP)
-        .value("normal_start", RefreeModuleEnums::Command::NORMAL_START)
-        .value("force_start", RefreeModuleEnums::Command::FORCE_START)
+    enum_<RefereeModuleEnums::Command>("Command")
+        .value("halt", RefereeModuleEnums::Command::HALT)
+        .value("stop", RefereeModuleEnums::Command::STOP)
+        .value("normal_start", RefereeModuleEnums::Command::NORMAL_START)
+        .value("force_start", RefereeModuleEnums::Command::FORCE_START)
         .value("prepare_kickoff_yellow",
-               RefreeModuleEnums::Command::PREPARE_KICKOFF_YELLOW)
+               RefereeModuleEnums::Command::PREPARE_KICKOFF_YELLOW)
         .value("prepare_kickoff_blue",
-               RefreeModuleEnums::Command::PREPARE_KICKOFF_BLUE)
+               RefereeModuleEnums::Command::PREPARE_KICKOFF_BLUE)
         .value("prepare_penalty_yellow",
-               RefreeModuleEnums::Command::PREPARE_PENALTY_YELLOW)
+               RefereeModuleEnums::Command::PREPARE_PENALTY_YELLOW)
         .value("prepare_penalty_blue",
-               RefreeModuleEnums::Command::PREPARE_PENALTY_BLUE)
+               RefereeModuleEnums::Command::PREPARE_PENALTY_BLUE)
         .value("direct_free_yellow",
-               RefreeModuleEnums::Command::DIRECT_FREE_YELLOW)
-        .value("direct_free_blue", RefreeModuleEnums::Command::DIRECT_FREE_BLUE)
+               RefereeModuleEnums::Command::DIRECT_FREE_YELLOW)
+        .value("direct_free_blue",
+               RefereeModuleEnums::Command::DIRECT_FREE_BLUE)
         .value("indirect_free_yellow",
-               RefreeModuleEnums::Command::INDIRECT_FREE_YELLOW)
+               RefereeModuleEnums::Command::INDIRECT_FREE_YELLOW)
         .value("indirect_free_blue",
-               RefreeModuleEnums::Command::INDIRECT_FREE_BLUE)
-        .value("timeout_yellow", RefreeModuleEnums::Command::TIMEOUT_YELLOW)
-        .value("timeout_blue", RefreeModuleEnums::Command::TIMEOUT_BLUE)
-        .value("goal_yellow", RefreeModuleEnums::Command::GOAL_YELLOW)
-        .value("goal_blue", RefreeModuleEnums::Command::GOAL_BLUE)
+               RefereeModuleEnums::Command::INDIRECT_FREE_BLUE)
+        .value("timeout_yellow", RefereeModuleEnums::Command::TIMEOUT_YELLOW)
+        .value("timeout_blue", RefereeModuleEnums::Command::TIMEOUT_BLUE)
+        .value("goal_yellow", RefereeModuleEnums::Command::GOAL_YELLOW)
+        .value("goal_blue", RefereeModuleEnums::Command::GOAL_BLUE)
         .value("ball_placement_yellow",
-               RefreeModuleEnums::Command::BALL_PLACEMENT_YELLOW)
+               RefereeModuleEnums::Command::BALL_PLACEMENT_YELLOW)
         .value("ball_placement_blue",
-               RefreeModuleEnums::Command::BALL_PLACEMENT_BLUE);
+               RefereeModuleEnums::Command::BALL_PLACEMENT_BLUE);
 }

--- a/soccer/ui/MainWindow.cpp
+++ b/soccer/ui/MainWindow.cpp
@@ -511,10 +511,10 @@ void MainWindow::updateViews() {
     }
 
     _ui.refStage->setText(
-        RefreeModuleEnums::stringFromStage(_processor->refereeModule()->stage)
+        RefereeModuleEnums::stringFromStage(_processor->refereeModule()->stage_)
             .c_str());
-    _ui.refCommand->setText(RefreeModuleEnums::stringFromCommand(
-                                _processor->refereeModule()->command)
+    _ui.refCommand->setText(RefereeModuleEnums::stringFromCommand(
+                                _processor->refereeModule()->command_)
                                 .c_str());
 
     // convert time left from ms to s and display it to two decimal places
@@ -1515,48 +1515,49 @@ void MainWindow::setUseRefChecked(bool use_ref) {
 }
 
 void MainWindow::on_fastHalt_clicked() {
-    _processor->refereeModule()->command = RefreeModuleEnums::HALT;
+    _processor->refereeModule()->command_ = RefereeModuleEnums::HALT;
 }
 
 void MainWindow::on_fastStop_clicked() {
-    _processor->refereeModule()->command = RefreeModuleEnums::STOP;
+    _processor->refereeModule()->command_ = RefereeModuleEnums::STOP;
 }
 
 void MainWindow::on_fastReady_clicked() {
-    _processor->refereeModule()->command = RefreeModuleEnums::NORMAL_START;
+    _processor->refereeModule()->command_ = RefereeModuleEnums::NORMAL_START;
 }
 
 void MainWindow::on_fastForceStart_clicked() {
-    _processor->refereeModule()->command = RefreeModuleEnums::FORCE_START;
+    _processor->refereeModule()->command_ = RefereeModuleEnums::FORCE_START;
 }
 
 void MainWindow::on_fastKickoffBlue_clicked() {
-    _processor->refereeModule()->command =
-        RefreeModuleEnums::PREPARE_KICKOFF_BLUE;
+    _processor->refereeModule()->command_ =
+        RefereeModuleEnums::PREPARE_KICKOFF_BLUE;
 }
 
 void MainWindow::on_fastKickoffYellow_clicked() {
-    _processor->refereeModule()->command =
-        RefreeModuleEnums::PREPARE_KICKOFF_YELLOW;
+    _processor->refereeModule()->command_ =
+        RefereeModuleEnums::PREPARE_KICKOFF_YELLOW;
 }
 
 void MainWindow::on_fastDirectBlue_clicked() {
-    _processor->refereeModule()->command = RefreeModuleEnums::DIRECT_FREE_BLUE;
+    _processor->refereeModule()->command_ =
+        RefereeModuleEnums::DIRECT_FREE_BLUE;
 }
 
 void MainWindow::on_fastDirectYellow_clicked() {
-    _processor->refereeModule()->command =
-        RefreeModuleEnums::DIRECT_FREE_YELLOW;
+    _processor->refereeModule()->command_ =
+        RefereeModuleEnums::DIRECT_FREE_YELLOW;
 }
 
 void MainWindow::on_fastIndirectBlue_clicked() {
-    _processor->refereeModule()->command =
-        RefreeModuleEnums::INDIRECT_FREE_BLUE;
+    _processor->refereeModule()->command_ =
+        RefereeModuleEnums::INDIRECT_FREE_BLUE;
 }
 
 void MainWindow::on_fastIndirectYellow_clicked() {
-    _processor->refereeModule()->command =
-        RefreeModuleEnums::INDIRECT_FREE_YELLOW;
+    _processor->refereeModule()->command_ =
+        RefereeModuleEnums::INDIRECT_FREE_YELLOW;
 }
 
 void MainWindow::on_actionVisionPrimary_Half_triggered() {

--- a/soccer/ui/MainWindow.cpp
+++ b/soccer/ui/MainWindow.cpp
@@ -510,10 +510,12 @@ void MainWindow::updateViews() {
         }
     }
 
-    _ui.refStage->setText(NewRefereeModuleEnums::stringFromStage(
-                              _processor->refereeModule()->stage).c_str());
-    _ui.refCommand->setText(NewRefereeModuleEnums::stringFromCommand(
-                                _processor->refereeModule()->command).c_str());
+    _ui.refStage->setText(
+        RefreeModuleEnums::stringFromStage(_processor->refereeModule()->stage)
+            .c_str());
+    _ui.refCommand->setText(RefreeModuleEnums::stringFromCommand(
+                                _processor->refereeModule()->command)
+                                .c_str());
 
     // convert time left from ms to s and display it to two decimal places
     int timeSeconds =
@@ -1513,49 +1515,48 @@ void MainWindow::setUseRefChecked(bool use_ref) {
 }
 
 void MainWindow::on_fastHalt_clicked() {
-    _processor->refereeModule()->command = NewRefereeModuleEnums::HALT;
+    _processor->refereeModule()->command = RefreeModuleEnums::HALT;
 }
 
 void MainWindow::on_fastStop_clicked() {
-    _processor->refereeModule()->command = NewRefereeModuleEnums::STOP;
+    _processor->refereeModule()->command = RefreeModuleEnums::STOP;
 }
 
 void MainWindow::on_fastReady_clicked() {
-    _processor->refereeModule()->command = NewRefereeModuleEnums::NORMAL_START;
+    _processor->refereeModule()->command = RefreeModuleEnums::NORMAL_START;
 }
 
 void MainWindow::on_fastForceStart_clicked() {
-    _processor->refereeModule()->command = NewRefereeModuleEnums::FORCE_START;
+    _processor->refereeModule()->command = RefreeModuleEnums::FORCE_START;
 }
 
 void MainWindow::on_fastKickoffBlue_clicked() {
     _processor->refereeModule()->command =
-        NewRefereeModuleEnums::PREPARE_KICKOFF_BLUE;
+        RefreeModuleEnums::PREPARE_KICKOFF_BLUE;
 }
 
 void MainWindow::on_fastKickoffYellow_clicked() {
     _processor->refereeModule()->command =
-        NewRefereeModuleEnums::PREPARE_KICKOFF_YELLOW;
+        RefreeModuleEnums::PREPARE_KICKOFF_YELLOW;
 }
 
 void MainWindow::on_fastDirectBlue_clicked() {
-    _processor->refereeModule()->command =
-        NewRefereeModuleEnums::DIRECT_FREE_BLUE;
+    _processor->refereeModule()->command = RefreeModuleEnums::DIRECT_FREE_BLUE;
 }
 
 void MainWindow::on_fastDirectYellow_clicked() {
     _processor->refereeModule()->command =
-        NewRefereeModuleEnums::DIRECT_FREE_YELLOW;
+        RefreeModuleEnums::DIRECT_FREE_YELLOW;
 }
 
 void MainWindow::on_fastIndirectBlue_clicked() {
     _processor->refereeModule()->command =
-        NewRefereeModuleEnums::INDIRECT_FREE_BLUE;
+        RefreeModuleEnums::INDIRECT_FREE_BLUE;
 }
 
 void MainWindow::on_fastIndirectYellow_clicked() {
     _processor->refereeModule()->command =
-        NewRefereeModuleEnums::INDIRECT_FREE_YELLOW;
+        RefreeModuleEnums::INDIRECT_FREE_YELLOW;
 }
 
 void MainWindow::on_actionVisionPrimary_Half_triggered() {


### PR DESCRIPTION
## Description
- Clean up the referee node in preparation for moving to a pub-sub
- Performs a small refactor of the business logic inside of the referee node

## Associated Issue
Issue #1424 

## Design Documents
[ROS Roadmap](https://docs.google.com/document/d/1wix-ZK9NPBY0zC8T9LyUihT1ONubXMKxHvb8KYmJkNQ/edit#)

## Steps to test
Referee should still work? I can't compile grsim on my computer because of some conflicts between the version of Qt4 and boost on my ubuntu 18.04, so I can't test.