### PR TITLE
Replace Qt libs with std::/boost::.

### DIFF
--- a/soccer/GrSimCommunicator.hpp
+++ b/soccer/GrSimCommunicator.hpp
@@ -1,17 +1,13 @@
-// An extension of FieldView that generates SimCommands in response
-// to clicks/drags when live.
-
 #pragma once
 
 #include <protobuf/grSim_Commands.pb.h>
 #include <protobuf/grSim_Packet.pb.h>
 #include <protobuf/grSim_Replacement.pb.h>
 
-#include <Geometry2d/TransformMatrix.hpp>
-#include <QUdpSocket>
-
 #include <Context.hpp>
+#include <Geometry2d/TransformMatrix.hpp>
 #include <Node.hpp>
+#include <boost/asio.hpp>
 
 class GrSimCommunicator : public Node {
 public:
@@ -26,5 +22,7 @@ public:
 
 private:
     Context* _context;
-    QUdpSocket _simCommandSocket;
+    boost::asio::io_service _io_service;
+    boost::asio::ip::udp::socket _asio_socket;
+    boost::asio::ip::udp::endpoint _grsim_endpoint;
 };

--- a/soccer/Node.hpp
+++ b/soccer/Node.hpp
@@ -6,7 +6,7 @@
  */
 class Node {
 public:
-    virtual ~Node() {}
+    virtual ~Node() = default;
 
     virtual void start(){};
 

--- a/soccer/Node.hpp
+++ b/soccer/Node.hpp
@@ -6,6 +6,8 @@
  */
 class Node {
 public:
+    virtual ~Node() {}
+
     virtual void start(){};
 
     // The callback

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -1,13 +1,6 @@
 #include <gameplay/GameplayModule.hpp>
 
-#include <poll.h>
-#include <QMutexLocker>
-
-#include <protobuf/RadioRx.pb.h>
-#include <protobuf/RadioTx.pb.h>
 #include <protobuf/messages_robocup_ssl_detection.pb.h>
-#include <protobuf/messages_robocup_ssl_geometry.pb.h>
-#include <protobuf/messages_robocup_ssl_wrapper.pb.h>
 #include <Constants.hpp>
 #include <Geometry2d/Util.hpp>
 #include <LogUtils.hpp>
@@ -15,10 +8,7 @@
 #include <RobotConfig.hpp>
 #include <Utils.hpp>
 #include <joystick/GamepadController.hpp>
-#include <joystick/GamepadJoystick.hpp>
 #include <joystick/Joystick.hpp>
-#include <joystick/SpaceNavJoystick.hpp>
-#include <multicast.hpp>
 #include <planning/IndependentMultiRobotPathPlanner.hpp>
 #include <rc-fshare/git_version.hpp>
 #include "DebugDrawer.hpp"
@@ -92,8 +82,6 @@ Processor::Processor(bool sim, bool defendPlus, VisionChannel visionChannel,
     // Initialize team-space transformation
     defendPlusX(defendPlus);
 
-    QMetaObject::connectSlotsByName(this);
-
     _context.is_simulation = _simulation;
 
     _context.field_dimensions = *currentDimensions;
@@ -144,12 +132,11 @@ Processor::~Processor() {
 void Processor::stop() {
     if (_running) {
         _running = false;
-        wait();
     }
 }
 
 void Processor::manualID(int value) {
-    QMutexLocker locker(&_loopMutex);
+    std::lock_guard locker(_loopMutex);
     _manualID = value;
 
     for (Joystick* joy : _joysticks) {
@@ -160,27 +147,27 @@ void Processor::manualID(int value) {
 void Processor::multipleManual(bool value) { _multipleManual = value; }
 
 void Processor::goalieID(int value) {
-    QMutexLocker locker(&_loopMutex);
+    std::lock_guard locker(_loopMutex);
     _gameplayModule->goalieID(value);
 }
 
 int Processor::goalieID() {
-    QMutexLocker locker(&_loopMutex);
+    std::lock_guard locker(_loopMutex);
     return _gameplayModule->goalieID();
 }
 
 void Processor::dampedRotation(bool value) {
-    QMutexLocker locker(&_loopMutex);
+    std::lock_guard locker(_loopMutex);
     _dampedRotation = value;
 }
 
 void Processor::dampedTranslation(bool value) {
-    QMutexLocker locker(&_loopMutex);
+    std::lock_guard locker(_loopMutex);
     _dampedTranslation = value;
 }
 
 void Processor::joystickKickOnBreakBeam(bool value) {
-    QMutexLocker locker(&_loopMutex);
+    std::lock_guard locker(_loopMutex);
     _kickOnBreakBeam = value;
 }
 
@@ -205,7 +192,7 @@ void Processor::setupJoysticks() {
  */
 void Processor::blueTeam(bool value) {
     // This is called from the GUI thread
-    QMutexLocker locker(&_loopMutex);
+    std::lock_guard locker(_loopMutex);
 
     if (_blueTeam != value) {
         _blueTeam = value;

--- a/soccer/Processor.hpp
+++ b/soccer/Processor.hpp
@@ -11,11 +11,9 @@
 #include <Geometry2d/Pose.hpp>
 #include <Geometry2d/TransformMatrix.hpp>
 #include <Logger.hpp>
-#include <QMutex>
-#include <QMutexLocker>
-#include <QThread>
 #include <Referee.hpp>
 #include <SystemState.hpp>
+#include <mutex>
 #include <optional>
 #include <vector>
 
@@ -57,7 +55,7 @@ class MultiRobotPathPlanner;
  * - handling the Joystick
  * - running motion control for each robot (see OurRobot#motionControl)
  */
-class Processor : public QThread {
+class Processor {
 public:
     struct Status {
         Status() {}
@@ -142,7 +140,7 @@ public:
     bool defendPlusX() { return _context.game_state.defendPlusX; }
 
     Status status() {
-        QMutexLocker lock(&_statusMutex);
+        std::lock_guard lock(_statusMutex);
         return _status;
     }
 
@@ -159,7 +157,9 @@ public:
 
     void useOpponentHalf(bool value) { _useOpponentHalf = value; }
 
-    QMutex& loopMutex() { return _loopMutex; }
+    std::lock_guard<std::mutex> lockLoopMutex() {
+        return std::lock_guard(_loopMutex);
+    }
 
     Radio* radio() { return _radio->getRadio(); }
 
@@ -184,9 +184,9 @@ public:
 
     Context* context() { return &_context; }
 
-protected:
-    void run() override;
+    void run();
 
+protected:
     void applyJoystickControls(const JoystickControlValues& controlVals,
                                OurRobot* robot);
 
@@ -227,7 +227,7 @@ private:
     // Locked when processing loop stuff is happening (not when blocked for
     // timing or I/O). This is public so the GUI thread can lock it to access
     // SystemState, etc.
-    QMutex _loopMutex;
+    std::mutex _loopMutex;
 
     /** global system state */
     Context _context;
@@ -253,7 +253,7 @@ private:
 
     // This is used by the GUI to indicate status of the processing loop and
     // network
-    QMutex _statusMutex;
+    std::mutex _statusMutex;
     Status _status;
 
     // modules

--- a/soccer/Referee.cpp
+++ b/soccer/Referee.cpp
@@ -47,16 +47,9 @@ Referee::Referee(Context* const context)
       ballPlacementY{},
       _asio_socket{_io_service} {}
 
-Referee::~Referee() { stop(); }
-
 void Referee::start() {
     setupRefereeMulticast();
     startReceive();
-}
-
-void Referee::stop() {
-    _asio_socket.shutdown(boost::asio::ip::udp::socket::shutdown_both);
-    _asio_socket.close();
 }
 
 void Referee::getPackets(std::vector<RefereePacket>& packets) {

--- a/soccer/Referee.hpp
+++ b/soccer/Referee.hpp
@@ -18,8 +18,6 @@
 #include "SystemState.hpp"
 #include "TeamInfo.hpp"
 
-class QUdpSocket;
-
 /**
  * @brief A packet we received over the network from ssl-refbox
  *
@@ -51,7 +49,7 @@ struct RefereePacket {
 class Referee : public Node {
 public:
     explicit Referee(Context* const context);
-    ~Referee();
+    ~Referee() override{};
 
     Referee(const Referee&) = delete;
     Referee& operator=(const Referee&) = delete;
@@ -60,7 +58,6 @@ public:
 
     void start() override;
     void run() override;
-    void stop() override;
 
     void getPackets(std::vector<RefereePacket>& packets);
 

--- a/soccer/Referee.hpp
+++ b/soccer/Referee.hpp
@@ -49,7 +49,7 @@ struct RefereePacket {
 class Referee : public Node {
 public:
     explicit Referee(Context* const context);
-    ~Referee() override{};
+    ~Referee() override = default;
 
     Referee(const Referee&) = delete;
     Referee& operator=(const Referee&) = delete;

--- a/soccer/VisionReceiver.cpp
+++ b/soccer/VisionReceiver.cpp
@@ -1,8 +1,6 @@
 #include "VisionReceiver.hpp"
 
 #include <unistd.h>
-#include <QMutexLocker>
-#include <QUdpSocket>
 #include <Utils.hpp>
 #include <multicast.hpp>
 #include <stdexcept>

--- a/soccer/gameplay/GameplayModule.cpp
+++ b/soccer/gameplay/GameplayModule.cpp
@@ -46,9 +46,7 @@ bool GameplayModule::hasFieldEdgeInsetChanged() const {
 // TODO: Replace this whole file when we move to ROS2
 Gameplay::GameplayModule::GameplayModule(Context* const context,
                                          Referee* const refereeModule)
-    : _mutex(QMutex::Recursive),
-      _context(context),
-      _refereeModule(refereeModule) {
+    : _context(context), _refereeModule(refereeModule) {
     calculateFieldObstacles();
 
     _oldFieldEdgeInset = _fieldEdgeInset->value();
@@ -333,8 +331,6 @@ Geometry2d::ShapeSet Gameplay::GameplayModule::goalZoneObstacles() const {
  * runs the current play
  */
 void Gameplay::GameplayModule::run() {
-    QMutexLocker lock(&_mutex);
-
     bool verbose = false;
     if (verbose) cout << "Starting GameplayModule::run()" << endl;
 

--- a/soccer/gameplay/GameplayModule.hpp
+++ b/soccer/gameplay/GameplayModule.hpp
@@ -12,7 +12,6 @@
 #include <Geometry2d/ShapeSet.hpp>
 
 #include <set>
-#include <QMutex>
 #include <QString>
 
 #include <Configuration.hpp>
@@ -143,10 +142,6 @@ protected:
     boost::python::object getMainModule();
 
 private:
-    /// This protects all of Gameplay.
-    /// This is held while plays are running.
-    QMutex _mutex;
-
     static ConfigDouble* _fieldEdgeInset;
     double _oldFieldEdgeInset;
 

--- a/soccer/joystick/GamepadController.cpp
+++ b/soccer/joystick/GamepadController.cpp
@@ -41,7 +41,7 @@ GamepadController::GamepadController()
 }
 
 GamepadController::~GamepadController() {
-    QMutexLocker(&mutex());
+    auto lock = lock_mutex();
     SDL_GameControllerClose(_controller);
     _controller = nullptr;
     SDL_Quit();
@@ -103,7 +103,7 @@ void GamepadController::closeJoystick() {
 bool GamepadController::valid() const { return connected; }
 
 void GamepadController::update() {
-    QMutexLocker(&mutex());
+    auto lock = lock_mutex();
     SDL_GameControllerUpdate();
 
     RJ::Time now = RJ::now();
@@ -246,11 +246,11 @@ void GamepadController::update() {
 }
 
 JoystickControlValues GamepadController::getJoystickControlValues() {
-    QMutexLocker(&mutex());
+    auto lock = lock_mutex();
     return _controls;
 }
 
 void GamepadController::reset() {
-    QMutexLocker(&mutex());
+    auto lock = lock_mutex();
     _controls.dribble = false;
 }

--- a/soccer/joystick/GamepadJoystick.cpp
+++ b/soccer/joystick/GamepadJoystick.cpp
@@ -29,7 +29,7 @@ GamepadJoystick::GamepadJoystick()
 }
 
 GamepadJoystick::~GamepadJoystick() {
-    QMutexLocker(&mutex());
+    auto lock = lock_mutex();
     SDL_JoystickClose(_joystick);
     _joystick = nullptr;
     SDL_Quit();
@@ -38,7 +38,7 @@ GamepadJoystick::~GamepadJoystick() {
 bool GamepadJoystick::valid() const { return _joystick != nullptr; }
 
 void GamepadJoystick::update() {
-    QMutexLocker(&mutex());
+    auto lock = lock_mutex();
     SDL_JoystickUpdate();
 
     // DRIBBLER CONTROL
@@ -122,11 +122,11 @@ void GamepadJoystick::update() {
 }
 
 JoystickControlValues GamepadJoystick::getJoystickControlValues() {
-    QMutexLocker(&mutex());
+    auto lock = lock_mutex();
     return _controls;
 }
 
 void GamepadJoystick::reset() {
-    QMutexLocker(&mutex());
+    auto lock = lock_mutex();
     _controls.dribble = false;
 }

--- a/soccer/joystick/Joystick.hpp
+++ b/soccer/joystick/Joystick.hpp
@@ -1,13 +1,12 @@
 
 #pragma once
 
-#include <Robot.hpp>
 #include <protobuf/RadioTx.pb.h>
 
-#include <QMutex>
+#include <Robot.hpp>
 #include <boost/utility.hpp>
+#include <mutex>
 #include <stdexcept>
-#include <stdint.h>
 #include <vector>
 
 struct JoystickControlValues {
@@ -35,7 +34,7 @@ public:
  */
 class Joystick : boost::noncopyable {
 public:
-    Joystick() : _mutex(QMutex::Recursive){};
+    Joystick(){};
     virtual ~Joystick(){};
 
     /**
@@ -75,9 +74,9 @@ public:
     static ConfigDouble* JoystickTranslationMaxDampedSpeed;
 
 protected:
-    QMutex& mutex() { return _mutex; }
+    std::lock_guard<std::mutex> lock_mutex() { return std::lock_guard(_mutex); }
     int robotId;
 
 private:
-    QMutex _mutex;
+    std::mutex _mutex;
 };

--- a/soccer/joystick/Joystick.hpp
+++ b/soccer/joystick/Joystick.hpp
@@ -34,8 +34,7 @@ public:
  */
 class Joystick : boost::noncopyable {
 public:
-    Joystick(){};
-    virtual ~Joystick(){};
+    virtual ~Joystick() = default;
 
     /**
      * @brief Whether or not this Joystick is connected to a real device

--- a/soccer/joystick/SpaceNavJoystick.cpp
+++ b/soccer/joystick/SpaceNavJoystick.cpp
@@ -21,7 +21,7 @@ SpaceNavJoystick::~SpaceNavJoystick() { close(); }
 bool SpaceNavJoystick::valid() const { return _daemonConnected; }
 
 void SpaceNavJoystick::update() {
-    QMutexLocker(&mutex());
+    auto lock = lock_mutex();
 
     //  try again if we failed last time
     if (!_daemonConnected && !_daemonTried) open();

--- a/soccer/main.cpp
+++ b/soccer/main.cpp
@@ -221,7 +221,7 @@ int main(int argc, char* argv[]) {
 
     win->logFileChanged();
 
-    processor->start();
+    std::thread processor_thread(&Processor::run, processor.get());
 
     while (
         !processor
@@ -244,6 +244,7 @@ int main(int argc, char* argv[]) {
 
     int ret = app.exec();
     processor->stop();
+    processor_thread.join();
 
     return ret;
 }

--- a/soccer/radio/SimRadio.cpp
+++ b/soccer/radio/SimRadio.cpp
@@ -25,8 +25,7 @@ SimRadio::SimRadio(Context* const context, bool blueTeam)
                                                       : SimYellowStatusPort)) {
     _grsim_endpoint = ip::udp::endpoint(ip::udp::v4(), SimCommandPort);
 
-    // TODO: Make sure the buffer is big enough.
-    _buffer.resize(128);
+    _buffer.resize(2);
     startReceive();
 }
 

--- a/soccer/radio/SimRadio.cpp
+++ b/soccer/radio/SimRadio.cpp
@@ -7,7 +7,6 @@
 #include <Robot.hpp>
 #include <Utils.hpp>
 #include <cmath>
-#include <iostream>
 #include <stdexcept>
 #include "PacketConvert.hpp"
 
@@ -192,8 +191,6 @@ void SimRadio::switchTeam(bool blueTeam) {
     }
 
     int status_port = blueTeam ? SimBlueStatusPort : SimYellowStatusPort;
-
-    std::cout << status_port << std::endl;
 
     // Let them throw exceptions
     _socket.bind(ip::udp::endpoint(ip::udp::v4(), status_port));

--- a/soccer/radio/SimRadio.cpp
+++ b/soccer/radio/SimRadio.cpp
@@ -15,15 +15,22 @@
 
 using namespace std;
 using namespace Packet;
-
-static QHostAddress LocalAddress(QHostAddress::LocalHost);
+using namespace boost::asio;
 
 SimRadio::SimRadio(Context* const context, bool blueTeam)
-    : _context(context), _blueTeam(blueTeam) {
-    switchTeam(blueTeam);
+    : _context(context),
+      _blueTeam(blueTeam),
+      _socket(_io_service, ip::udp::endpoint(ip::udp::v4(),
+                                             blueTeam ? SimBlueStatusPort
+                                                      : SimYellowStatusPort)) {
+    _grsim_endpoint = ip::udp::endpoint(ip::udp::v4(), SimCommandPort);
+
+    // TODO: Make sure the buffer is big enough.
+    _buffer.resize(128);
+    startReceive();
 }
 
-bool SimRadio::isOpen() const { return _tx_socket.isValid(); }
+bool SimRadio::isOpen() const { return _socket.is_open(); }
 
 void SimRadio::send(Packet::RadioTx& radioTx) {
     grSim_Packet simPacket;
@@ -79,68 +86,80 @@ void SimRadio::send(Packet::RadioTx& radioTx) {
 
     std::string out;
     simPacket.SerializeToString(&out);
-    _tx_socket.writeDatagram(&out[0], out.size(),
-                             QHostAddress(QHostAddress::LocalHost),
-                             SimCommandPort);
+
+    _socket.send_to(buffer(out), _grsim_endpoint);
 }
 
-void SimRadio::receive() {
-    while (_rx_socket.hasPendingDatagrams()) {
-        char byte = 0;
-        // one byte at a time
-        _rx_socket.readDatagram(&byte, 1);
+void SimRadio::receive() { _io_service.poll(); }
 
-        // grSim really needs to set up a proto packet for robot status.
-        // Instead they pack their own byte up in a custom way :/
-        //
-        // byte structure:
-        // 0-2: Robot_ID
-        // 3: touching_ball
-        // 4: just_kicked
-        // 5: robot_on
-        const uint8_t robot_id_mask = 0x7;
-        const uint8_t touching_ball_mask = 0x1 << 3;
-        const uint8_t just_kicked_mask = 0x1 << 4;
-        const uint8_t robot_on_mask = 0x1 << 5;
+void SimRadio::startReceive() {
+    // Set a receive callback
+    _socket.async_receive(
+        boost::asio::buffer(_buffer),
+        [this](const boost::system::error_code& error, std::size_t num_bytes) {
+            receivePacket(error, num_bytes);
+        });
+}
 
-        int robot_id = byte & robot_id_mask;
-        bool ball_sense = byte & touching_ball_mask;
-        bool just_kicked = byte & just_kicked_mask;
-        bool robot_on = byte & robot_on_mask;
-
-        RadioRx rx;
-        rx.set_robot_id(robot_id);
-        rx.set_hardware_version(RJ2015);
-        rx.set_battery(100);
-
-        rx.set_ball_sense_status(ball_sense ? Packet::HasBall : Packet::NoBall);
-
-        const int num_motors = 5;
-        // 5 motors including dribbler
-        for (int i = 0; i < num_motors; i++) {
-            rx.add_motor_status(MotorStatus::Good);
-        }
-
-        rx.set_fpga_status(FpgaGood);
-        rx.set_timestamp(RJ::timestamp());
-
-        const uint8_t kicker_status_charging = Kicker_Enabled | Kicker_I2C_OK;
-        const uint8_t kicker_status_ready =
-            Kicker_Charged | kicker_status_charging;
-        ;
-
-        rx.set_kicker_status(just_kicked ? kicker_status_charging
-                                         : kicker_status_ready);
-        rx.set_kicker_voltage(200);
-
-        std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
-        _reversePackets.push_back(rx);
+void SimRadio::receivePacket(const boost::system::error_code& error,
+                             std::size_t num_bytes) {
+    for (int i = 0; i < num_bytes; i++) {
+        handleReceive(_buffer[i]);
     }
+    startReceive();
+}
+
+void SimRadio::handleReceive(uint8_t data) {
+    // grSim really needs to set up a proto packet for robot status.
+    // Instead they pack their own byte up in a custom way :/
+    //
+    // byte structure:
+    // 0-2: Robot_ID
+    // 3: touching_ball
+    // 4: just_kicked
+    // 5: robot_on
+    const uint8_t robot_id_mask = 0x7;
+    const uint8_t touching_ball_mask = 0x1 << 3;
+    const uint8_t just_kicked_mask = 0x1 << 4;
+    const uint8_t robot_on_mask = 0x1 << 5;
+
+    int this_robot_id = data & robot_id_mask;
+    bool ball_sense = data & touching_ball_mask;
+    bool just_kicked = data & just_kicked_mask;
+    bool robot_on = data & robot_on_mask;
+
+    RadioRx rx;
+    rx.set_robot_id(this_robot_id);
+    rx.set_hardware_version(RJ2015);
+    rx.set_battery(100);
+
+    rx.set_ball_sense_status(ball_sense ? Packet::HasBall : Packet::NoBall);
+
+    const int num_motors = 5;
+    // 5 motors including dribbler
+    for (int i = 0; i < num_motors; i++) {
+        rx.add_motor_status(MotorStatus::Good);
+    }
+
+    rx.set_fpga_status(FpgaGood);
+    rx.set_timestamp(RJ::timestamp());
+
+    const uint8_t kicker_status_charging = Kicker_Enabled | Kicker_I2C_OK;
+    const uint8_t kicker_status_ready = Kicker_Charged | kicker_status_charging;
+    ;
+
+    rx.set_kicker_status(just_kicked ? kicker_status_charging
+                                     : kicker_status_ready);
+    rx.set_kicker_voltage(200);
+
+    std::lock_guard<std::mutex> lock(_reverse_packets_mutex);
+    _reversePackets.push_back(rx);
 }
 
 void SimRadio::stopRobots() {
     grSim_Packet simPacket;
     grSim_Commands* simRobotCommands = simPacket.mutable_commands();
+
     for (int i = 0; i < _context->state.self.size(); i++) {
         grSim_Robot_Command* simRobot = simRobotCommands->add_robot_commands();
         simRobot->set_id(_context->state.self[i]->shell());
@@ -154,32 +173,29 @@ void SimRadio::stopRobots() {
         simRobot->set_spinner(0);
         simRobot->set_wheelsspeed(false);
     }
+
     simRobotCommands->set_isteamyellow(!_blueTeam);
     simRobotCommands->set_timestamp(RJ::timestamp());
 
     std::string out;
     simPacket.SerializeToString(&out);
-    _tx_socket.writeDatagram(&out[0], out.size(),
-                             QHostAddress(QHostAddress::LocalHost),
-                             SimCommandPort);
+    _socket.send_to(boost::asio::buffer(out),
+                    ip::udp::endpoint(ip::udp::v4(), SimCommandPort));
 }
 
 void SimRadio::switchTeam(bool blueTeam) {
-    stopRobots();
     _blueTeam = blueTeam;
-    _tx_socket.close();
-    _rx_socket.close();
-    _channel = blueTeam ? 1 : 0;
-    if (!_tx_socket.bind(RadioRxPort + _channel)) {
-        throw runtime_error(QString("Can't bind to the %1 team's radio port.")
-                                .arg(blueTeam ? "blue" : "yellow")
-                                .toStdString());
+
+    if (_socket.is_open()) {
+        // We don't really care what port the tx is on, just the rx
+        stopRobots();
+        _socket.close();
     }
+
     int status_port = blueTeam ? SimBlueStatusPort : SimYellowStatusPort;
-    if (!_rx_socket.bind(status_port)) {
-        throw runtime_error(
-            QString("Can't bind to the %1 team's radio status port.")
-                .arg(blueTeam ? "blue" : "yellow")
-                .toStdString());
-    }
+
+    std::cout << status_port << std::endl;
+
+    // Let them throw exceptions
+    _socket.bind(ip::udp::endpoint(ip::udp::v4(), status_port));
 }

--- a/soccer/radio/SimRadio.hpp
+++ b/soccer/radio/SimRadio.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <Context.hpp>
-#include <QUdpSocket>
 #include <SystemState.hpp>
+#include <boost/asio.hpp>
+#include <cstdint>
 
 #include "Radio.hpp"
 
@@ -14,18 +15,26 @@ public:
     static std::size_t instance_count;
     SimRadio(Context* const context, bool blueTeam = false);
 
-    virtual bool isOpen() const override;
-    virtual void send(Packet::RadioTx& radioTx) override;
-    virtual void receive() override;
-    virtual void switchTeam(bool blueTeam) override;
+    bool isOpen() const override;
+    void send(Packet::RadioTx& radioTx) override;
+    void receive() override;
+    void switchTeam(bool blueTeam) override;
 
     void stopRobots();
 
 private:
     Context* const _context;
 
-    QUdpSocket _tx_socket;
-    QUdpSocket _rx_socket;
-    int _channel;
+    void handleReceive(uint8_t data);
+    void startReceive();
+    void receivePacket(const boost::system::error_code& error,
+                       size_t num_bytes);
+
+    boost::asio::io_service _io_service;
+    boost::asio::ip::udp::socket _socket;
+    boost::asio::ip::udp::endpoint _grsim_endpoint;
+
+    std::vector<char> _buffer;
+
     bool _blueTeam;
 };


### PR DESCRIPTION
Still need to do QString but that's a battle for another day.

## Description
This PR gets rid of all instances of `QUdpSocket`, `QThread` and `QMutex`.

## Associated Issue
N/A. This is a step towards #1432.

## Design Documents
N/A

## Steps to test
### Basic soccer regression testing
1. Open soccer in sim mode. Make sure ball/robot placement still works.

Expected result: no regressions