### PR TITLE
Updated clang_format_6 to clang_format_10

### DIFF
--- a/common/Geometry2d/Pose.hpp
+++ b/common/Geometry2d/Pose.hpp
@@ -69,7 +69,7 @@ public:
      * ------|------
      *       |
      */
-    Pose withOrigin(Pose other) const {
+    [[nodiscard]] Pose withOrigin(Pose other) const {
         Point rotated = position().rotated(other.heading());
         return other + Pose(rotated, heading());
     }

--- a/common/Geometry2d/Pose.hpp
+++ b/common/Geometry2d/Pose.hpp
@@ -36,13 +36,8 @@ public:
         : _position(other(0), other(1)), _heading(other(2)) {}
 
     /**
-     * Copy-constructor - default
-     */
-    Pose(const Pose& other) = default;
-
-    /**
-     * Compute the pose specified using this pose as coordinates in a frame of
-     * reference specified by `other`, in the global space.
+     * Compute the pose specified using this pose as coordinates in a
+     * frame of reference specified by `other`, in the global space.
      *
      * i.e.
      *

--- a/makefile
+++ b/makefile
@@ -153,11 +153,13 @@ checkstyle:
 	@printf "Run this command to reformat code if needed:\n\ngit apply <(curl -L $${LINK_PREFIX:-file://}clean.patch)\n\n"
 	@stylize.v1 --git_diffbase=$(STYLIZE_DIFFBASE) --patch_output "$${CIRCLE_ARTIFACTS:-.}/clean.patch"
 
+CLANG_FORMAT_BINARY=clang-format-10
+
 pretty-lines:
-	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -binary clang-format-9 -i -p1
+	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -binary $(CLANG_FORMAT_BINARY) -i -p1
 	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/yapf-diff.py -style .style.yapf -i -p1
 
 checkstyle-lines:
-	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -binary clang-format-9 -p1 | tee /tmp/checkstyle.patch
+	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -binary $(CLANG_FORMAT_BINARY) -p1 | tee /tmp/checkstyle.patch
 	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/yapf-diff.py -style .style.yapf -p1 | tee -a /tmp/checkstyle.patch
 	@bash -c '[[ ! "$$(cat /tmp/checkstyle.patch)" ]] || (echo "****************************** Checkstyle errors *******************************" && exit 1)'

--- a/makefile
+++ b/makefile
@@ -156,11 +156,11 @@ checkstyle:
 	@stylize.v1 --git_diffbase=$(STYLIZE_DIFFBASE) --patch_output "$${CIRCLE_ARTIFACTS:-.}/clean.patch"
 
 pretty-lines:
-	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -binary clang-format -i -p1
+	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -binary clang-format-9 -i -p1
 	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/yapf-diff.py -style .style.yapf -i -p1
 
 checkstyle-lines:
-	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -binary clang-format -p1 | tee /tmp/checkstyle.patch
+	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -binary clang-format-9 -p1 | tee /tmp/checkstyle.patch
 	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/yapf-diff.py -style .style.yapf -p1 | tee -a /tmp/checkstyle.patch
 	@bash -c '[[ ! "$$(cat /tmp/checkstyle.patch)" ]] || (echo "****************************** Checkstyle errors *******************************" && exit 1)'
 

--- a/makefile
+++ b/makefile
@@ -146,9 +146,7 @@ apidocs:
 	@echo "\n=> Open up 'api_docs/html/index.html' in a browser to view a local copy of the documentation"
 
 STYLIZE_DIFFBASE ?= staging
-# automatically format code according to our style config defined in .clang-format
-pretty:
-	@stylize.v1 -i --git_diffbase=$(STYLIZE_DIFFBASE)
+
 # check if everything in our codebase is in accordance with the style config defined in .clang-format
 # a nonzero exit code indicates that there's a formatting error somewhere
 checkstyle:
@@ -163,15 +161,3 @@ checkstyle-lines:
 	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python2 util/clang-format-diff.py -binary clang-format-9 -p1 | tee /tmp/checkstyle.patch
 	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/yapf-diff.py -style .style.yapf -p1 | tee -a /tmp/checkstyle.patch
 	@bash -c '[[ ! "$$(cat /tmp/checkstyle.patch)" ]] || (echo "****************************** Checkstyle errors *******************************" && exit 1)'
-
-# Option to use old version of stylize
-STYLE_EXCLUDE_DIRS=build \
-	external
-# automatically format code according to our style config defined in .clang-format
-pretty-old:
-	@stylize --diffbase=$(STYLIZE_DIFFBASE) --clang_style=file --yapf_style=.style.yapf --exclude_dirs $(STYLE_EXCLUDE_DIRS)
-# check if everything in our codebase is in accordance with the style config defined in .clang-format
-# a nonzero exit code indicates that there's a formatting error somewhere
-checkstyle-old:
-	@printf "Run this command to reformat code if needed:\n\ngit apply <(curl -L $${LINK_PREFIX:-file://}clean.patch)\n\n"
-	@stylize --diffbase=$(STYLIZE_DIFFBASE) --clang_style=file --yapf_style=.style.yapf --exclude_dirs $(STYLE_EXCLUDE_DIRS) --check --output_patch_file="/tmp/clean.patch"

--- a/util/arch-packages.txt
+++ b/util/arch-packages.txt
@@ -51,7 +51,5 @@ ode
 flann
 freeglut
 
-go
-
 mypy
 python-pylint

--- a/util/arch-setup
+++ b/util/arch-setup
@@ -29,14 +29,10 @@ sudo pip install -r $BASE/util/requirements3.txt
 
 sudo pip2 install -r $BASE/util/requirements2.txt
 
-# install stylize
-if [ -z "$GOPATH" ]; then
-    echo "[WARN] No GOPATH set, not installing stylize."
-else
-    go get github.com/justbuchanan/stylize
-    go install github.com/justbuchanan/stylize
-fi
-
 echo "-- Updating submodules"
 git submodule sync
 git submodule update --init --recursive
+
+echo "-----------------------------------------------------------------------------------------------------------------------------"
+echo "- NOTE: clang_format_10 is required so if you're using this then you probably need to edit arch-setup / install it manually -"
+echo "-----------------------------------------------------------------------------------------------------------------------------"

--- a/util/osx-setup
+++ b/util/osx-setup
@@ -39,14 +39,6 @@ brew linkapps qt5
 echo "-- Installing python3 dependencies"
 sudo pip3 install -r "$BASE/util/requirements3.txt"
 
-# install stylize
-if [ -z "$GOPATH" ]; then
-    echo "[WARN] No GOPATH set, not installing stylize."
-else
-    go get github.com/justbuchanan/stylize
-    go install github.com/justbuchanan/stylize
-fi
-
 # prevent OS X's AppNap "feature" from sleeping the simulator
 echo "-- Disabling AppNap for simulator"
 defaults write org.robojackets.robocup.simulator NSAppSleepDisabled -bool YES
@@ -54,3 +46,7 @@ defaults write org.robojackets.robocup.simulator NSAppSleepDisabled -bool YES
 echo "-- Updating submodules"
 git submodule sync
 git submodule update --init --recursive
+
+echo "----------------------------------------------------------------------------------------------------------------------------"
+echo "- NOTE: clang_format_10 is required so if you're using this then you probably need to edit osx-setup / install it manually -"
+echo "----------------------------------------------------------------------------------------------------------------------------"

--- a/util/ubuntu-packages.txt
+++ b/util/ubuntu-packages.txt
@@ -39,6 +39,7 @@ g++
 
 # C/C++ (and more) code-formatting tool
 clang-format
+clang-format-9
 
 # contains a ton of great C++ libraries
 libboost-all-dev

--- a/util/ubuntu-packages.txt
+++ b/util/ubuntu-packages.txt
@@ -38,7 +38,6 @@ clang
 g++
 
 # C/C++ (and more) code-formatting tool
-clang-format
 clang-format-10
 
 # contains a ton of great C++ libraries

--- a/util/ubuntu-packages.txt
+++ b/util/ubuntu-packages.txt
@@ -39,7 +39,7 @@ g++
 
 # C/C++ (and more) code-formatting tool
 clang-format
-clang-format-9
+clang-format-10
 
 # contains a ton of great C++ libraries
 libboost-all-dev

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -135,6 +135,12 @@ if $ADD_REPOS; then
     add-apt-repository -y ppa:ubuntu-toolchain-r/test
 fi
 
+# Add the llvm key
+# Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
+echo "Adding LLVM apt key"
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+echo "Done adding LLVM apt key"
+
 # Install clang-format-10 using llvm repo
 if [ "$SYSTEM" = "ubuntu-20.04" ]; then
     sudo add-apt-repository -s "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main"
@@ -143,12 +149,6 @@ elif [ "$SYSTEM" = "ubuntu-18.04" ]; then
 elif [ "$SYSTEM" = "ubuntu-16.04" ]; then
     sudo add-apt-repository -s "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
 fi
-
-# Add the llvm key
-# Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
-echo "Adding LLVM apt key"
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-echo "Done adding LLVM apt key"
 
 apt-get update
 

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -137,10 +137,8 @@ fi
 
 # Add the llvm key
 # Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
-echo "Adding LLVM apt key"
-apt-get install wget # Somehow we don't have wget
+apt-get install wget apt-transport-https ca-certificates # Somehow we don't have wget, and 16.04 doesn't support https lmao
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-echo "Done adding LLVM apt key"
 
 # Install clang-format-10 using llvm repo
 if [ "$SYSTEM" = "ubuntu-20.04" ]; then

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -156,16 +156,6 @@ fi
 
 PACKAGES="$(sed 's/#.*//;/^$/d' $BASE/util/ubuntu-packages.txt)"
 
-# install all of the packages listed in required_packages.txt
-apt-get install $ARGS $PACKAGES
-
-# Use ubuntu's 'update-alternatives' to select the newer compiler as the default
-# See issue #468 on GitHub
-# https://askubuntu.com/questions/466651/how-do-i-use-the-latest-gcc-on-ubuntu
-if [ "$SYSTEM" = "ubuntu-18.04" ] && ! command -v clang-format >/dev/null; then
-    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 100
-fi
-
 # Install clang-format-10 using llvm repo
 if [ "$SYSTEM" = "ubuntu-20.04" ]; then
     sudo add-apt-repository -s "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main"
@@ -174,9 +164,20 @@ elif [ "$SYSTEM" = "ubuntu-18.04" ]; then
 elif [ "$SYSTEM" = "ubuntu-16.04" ]; then
     sudo add-apt-repository -s "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
 fi
+
 # Add the llvm key
 # Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+
+# install all of the packages listed in required_packages.txt
+apt update && apt install $ARGS $PACKAGES
+
+# Use ubuntu's 'update-alternatives' to select the newer compiler as the default
+# See issue #468 on GitHub
+# https://askubuntu.com/questions/466651/how-do-i-use-the-latest-gcc-on-ubuntu
+if [ "$SYSTEM" = "ubuntu-18.04" ] && ! command -v clang-format >/dev/null; then
+    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 100
+fi
 
 # install python3 requirements
 pip3 install -r $BASE/util/requirements3.txt

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -101,7 +101,7 @@ done
 # Become root
 if [ $UID -ne 0 ]; then
 	echo "-- Becoming root"
-	exec sudo GOPATH=$GOPATH $0 $@
+	exec sudo $0 $@
 fi
 
 if $OVERWRITE_SOURCES; then
@@ -177,13 +177,6 @@ PACKAGES="$(sed 's/#.*//;/^$/d' $BASE/util/ubuntu-packages.txt)"
 
 # install all of the packages listed in required_packages.txt
 apt-get install $ARGS $PACKAGES
-
-# Use ubuntu's 'update-alternatives' to select the newer compiler as the default
-# See issue #468 on GitHub
-# https://askubuntu.com/questions/466651/how-do-i-use-the-latest-gcc-on-ubuntu
-if [ "$SYSTEM" = "ubuntu-18.04" ] && ! command -v clang-format >/dev/null; then
-    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 100
-fi
 
 # install python3 requirements
 pip3 install -r $BASE/util/requirements3.txt

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -167,13 +167,6 @@ pip3 install -r $BASE/util/requirements3.txt
 # install python2 requirements
 pip2 install -r $BASE/util/requirements2.txt
 
-# install stylize
-if [ -z "$GOPATH" ]; then
-    echo "[WARN] No GOPATH set, not installing stylize."
-else
-    go get gopkg.in/justbuchanan/stylize.v1
-fi
-
 # This script is run as sudo, but we don't want submodules to be owned by the
 # root user, so we use `su` to update submodules as the normal user
 SETUP_USER="$SUDO_USER"

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -135,6 +135,21 @@ if $ADD_REPOS; then
     add-apt-repository -y ppa:ubuntu-toolchain-r/test
 fi
 
+# Install clang-format-10 using llvm repo
+if [ "$SYSTEM" = "ubuntu-20.04" ]; then
+    sudo add-apt-repository -s "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main"
+elif [ "$SYSTEM" = "ubuntu-18.04" ]; then
+    sudo add-apt-repository -s "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
+elif [ "$SYSTEM" = "ubuntu-16.04" ]; then
+    sudo add-apt-repository -s "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
+fi
+
+# Add the llvm key
+# Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
+echo "Adding LLVM apt key"
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+echo "Done adding LLVM apt key"
+
 apt-get update
 
 MACH=$(uname -m)
@@ -156,23 +171,8 @@ fi
 
 PACKAGES="$(sed 's/#.*//;/^$/d' $BASE/util/ubuntu-packages.txt)"
 
-# Install clang-format-10 using llvm repo
-if [ "$SYSTEM" = "ubuntu-20.04" ]; then
-    sudo add-apt-repository -s "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main"
-elif [ "$SYSTEM" = "ubuntu-18.04" ]; then
-    sudo add-apt-repository -s "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
-elif [ "$SYSTEM" = "ubuntu-16.04" ]; then
-    sudo add-apt-repository -s "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
-fi
-
-# Add the llvm key
-# Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
-echo "Adding LLVM apt key"
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-echo "Done adding LLVM apt key"
-
 # install all of the packages listed in required_packages.txt
-apt update && apt install $ARGS $PACKAGES
+apt-get install $ARGS $PACKAGES
 
 # Use ubuntu's 'update-alternatives' to select the newer compiler as the default
 # See issue #468 on GitHub

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -49,6 +49,10 @@ elif cat /etc/os-release | grep -iq '^NAME=.*Ubuntu'; then # We are using a vers
         echo "Ubuntu 19.04 Detected..."
         SYSTEM="ubuntu-19.04"
         ADD_REPOS=false
+    elif cat /etc/os-release | grep -iq '^VERSION=.*20.04'; then # Using Ubuntu 20.04
+        echo "Ubuntu 20.04 Detected..."
+        SYSTEM="ubuntu-20.04"
+        ADD_REPOS=false
     else
         echo "$DISTRO_STR" >&2
         exit 1
@@ -161,6 +165,18 @@ apt-get install $ARGS $PACKAGES
 if [ "$SYSTEM" = "ubuntu-18.04" ] && ! command -v clang-format >/dev/null; then
     update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 100
 fi
+
+# Install clang-format-10 using llvm repo
+if [ "$SYSTEM" = "ubuntu-20.04" ]; then
+    sudo add-apt-repository -s "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main"
+elif [ "$SYSTEM" = "ubuntu-18.04" ]; then
+    sudo add-apt-repository -s "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
+elif [ "$SYSTEM" = "ubuntu-16.04" ]; then
+    sudo add-apt-repository -s "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
+fi
+# Add the llvm key
+# Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 
 # install python3 requirements
 pip3 install -r $BASE/util/requirements3.txt

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -143,7 +143,12 @@ fi
 
 # Add the llvm key
 # Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
-apt-get install $ARGS wget apt-transport-https ca-certificates # Somehow we don't have wget, and 16.04 doesn't support https lmao
+apt-get install $ARGS wget # Somehow we don't have wget
+
+# Somehow 16.04 doesn't support https
+if [ "$SYSTEM" = "ubuntu-16.04" ]; then
+  apt-get install $ARGS apt-transport-https
+fi
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
 # Install clang-format-10 using llvm repo
@@ -171,7 +176,7 @@ echo "-- Installing required packages"
 PACKAGES="$(sed 's/#.*//;/^$/d' $BASE/util/ubuntu-packages.txt)"
 
 # install all of the packages listed in required_packages.txt
-apt-get install $ARGS "$PACKAGES"
+apt-get install $ARGS $PACKAGES
 
 # Use ubuntu's 'update-alternatives' to select the newer compiler as the default
 # See issue #468 on GitHub

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -167,7 +167,9 @@ fi
 
 # Add the llvm key
 # Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+echo "Adding LLVM apt key"
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+echo "Done adding LLVM apt key"
 
 # install all of the packages listed in required_packages.txt
 apt update && apt install $ARGS $PACKAGES

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -135,9 +135,15 @@ if $ADD_REPOS; then
     add-apt-repository -y ppa:ubuntu-toolchain-r/test
 fi
 
+# if yes option is checked, add  a -y
+ARGS=""
+if $YES; then
+    ARGS="-y"
+fi
+
 # Add the llvm key
 # Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
-apt-get install wget apt-transport-https ca-certificates # Somehow we don't have wget, and 16.04 doesn't support https lmao
+apt-get install $ARGS wget apt-transport-https ca-certificates # Somehow we don't have wget, and 16.04 doesn't support https lmao
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
 # Install clang-format-10 using llvm repo
@@ -157,21 +163,15 @@ unset DPKG_FLAGS
 BASE=$(readlink -f $(dirname $0)/..)
 
 echo "-- Installing udev rules"
-cp -f $BASE/util/robocup.rules /etc/udev/rules.d/
+cp -f "$BASE"/util/robocup.rules /etc/udev/rules.d/
 udevadm control --reload || true # reload rules
 
 echo "-- Installing required packages"
 
-# if yes option is checked, add  a -y
-ARGS=""
-if $YES; then
-    ARGS="-y"
-fi
-
 PACKAGES="$(sed 's/#.*//;/^$/d' $BASE/util/ubuntu-packages.txt)"
 
 # install all of the packages listed in required_packages.txt
-apt-get install $ARGS $PACKAGES
+apt-get install $ARGS "$PACKAGES"
 
 # Use ubuntu's 'update-alternatives' to select the newer compiler as the default
 # See issue #468 on GitHub

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -138,6 +138,7 @@ fi
 # Add the llvm key
 # Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
 echo "Adding LLVM apt key"
+apt-get install wget # Somehow we don't have wget
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 echo "Done adding LLVM apt key"
 


### PR DESCRIPTION
## Description
`clang_format_6` is pretty retarded about c++17 attributes, ie. `[[nodiscard]]`:
```c++
    /**
     * Implicit conversion from Eigen::Vector3d
     */
    Pose(const Eigen::Vector3d& other)
        : _position(other(0), other(1)),
          _heading(other(2)){}

              /**
               * Compute the pose specified using this pose as coordinates in a
               * frame of reference specified by `other`, in the global space.
               *
               * i.e.
               *
               * x:
               *       |  x
               *       | /
               *       |/
               * ------|-------
               *       |
               *       |
               *       |
               *
               * y:
               *     |
               *     |
               * ----|----
               *     |\
               *     | y
               *
               * y.withOrigin(x):
               *       |  x
               *       | / \
               *       |/   y
               * ------|------
               *       |
               */
                  [[nodiscard]] Pose withOrigin(Pose other) const {
        Point rotated = position().rotated(other.heading());
        return other + Pose(rotated, heading());
    }
```

This PR:
1. Updates `make pretty-lines` and `make checkstyle-lines` to use `clang-format-9` instead of `clang-format` (which defaults to `clang-format-6` on 18.04)
2. Adds `clang-format-10` on `ubuntu-packages.txt`
3. Added llvm apt repository to the ubuntu setup script for `clang-format-10`

## Steps to test
### `[[nodiscard]]` is formatted properly on CI
1. Let CI run

Expected result: The addition of `[[nodiscard]]` to `Pose.hpp` shouldn't screw up the comment formatting, and it shouldn't error out because it can't find `clang-format-9`.