### PR TITLE
Hotfix/fsm types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,11 @@ jobs:
       - run: make test-soccer
       - run: make test-python
 
-  # FIXME: pylint is broken on 18.04
   python-static:
     <<: *dir
-    docker:
-      - image: robojackets/robocup-software:16
+    <<: *image
+#    docker:
+#      - image: robojackets/robocup-software:16
     steps:
       - checkout
       - <<: *install_deps

--- a/soccer/gameplay/fsm.py
+++ b/soccer/gameplay/fsm.py
@@ -18,7 +18,6 @@ StateMethod = Callable[[], None]  # Takes nothing, returns nothing
 OnEnterMethod = Callable[[], None]  # Takes nothing, returns nothing
 OnExitMethod = Callable[[], None]  # Takes nothing, returns nothing
 
-
 ## @brief generic hierarchial state machine class.
 #
 # states can have substates.  If the machine is in a state, then it is also implicitly in that state's parent state
@@ -77,7 +76,8 @@ class StateMachine:
             # transition if an 'event' fires
             next_states = []
             if self.state in self._transitions:
-                for next_state, transition in self._transitions[self.state].items():
+                for next_state, transition in self._transitions[
+                        self.state].items():
                     if transition['condition']():
                         next_states += [next_state]
 
@@ -110,8 +110,10 @@ class StateMachine:
         if from_state not in self._transitions:
             self._transitions[from_state] = {}
 
-        self._transitions[from_state][to_state] = {'condition': condition_fn,
-                                                   'name': event_name}
+        self._transitions[from_state][to_state] = {
+            'condition': condition_fn,
+            'name': event_name
+        }
 
     # sets @state to the new_state given
     # calls 'on_exit_STATENAME()' if it exists
@@ -119,7 +121,8 @@ class StateMachine:
     def transition(self, new_state: State) -> None:
         # print("TRANSITION: " + str(self.__class__.__name__) + ": " + str(self.state) + " -> " + str(new_state))
         if self.state is not None:
-            state_ancestors: List[State] = self.ancestors_of_state(self.state) + [self.state]
+            state_ancestors: List[State] = self.ancestors_of_state(
+                self.state) + [self.state]
             for state in state_ancestors:
                 if not self.state_is_substate(new_state, state):
                     method_name = "on_exit_" + state.name
@@ -131,7 +134,8 @@ class StateMachine:
                     if state_method is not None:
                         state_method()
 
-        new_state_ancestors: List[State] = self.ancestors_of_state(new_state) + [new_state]
+        new_state_ancestors: List[State] = self.ancestors_of_state(
+            new_state) + [new_state]
         for state in new_state_ancestors:
             if not self.state_is_substate(self.state, state):
                 # Somehow pylint is dying in the below statement even though the types are clear as day
@@ -150,7 +154,8 @@ class StateMachine:
     def is_in_state(self, state: State) -> bool:
         return self.state_is_substate(self.state, state)
 
-    def state_is_substate(self, state: Optional[State], possible_parent: State) -> bool:
+    def state_is_substate(self, state: Optional[State],
+                          possible_parent: State) -> bool:
         ancestor = state
         while ancestor is not None:
             if possible_parent == ancestor: return True
@@ -160,7 +165,8 @@ class StateMachine:
 
     # looks at the list @ancestors and returns the one that the current state is a descendant of
     # returns None if the current state doesn't descend from one in the list
-    def corresponding_ancestor_state(self, ancestors: Iterable[State]) -> Optional[State]:
+    def corresponding_ancestor_state(
+            self, ancestors: Iterable[State]) -> Optional[State]:
         state = self.state
         while state is not None:
             if state in ancestors:

--- a/soccer/gameplay/fsm.py
+++ b/soccer/gameplay/fsm.py
@@ -1,7 +1,23 @@
 import logging
 from enum import Enum
 import graphviz as gv
-from typing import Union, Callable
+from typing import Union, Callable, Dict, Optional, Iterable, List, Any
+
+State = Enum
+StateHierarchy = Dict[State, State]
+TransitionFunction = Callable[[None], bool]  # Takes no args, returns a bool
+
+# Rip TypedDict requires 3.8
+# class Event(TypedDict):
+#     condition: TransitionFunction
+#     name: str
+
+Event = Any
+TransitionTable = Dict[State, Dict[State, Event]]  # [from][to] = Event
+StateMethod = Callable[[None], None]  # Takes nothing, returns nothing
+OnEnterMethod = Callable[[None], None]  # Takes nothing, returns nothing
+OnExitMethod = Callable[[None], None]  # Takes nothing, returns nothing
+
 
 ## @brief generic hierarchial state machine class.
 #
@@ -15,15 +31,15 @@ from typing import Union, Callable
 #
 # Subclasses of StateMachine can optionally implement them and they will automatically be called at the appropriate times.
 class StateMachine:
-    def __init__(self, start_state):
+    def __init__(self, start_state: State):
         # stores all states in the form _state_hierarchy[state] = parent_state
-        self._state_hierarchy = {}
-        self._transitions = {}
-        self._start_state = start_state
-        self._state = None
+        self._state_hierarchy: StateHierarchy = {}
+        self._transitions: TransitionTable = {}
+        self._start_state: State = start_state
+        self._state: Optional[State] = None
 
     @property
-    def start_state(self) -> None:
+    def start_state(self) -> State:
         return self._start_state
 
     ## Resets the FSM back into the start state
@@ -31,7 +47,7 @@ class StateMachine:
         self.transition(self.start_state)
 
     ## Registers a new state (which can optionally be a substate of an existing state)
-    def add_state(self, state, parent_state=None):
+    def add_state(self, state: State, parent_state: Optional[State] = None):
         if not isinstance(state, Enum):
             raise TypeError("State should be an Enum type")
         self._state_hierarchy[state] = parent_state
@@ -40,7 +56,7 @@ class StateMachine:
     # checks transition conditions for all edges leading away from the current state
     # if one evaluates to true, we transition to it
     # if more than one evaluates to true, we throw a RuntimeError
-    def spin(self):
+    def spin(self) -> None:
         s1 = self.state
 
         # call execute_STATENAME
@@ -61,8 +77,7 @@ class StateMachine:
             # transition if an 'event' fires
             next_states = []
             if self.state in self._transitions:
-                for next_state, transition in self._transitions[
-                    self.state].items():
+                for next_state, transition in self._transitions[self.state].items():
                     if transition['condition']():
                         next_states += [next_state]
 
@@ -81,9 +96,9 @@ class StateMachine:
             StateMachine.spin(self)
 
     # if you add a transition that already exists, the old one will be overwritten
-    def add_transition(self, from_state, to_state,
-                       condition: Union[bool, Callable],
-                       event_name: str):
+    def add_transition(self, from_state: State, to_state: State,
+                       condition: Union[bool, TransitionFunction],
+                       event_name: str) -> None:
         if isinstance(condition, bool):
             condition = lambda: condition
 
@@ -96,7 +111,7 @@ class StateMachine:
     # sets @state to the new_state given
     # calls 'on_exit_STATENAME()' if it exists
     # calls 'on_enter_STATENAME()' if it exists
-    def transition(self, new_state):
+    def transition(self, new_state: State) -> None:
         # print("TRANSITION: " + str(self.__class__.__name__) + ": " + str(self.state) + " -> " + str(new_state))
         if self.state is not None:
             for state in self.ancestors_of_state(self.state) + [self.state]:
@@ -111,6 +126,7 @@ class StateMachine:
                         state_method()
 
         for state in self.ancestors_of_state(new_state) + [new_state]:
+            state: State
             if not self.state_is_substate(self.state, state):
                 method_name = "on_enter_" + state.name
                 state_method = None
@@ -124,10 +140,10 @@ class StateMachine:
         self._state = new_state
 
     # traverses the state hierarchy to see if it's in @state or one of @state's descendent states
-    def is_in_state(self, state):
+    def is_in_state(self, state: State) -> bool:
         return self.state_is_substate(self.state, state)
 
-    def state_is_substate(self, state, possible_parent):
+    def state_is_substate(self, state: State, possible_parent: State) -> bool:
         ancestor = state
         while ancestor is not None:
             if possible_parent == ancestor: return True
@@ -137,7 +153,7 @@ class StateMachine:
 
     # looks at the list @ancestors and returns the one that the current state is a descendant of
     # returns None if the current state doesn't descend from one in the list
-    def corresponding_ancestor_state(self, ancestors):
+    def corresponding_ancestor_state(self, ancestors: Iterable[State]) -> Optional[State]:
         state = self.state
         while state is not None:
             if state in ancestors:
@@ -149,7 +165,7 @@ class StateMachine:
     # returns a list of the ancestors of the given state
     # if B is a child state of A and C is a child state of B, ancestors_of_state(C) == [A, B]
     # if @state has no ancestors, returns an empty list
-    def ancestors_of_state(self, state):
+    def ancestors_of_state(self, state) -> List[State]:
         ancestors = []
         state = self._state_hierarchy[state]
         while state is not None:
@@ -158,7 +174,7 @@ class StateMachine:
         return ancestors
 
     # returns a graphviz.Digraph object
-    def as_graphviz(self):
+    def as_graphviz(self) -> gv.Digraph:
         g = gv.Digraph(self.__class__.__name__, format='png')
 
         cluster_index = 0
@@ -200,10 +216,10 @@ class StateMachine:
         return g
 
     # writes a png file of the graphviz output to the specified location
-    def write_diagram_png(self, filename: str):
+    def write_diagram_png(self, filename: str) -> None:
         g = self.as_graphviz()
         g.render(filename=filename, cleanup=True)
 
     @property
-    def state(self):
+    def state(self) -> Optional[State]:
         return self._state

--- a/soccer/gameplay/fsm.py
+++ b/soccer/gameplay/fsm.py
@@ -62,13 +62,13 @@ class StateMachine:
         if self.state is not None:
             for state in self.ancestors_of_state(self.state) + [self.state]:
                 method_name = "execute_" + state.name
-                state_method: Optional[StateMethod] = None
+                exec_callback: Optional[StateMethod] = None
                 try:
-                    state_method = getattr(self, method_name)
+                    exec_callback = getattr(self, method_name)
                 except AttributeError:
                     pass
-                if state_method is not None:
-                    state_method()
+                if exec_callback is not None:
+                    exec_callback()
 
         if self.state is None:
             self.transition(self.start_state)
@@ -123,13 +123,13 @@ class StateMachine:
             for state in state_ancestors:
                 if not self.state_is_substate(new_state, state):
                     method_name = "on_exit_" + state.name
-                    state_method: Optional[OnExitMethod] = None
+                    exit_callback: Optional[OnExitMethod] = None
                     try:
-                        state_method = getattr(self, method_name)  # call the transition FROM method if it exists
+                        exit_callback = getattr(self, method_name)  # call the transition FROM method if it exists
                     except AttributeError:
                         pass
-                    if state_method is not None:
-                        state_method()
+                    if exit_callback is not None:
+                        exit_callback()
 
         new_state_ancestors: List[State] = self.ancestors_of_state(
             new_state) + [new_state]
@@ -137,13 +137,13 @@ class StateMachine:
             if not self.state_is_substate(self.state, state):
                 # Somehow pylint is dying in the below statement even though the types are clear as day
                 method_name = "on_enter_" + state.name  # pylint: disable=no-member
-                state_method: Optional[OnEnterMethod] = None
+                enter_callback: Optional[OnEnterMethod] = None
                 try:
-                    state_method = getattr(self, method_name)  # call the transition TO method if it exists
+                    enter_callback = getattr(self, method_name)  # call the transition TO method if it exists
                 except AttributeError:
                     pass
-                if state_method is not None:
-                    state_method()
+                if enter_callback is not None:
+                    enter_callback()
 
         self._state = new_state
 

--- a/soccer/gameplay/fsm.py
+++ b/soccer/gameplay/fsm.py
@@ -62,7 +62,7 @@ class StateMachine:
         if self.state is not None:
             for state in self.ancestors_of_state(self.state) + [self.state]:
                 method_name = "execute_" + state.name
-                state_method = None
+                state_method: Optional[StateMethod] = None
                 try:
                     state_method = getattr(self, method_name)
                 except AttributeError:
@@ -123,7 +123,7 @@ class StateMachine:
             for state in state_ancestors:
                 if not self.state_is_substate(new_state, state):
                     method_name = "on_exit_" + state.name
-                    state_method = None
+                    state_method: Optional[OnExitMethod] = None
                     try:
                         state_method = getattr(self, method_name)  # call the transition FROM method if it exists
                     except AttributeError:
@@ -137,7 +137,7 @@ class StateMachine:
             if not self.state_is_substate(self.state, state):
                 # Somehow pylint is dying in the below statement even though the types are clear as day
                 method_name = "on_enter_" + state.name  # pylint: disable=no-member
-                state_method = None
+                state_method: Optional[OnEnterMethod] = None
                 try:
                     state_method = getattr(self, method_name)  # call the transition TO method if it exists
                 except AttributeError:

--- a/soccer/gameplay/fsm.py
+++ b/soccer/gameplay/fsm.py
@@ -125,7 +125,9 @@ class StateMachine:
                     method_name = "on_exit_" + state.name
                     exit_callback: Optional[OnExitMethod] = None
                     try:
-                        exit_callback = getattr(self, method_name)  # call the transition FROM method if it exists
+                        exit_callback = getattr(
+                            self, method_name
+                        )  # call the transition FROM method if it exists
                     except AttributeError:
                         pass
                     if exit_callback is not None:
@@ -139,7 +141,9 @@ class StateMachine:
                 method_name = "on_enter_" + state.name  # pylint: disable=no-member
                 enter_callback: Optional[OnEnterMethod] = None
                 try:
-                    enter_callback = getattr(self, method_name)  # call the transition TO method if it exists
+                    enter_callback = getattr(
+                        self, method_name
+                    )  # call the transition TO method if it exists
                 except AttributeError:
                     pass
                 if enter_callback is not None:

--- a/soccer/gameplay/fsm.py
+++ b/soccer/gameplay/fsm.py
@@ -100,10 +100,7 @@ class StateMachine:
                        condition: Union[bool, TransitionFunction],
                        event_name: str) -> None:
         if isinstance(condition, bool):
-            condition_bool: bool = cast(bool, condition)
-
-            def condition_fn() -> bool:
-                return condition_bool
+            condition_fn = lambda: condition
         else:
             condition_fn = condition
 


### PR DESCRIPTION
## Description
`pylint` is now broken on 16.04 after updating the docker image from the error, ie. see [here](https://app.circleci.com/pipelines/github/RoboJackets/robocup-software/136/workflows/d32174df-40c2-47aa-871f-5b6636c6c407/jobs/13040)
```
soccer/gameplay/fsm.py:115:44: E1101: Instance of 'list' has no 'name' member (no-member)
```

~This PR adds type information to `fsm.py` to fix this error~
nvm, now `mypy` is angry. This PR just adds a comment to disable that `pylint` from checking that line because `pylint` stills infers wrong types even after adding all the type information

## Steps to test
### Check CI

Expected result: CI doesn't break after running `pylint`