### PR TITLE
Added typing-extensions to requirements

### DIFF
--- a/util/requirements3.txt
+++ b/util/requirements3.txt
@@ -8,3 +8,4 @@ pylint # static checker for python
 mypy # static arugment checker
 
 yapf # python checker
+typing-extensions # For TypedDict


### PR DESCRIPTION
## Description
`typing-extensions` was missing from `requirements`

## Steps to test
### `typing-extensions` is installed
1. Run `ubuntu--setup`

Expectations: `typing-extensions` is installed if it isn't already installed