### PR TITLE
Changed logic to grsim config linking to check for existing files

### DIFF
--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -22,9 +22,6 @@ NO_SUBMODULES=false
 
 BASE=$(readlink -f $(dirname $0)/..)
 
-echo "-- Installing grSim default configuration"
-ln -vs "$BASE"/grsim.xml $HOME/.grsim.xml
-
 if cat /etc/os-release | grep -iq '^NAME=.*Debian'; then # dont add repositories on debian, unsupported
     echo "[WARN] You are using a flavor of debian. This configuration is not officially supported..." >&2
     SYSTEM="debian"
@@ -184,6 +181,20 @@ apt-get install $ARGS $PACKAGES
 # install python3 requirements
 pip3 install --upgrade pip
 pip3 install -r $BASE/util/requirements3.txt
+
+echo "-- Installing grSim default configuration"
+GRSIM_XML_INSTALL_LOCATION="$HOME/.grsim.xml"
+SOURCE_GRSIM_XML_LOCATION="$BASE"/grsim.xml
+
+if [ "$(readlink -f "$GRSIM_XML_INSTALL_LOCATION")" == "$SOURCE_GRSIM_XML_LOCATION" ]; then
+    echo "-- grSim default configuration is already installed! Doing nothing."
+else
+    if test -f "$GRSIM_XML_INSTALL_LOCATION"; then
+        echo "$HOME/.grsim.xml exists! Renaming it to grsim.xml.old..."
+        mv "$HOME/.grsim.xml" "$HOME/.grsim.xml.old"
+    fi
+    ln -vsf "$SOURCE_GRSIM_XML_LOCATION" "$GRSIM_XML_INSTALL_LOCATION"
+fi
 
 # This script is run as sudo, but we don't want submodules to be owned by the
 # root user, so we use `su` to update submodules as the normal user


### PR DESCRIPTION
## Description
This PR fixes #1452.

## Steps to test
### Test Case 1
1. Run `ubuntu-setup`

Expected result: It doesn't error out even if you already have ~/grsim.xml