### PR TITLE
Make diff checks operate against the most recent common ancestor.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       # Ensure latest deps are installed
       - <<: *install_deps
       - run: pip3 install --upgrade -r util/requirements3.txt
-      - run: git fetch origin && STYLIZE_DIFFBASE=origin/staging make checkstyle-lines
+      - run: git fetch origin && DIFFBRANCH=origin/staging make checkstyle-lines
       - store_artifacts:
           path: /tmp/clean.patch
 
@@ -87,7 +87,7 @@ jobs:
       - <<: *install_deps
       - <<: *load_workspace
       - run: |
-          STYLIZE_DIFFBASE=origin/staging make checktidy-lines
+          DIFFBRANCH=origin/staging make checktidy-lines
           cat /tmp/checktidy.patch
           if grep -q 'No relevant changes found' /tmp/checktidy.patch; then
             echo "No relevant changes found"

--- a/makefile
+++ b/makefile
@@ -157,13 +157,15 @@ apidocs:
 	cp doc/doxygen.css api_docs/html/
 	@echo "\n=> Open up 'api_docs/html/index.html' in a browser to view a local copy of the documentation"
 
-STYLIZE_DIFFBASE ?= staging
+# Find the most recent common ancestor. This prevents new commits on staging from registering as diffs.
+DIFFBRANCH ?= staging
+DIFFBASE ?= $(shell git merge-base $(DIFFBRANCH) HEAD)
 
 # check if everything in our codebase is in accordance with the style config defined in .clang-format
 # a nonzero exit code indicates that there's a formatting error somewhere
 checkstyle:
 	@printf "Run this command to reformat code if needed:\n\ngit apply <(curl -L $${LINK_PREFIX:-file://}clean.patch)\n\n"
-	@stylize.v1 --git_diffbase=$(STYLIZE_DIFFBASE) --patch_output "$${CIRCLE_ARTIFACTS:-.}/clean.patch"
+	@stylize.v1 --git_diffbase=$(DIFFBASE) --patch_output "$${CIRCLE_ARTIFACTS:-.}/clean.patch"
 
 CLANG_FORMAT_BINARY=clang-format-10
 CLANG_TIDY_BINARY=clang-tidy-10
@@ -176,8 +178,8 @@ else
 endif
 
 pretty-lines:
-	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/clang-format-diff.py -binary $(CLANG_FORMAT_BINARY) -i -p1
-	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/yapf-diff.py -style .style.yapf -i -p1
+	@git diff -U0 --no-color $(DIFFBASE) | python3 util/clang-format-diff.py -binary $(CLANG_FORMAT_BINARY) -i -p1
+	@git diff -U0 --no-color $(DIFFBASE) | python3 util/yapf-diff.py -style .style.yapf -i -p1
 
 tidy-lines:
 ifeq ("$(wildcard ./build/compile_commands.json)","")
@@ -185,12 +187,12 @@ ifeq ("$(wildcard ./build/compile_commands.json)","")
 	exit 1
 endif
 	@printf "Running clang-tidy-diff...\n"
-	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/clang-tidy-diff.py -clang-tidy-binary $(CLANG_TIDY_BINARY) -p1 -path build -j$(CORES)
+	@git diff -U0 --no-color $(DIFFBASE) | python3 util/clang-tidy-diff.py -clang-tidy-binary $(CLANG_TIDY_BINARY) -p1 -path build -j$(CORES)
 
 checkstyle-lines:
-	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/clang-format-diff.py -binary $(CLANG_FORMAT_BINARY) -p1 | tee /tmp/checkstyle.patch
-	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/yapf-diff.py -style .style.yapf -p1 | tee -a /tmp/checkstyle.patch
+	@git diff -U0 --no-color $(DIFFBASE) | python3 util/clang-format-diff.py -binary $(CLANG_FORMAT_BINARY) -p1 | tee /tmp/checkstyle.patch
+	@git diff -U0 --no-color $(DIFFBASE) | python3 util/yapf-diff.py -style .style.yapf -p1 | tee -a /tmp/checkstyle.patch
 	@bash -c '[[ ! "$$(cat /tmp/checkstyle.patch)" ]] || (echo "****************************** Checkstyle errors *******************************" && exit 1)'
 
 checktidy-lines:
-	@git diff -U0 --no-color $(STYLIZE_DIFFBASE) | python3 util/clang-tidy-diff.py -clang-tidy-binary $(CLANG_TIDY_BINARY) -p1 -path build -j$(CORES) > /tmp/checktidy.patch
+	@git diff -U0 --no-color $(DIFFBASE) | python3 util/clang-tidy-diff.py -clang-tidy-binary $(CLANG_TIDY_BINARY) -p1 -path build -j$(CORES) > /tmp/checktidy.patch


### PR DESCRIPTION
## Description
Use `git merge-base` to find the most recent common ancestor for diffing. This prevents it from registering new commits on the base branch as diffs in the new branch.

## Associated Issue
N/A

## Design Documents
N/A

## Steps to test
### Make checkstyle-lines
1. Branch A off of staging
2. Merge B into staging, with changes on previously incorrectly-formatted lines

Expected result: Branch A should pass CI. In addition, diffs from CI should always match local diffs.