### PR TITLE
Added pipefail to makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,3 +1,4 @@
+SHELL=/bin/bash -o pipefail
 MAKE_FLAGS = --no-print-directory
 TESTS = *
 FIRMWR_TESTS = -i2c -io-expander -fpga -piezo -neopixel -attiny -led -radio-sender -radio-receiver
@@ -64,7 +65,7 @@ run-sim-release: all-release backend-headless-simulator-soccer
 rsr: run-sim-release
 rrs: rsr
 rr: run-release
-view: 
+view:
 	./run/soccer -vlog $(file)
 
 # backend targets to launch soccer with grSim in headless


### PR DESCRIPTION
## Description
We didn't have `pipefail` set in our makefiles before, meaning that any commands that failed in a pipe would still succeed, important for things like CI linting, ie. see #1472 .

Note: Waiting on #1472 to update `clang-format-diff`

## Steps to test
### Style fails
1. Check CI: [here](https://app.circleci.com/pipelines/github/RoboJackets/robocup-software/217/workflows/e783c04f-2330-4a35-ac30-b2656fb06340/jobs/13405/steps)

Expected result: CI fails properly.