### PR TITLE
Increases FLOAT_EPSILON to 1e-4 to fix bug with floating point in Release

### DIFF
--- a/common/Geometry2d/Util.hpp
+++ b/common/Geometry2d/Util.hpp
@@ -34,7 +34,7 @@ static inline T sign(T f) {
 }
 
 // TODO(1485): Make this smaller once we figure out why test are failing in O3.
-//static const float FLOAT_EPSILON = 0.00001;
+// static const float FLOAT_EPSILON = 0.00001;
 static const float FLOAT_EPSILON = 1e-4;
 static bool nearlyEqual(float a, float b) {
     return std::fabs(a - b) < FLOAT_EPSILON;

--- a/common/Geometry2d/Util.hpp
+++ b/common/Geometry2d/Util.hpp
@@ -33,7 +33,9 @@ static inline T sign(T f) {
     return 0;
 }
 
-static const float FLOAT_EPSILON = 0.00001;
+// TODO(1485): Make this smaller once we figure out why test are failing in O3.
+//static const float FLOAT_EPSILON = 0.00001;
+static const float FLOAT_EPSILON = 1e-4;
 static bool nearlyEqual(float a, float b) {
     return std::fabs(a - b) < FLOAT_EPSILON;
 }


### PR DESCRIPTION
## Description
Temporarily increases `FLOAT_EPSILON` to `1e-4` so that tests don't fail when compiled in Release.

## Associated Issue
#1485 

## Design Documents
[Link](link-to-design-doc)

## Steps to test
### Build in Release
1. Run test

Expected result: Test doesn't fail.
