### PR TITLE
Pin mypy to 0.770 to avoid __init__.py bug

### DIFF
--- a/util/requirements3.txt
+++ b/util/requirements3.txt
@@ -5,7 +5,7 @@ watchdog # file-system event notifications
 munkres	# provides the 'hungarian algorithm', which we use for robot role assignment
 
 pylint # static checker for python
-mypy # static arugment checker
+mypy == 0.770 # static arugment checker. Pinned to 0.770 because something is broken with 0.780
 
 yapf # python checker
 typing-extensions # For TypedDict


### PR DESCRIPTION
## Description
`mypy` 0.780 errors out from error:
```
soccer/gameplay/timeout_behavior.py: error: Source file found twice under different module names: 'gameplay.main' and 'main'
Found 1 error in 1 file (checked 204 source files)
```

This is [this issue on mypy](https://github.com/python/mypy/issues/8944). On there, it is recommended that `mypy_path` should not point to a folder that has a `__init__.py` file to avoid ambiguous names.

This PR pins `mypy` to 0.770 to avoid this bug / error

## Steps to test
### `mypy` doesn't error out
1. Run `make mypy`
Expected result: No errors