### PR TITLE
[MP Rewrite Part 1] Break out and clean up BallState

### DIFF
--- a/soccer/Logger.cpp
+++ b/soccer/Logger.cpp
@@ -221,15 +221,15 @@ std::shared_ptr<Packet::LogFrame> Logger::createLogFrame(Context* context) {
     }
 
     // Ball
-    if (context->state.ball.valid) {
+    if (context->world_state.ball.visible) {
         log_frame->mutable_ball()->mutable_pos()->set_x(
-            static_cast<float>(context->state.ball.pos.x()));
+            static_cast<float>(context->world_state.ball.position.x()));
         log_frame->mutable_ball()->mutable_pos()->set_y(
-            static_cast<float>(context->state.ball.pos.y()));
+            static_cast<float>(context->world_state.ball.position.y()));
         log_frame->mutable_ball()->mutable_vel()->set_x(
-            static_cast<float>(context->state.ball.vel.x()));
+            static_cast<float>(context->world_state.ball.velocity.x()));
         log_frame->mutable_ball()->mutable_vel()->set_y(
-            static_cast<float>(context->state.ball.vel.y()));
+            static_cast<float>(context->world_state.ball.velocity.y()));
     }
 
     log_frame->set_manual_id(context->game_settings.joystick_config.manualID);

--- a/soccer/LoggerTest.cpp
+++ b/soccer/LoggerTest.cpp
@@ -16,14 +16,14 @@ TEST(Logger, SaveContext) {
     // It should save robot states, and their radio packets
     context.world_state.our_robots.at(0) =
         RobotState{Geometry2d::Pose(1, 2, 3), Geometry2d::Twist(4, 5, 6),
-                   start_time, true, true};
+                   start_time, true};
     context.robot_status.at(0).timestamp = start_time;
     context.robot_status.at(0).kicker = RobotStatus::KickerState::kCharged;
 
     // It should not save invisible robots though
     context.world_state.our_robots.at(1) =
         RobotState{Geometry2d::Pose(1, 2, 3), Geometry2d::Twist(4, 5, 6),
-                   start_time, false, true};
+                   start_time, false};
 
     // Or their radio packets
     context.robot_status.at(1).kicker = RobotStatus::KickerState::kFailed;
@@ -52,7 +52,7 @@ TEST(Logger, SerializeDeserialize) {
     RJ::Time start_time = RJ::now();
     context.world_state.our_robots.at(0) =
         RobotState{Geometry2d::Pose(1, 2, 3), Geometry2d::Twist(4, 5, 6),
-                   start_time, true, true};
+                   start_time, true};
     context.robot_status.at(0).timestamp = start_time;
     context.robot_status.at(0).kicker = RobotStatus::KickerState::kCharged;
 

--- a/soccer/Processor.cpp
+++ b/soccer/Processor.cpp
@@ -165,8 +165,9 @@ void Processor::runModels() {
 
     // Fill the list of our robots/balls based on whether we are the blue team
     // or not
-    _vision->fillBallState(_context.state);
-    _vision->fillRobotState(_context.state, _context.game_state.blueTeam);
+    _vision->fillBallState(&_context.world_state);
+    _vision->fillRobotState(&_context.world_state,
+                            _context.game_state.blueTeam);
 }
 
 /**

--- a/soccer/Processor.hpp
+++ b/soccer/Processor.hpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <vector>
 
+#include "Context.hpp"
 #include "GrSimCommunicator.hpp"
 #include "Node.hpp"
 #include "VisionReceiver.hpp"

--- a/soccer/Referee.cpp
+++ b/soccer/Referee.cpp
@@ -143,13 +143,13 @@ void Referee::setupRefereeMulticast() {
 
 void Referee::run() {
     _io_service.poll();
-    spinKickWatcher(_context->state);
+    spinKickWatcher(_context->world_state.ball);
     update();
 }
 
-void Referee::spinKickWatcher(const SystemState& system_state) {
+void Referee::spinKickWatcher(const BallState& ball) {
     /// Only run the kick detector when the ball is visible
-    if (!system_state.ball.valid) {
+    if (!ball.visible) {
         return;
     }
 
@@ -160,12 +160,12 @@ void Referee::spinKickWatcher(const SystemState& system_state) {
 
         case CapturePosition:
             // Do this in the processing thread
-            _readyBallPos = system_state.ball.pos;
+            _readyBallPos = ball.position;
             _kickDetectState = WaitForKick;
             break;
 
         case WaitForKick:
-            if (system_state.ball.pos.nearPoint(_readyBallPos, KickThreshold)) {
+            if (ball.position.nearPoint(_readyBallPos, KickThreshold)) {
                 return;
             }
             // The ball appears to have moved
@@ -178,7 +178,7 @@ void Referee::spinKickWatcher(const SystemState& system_state) {
                 std::chrono::duration_cast<std::chrono::milliseconds>(
                     RJ::Time() - _kickTime)
                     .count();
-            if (system_state.ball.pos.nearPoint(_readyBallPos, KickThreshold)) {
+            if (ball.position.nearPoint(_readyBallPos, KickThreshold)) {
                 // The ball is back where it was.  There was probably a
                 // vision error.
                 _kickDetectState = WaitForKick;

--- a/soccer/Referee.hpp
+++ b/soccer/Referee.hpp
@@ -106,7 +106,7 @@ protected:
 
     // Unconditional setter for the team color.
     void blueTeam(bool value) { _context->game_state.blueTeam = value; }
-    void spinKickWatcher(const SystemState& system_state);
+    void spinKickWatcher(const BallState& ball);
 
     enum KickDetectState {
         WaitForReady,

--- a/soccer/Robot.cpp
+++ b/soccer/Robot.cpp
@@ -1,4 +1,3 @@
-#include <execinfo.h>
 #include <protobuf/LogFrame.pb.h>
 
 #include <LogUtils.hpp>

--- a/soccer/SystemState.cpp
+++ b/soccer/SystemState.cpp
@@ -9,160 +9,12 @@
 #include <optional>
 
 #include "DebugDrawer.hpp"
-#include "planning/paths/Path.hpp"
+#include "planning/DynamicObstacle.hpp"
 
 using namespace Packet;
 using namespace std;
 using namespace Planning;
 using namespace Geometry2d;
-using Planning::MotionInstant;
-
-class BallPath : public Planning::Path {
-public:
-    BallPath(const Ball& ball) : ball(ball){};
-
-    bool hit(const Geometry2d::ShapeSet& /*obstacles*/,
-             RJ::Seconds /*startTimeIntoPath*/,
-             RJ::Seconds* /*hitTime*/) const override {
-        throw std::runtime_error("Unsupported Opperation");
-    }
-
-    void draw(DebugDrawer* /*constdebug_drawer*/,
-              const QColor& /*color*/ = Qt::black,
-              const QString& /*layer*/ = "Motion") const override {
-        throw std::runtime_error("Unsupported Opperation");
-    }
-
-    [[nodiscard]] RJ::Seconds getDuration() const override {
-        return RJ::Seconds::max();
-    }
-
-    [[nodiscard]] std::unique_ptr<Path> subPath(
-        RJ::Seconds /*startTime*/, RJ::Seconds /*endTime*/) const override {
-        throw std::runtime_error("Unsupported Operation");
-    }
-
-    [[nodiscard]] RobotInstant start() const override {
-        return RobotInstant(ball.predict(startTime()));
-    }
-    [[nodiscard]] RobotInstant end() const override {
-        throw std::runtime_error("Unsupported Operation");
-    }
-
-    [[nodiscard]] std::unique_ptr<Path> clone() const override {
-        return std::make_unique<BallPath>(*this);
-    }
-
-protected:
-    [[nodiscard]] std::optional<RobotInstant> eval(
-        RJ::Seconds t) const override {
-        return RobotInstant(ball.predict(startTime() + t));
-    }
-
-private:
-    const Ball& ball;
-};
-
-std::unique_ptr<Planning::Path> Ball::path(RJ::Time startTime) const {
-    auto path = std::make_unique<BallPath>(*this);
-    path->setStartTime(startTime);
-    return std::move(path);
-}
-
-constexpr auto ballDecayConstant = 0.180;
-
-Planning::MotionInstant Ball::predict(RJ::Time estimateTime) const {
-    if (estimateTime < time) {
-        // debugThrow("Estimated Time can't be before observation time.");
-        std::cout
-            << "CRITICAL ERROR: Estimated Time can't be before observation time"
-            << std::endl;
-        std::cout << "estimateTime: " << RJ::timestamp(estimateTime)
-                  << std::endl;
-        std::cout << "actualTime: " << RJ::timestamp(time) << std::endl;
-        estimateTime = time;
-
-        // return MotionInstant();
-    }
-
-    MotionInstant instant;
-    auto t = RJ::Seconds(estimateTime - time);
-
-    const auto s0 = vel.mag();
-
-    double speed = 0;
-    double distance = 0;
-    if (s0 != 0) {
-        auto maxTime = s0 / ballDecayConstant;
-        if (t.count() >= maxTime) {
-            speed = 0;
-            distance = s0 * maxTime - pow(maxTime, 2) / 2.0 * ballDecayConstant;
-        } else {
-            speed = s0 - (t.count() * ballDecayConstant);
-            distance = s0 * t.count() - pow(t.count(), 2) / 2.0 * ballDecayConstant;
-        }
-    } else {
-        speed = 0;
-        distance = 0;
-    }
-
-    // Based on sim ball
-    // v = v0 * e^-0.2913t
-    // d = v0 * -3.43289 (-1 + e^(-0.2913 t))
-    // auto part = std::exp(-0.2913f * t.count());
-    // auto speed = s0 * part;
-    // auto distance = s0 * -3.43289f * (part - 1.0f);
-
-    return MotionInstant(pos + vel.normalized(distance), vel.normalized(speed));
-}
-
-Geometry2d::Point Ball::predictPosition(double seconds_from_now) const {
-    const auto motionInstant = this->predict(RJ::now() + RJ::Seconds(seconds_from_now));
-    return motionInstant.pos;
-}
-
-RJ::Time Ball::estimateTimeTo(const Geometry2d::Point& point,
-                              Geometry2d::Point* nearPointOut) const {
-    Line line(pos, pos + vel);
-    auto nearPoint = line.nearestPoint(point);
-    if (nearPointOut != nullptr) {
-        *nearPointOut = nearPoint;
-    }
-    auto dist = nearPoint.distTo(pos);
-    // d = v0t - 1/2*t^2*Constant
-    // d = v0t - 1/2*t^2*Constant
-    // t = (v - sqrt(-2 C d + v^2))/C
-
-    auto v = vel.mag();
-    auto part = pow(v, 2) - 2 * ballDecayConstant * dist;
-    if (part > 0) {
-        auto t = (v - sqrt(part)) / ballDecayConstant;
-        return time + RJ::Seconds(t);
-    }
-    return RJ::Time::max();
-
-    // auto part = vel.mag() * -3.43289;
-}
-
-double Ball::estimateSecondsTo(const Geometry2d::Point& point) const {
-    const auto time = estimateTimeTo(point);
-    return RJ::Seconds(time - RJ::now()).count();
-}
-
-double Ball::predictSecondsToStop() const {
-    return vel.mag() / ballDecayConstant;
-}
-
-double Ball::estimateSecondsToDist(double dist) const {
-    auto v = vel.mag();
-    auto part = pow(v, 2) - 2 * ballDecayConstant * dist;
-    auto t = (vel.mag() - part) / ballDecayConstant;
-    if (part > 0) {
-        auto t = (v - sqrt(part)) / ballDecayConstant;
-        return t;
-    }
-    return std::numeric_limits<double>::infinity();
-}
 
 SystemState::SystemState(Context* const context) {
     // FIXME - boost::array?
@@ -173,6 +25,8 @@ SystemState::SystemState(Context* const context) {
         self[i] = new OurRobot(context, i);      // NOLINT
         opp[i] = new OpponentRobot(context, i);  // NOLINT
     }
+
+    ball = &(context->world_state.ball);
 }
 
 SystemState::~SystemState() {

--- a/soccer/SystemState.hpp
+++ b/soccer/SystemState.hpp
@@ -11,77 +11,33 @@
 #include <Geometry2d/Polygon.hpp>
 #include <Geometry2d/Segment.hpp>
 #include <Geometry2d/ShapeSet.hpp>
-#include <QColor>
-#include <QMap>
 #include <Utils.hpp>
-#include <memory>
-#include <string>
-#include <vector>
 
-#include "planning/MotionInstant.hpp"
-#include "planning/paths/Path.hpp"
+#include "planning/DynamicObstacle.hpp"
+#include "planning/Instant.hpp"
+#include "planning/Trajectory.hpp"
 
 class RobotConfig;
 class OurRobot;
 class OpponentRobot;
+class BallState;
 
 namespace Packet {
 class LogFrame;
 }  // namespace Packet
 
-/**
- * @brief Our beliefs about the ball's position and velocity
- */
-class Ball {
-public:
-    Geometry2d::Point pos;
-    Geometry2d::Point vel;
-    RJ::Time time;
-    bool valid = false;
-
-    [[nodiscard]] Planning::MotionInstant predict(RJ::Time estimateTime) const;
-    [[nodiscard]] Geometry2d::Point predictPosition(
-        double seconds_from_now) const;
-
-    [[nodiscard]] std::unique_ptr<Planning::Path> path(
-        RJ::Time startTime) const;
-
-    RJ::Time estimateTimeTo(const Geometry2d::Point& point,
-                            Geometry2d::Point* nearPointOut = nullptr) const;
-
-    [[nodiscard]] double estimateSecondsTo(
-        const Geometry2d::Point& point) const;
-
-    [[nodiscard]] double estimateSecondsToDist(double dist) const;
-
-    [[nodiscard]] double predictSecondsToStop() const;
-};
-
 class Context;
 
 /**
- * @brief Holds the positions of everything on the field
- * @details  this has the debugging drawer for the gui
- * but it also contains the game state, so this is passed game state information
- * contains essentially everything data wise
- * used in all threads, this is the class that is passed to for data
+ * @brief Holds helper objects for everything on the field. This is being phased
+ * out on the C++ side, but is still in use throughout the python side (which
+ * needs to access C++ helpers i.e. in the OurRobot class). This will be removed
+ * with the move to ROS.
  */
 class SystemState {
 public:
     SystemState(Context* const context);
     ~SystemState();
-
-    /**
-     * @defgroup drawing_functions Drawing Functions
-     * These drawing functions add certain shapes/lines to the current LogFrame.
-     * Each time the FieldView updates, it reads the LogFrame and draws these
-     * items.
-     * This way debug data can be drawn on-screen and also logged.
-     *
-     * Each drawing function also associates the drawn content with a particular
-     * 'layer'.  Separating drawing items into layers lets you choose at runtime
-     * which items actually get drawn.
-     */
 
     RJ::Time time;
 
@@ -103,7 +59,10 @@ public:
     std::vector<OurRobot*> self;
     std::vector<OpponentRobot*> opp;
 
-    Ball ball;
+    /**
+     * A reference to the ball state. This is a helper for python code.
+     */
+    BallState* ball;
 
     std::vector<int> ourValidIds();
 

--- a/soccer/WorldState.hpp
+++ b/soccer/WorldState.hpp
@@ -1,7 +1,13 @@
 #pragma once
 
-#include <Constants.hpp>
-#include <Geometry2d/Pose.hpp>
+#include "Constants.hpp"
+#include "Geometry2d/Pose.hpp"
+#include "planning/Instant.hpp"
+#include "planning/Trajectory.hpp"
+#include "time.hpp"
+
+// TODO(Kyle): Make this configurable
+constexpr double kBallDecayConstant = 0.180;
 
 /**
  * @brief Contains robot motion state data
@@ -14,12 +20,80 @@ struct RobotState {
     Geometry2d::Twist velocity;
     RJ::Time timestamp;
     bool visible = false;
-    bool velocity_valid = false;
 };
 
+/**
+ * Our belief about the ball's current position and velocity.
+ */
 struct BallState {
     Geometry2d::Point position;
     Geometry2d::Point velocity;
+    RJ::Time timestamp;
+    bool visible = false;
+
+    /**
+     * Default constructor: an invalid ball with visible=false.
+     */
+    BallState() = default;
+
+    /**
+     * Construct a BallState with a valid estimate.
+     */
+    BallState(Geometry2d::Point position, Geometry2d::Point velocity,
+              RJ::Time timestamp = RJ::now())
+        : position(position), velocity(velocity), timestamp(timestamp) {
+        visible = true;
+    }
+
+    /**
+     * Predict the ball's state at a particular instance in time.
+     * @param time the time at which to evaluate the ball's position.
+     * @return the ball's state.
+     */
+    [[nodiscard]] BallState predict_at(RJ::Time time) const;
+
+    /**
+     * Similar to \ref predict_at "predict_at(RJ::Time)", but for a duration in
+     * the future
+     */
+    [[nodiscard]] BallState predict_in(RJ::Seconds seconds) const;
+
+    /**
+     * Estimate the instant in time at which the ball will reach the given
+     * position (or the nearest point along the line of its path).
+     * @param near_to the query point
+     * @param out the nearest point to `near_to` along the path.
+     * @return the instant in time at which the ball is nearest to `near_to`.
+     */
+    [[nodiscard]] RJ::Time query_time_near(
+        Geometry2d::Point near_to, Geometry2d::Point* out = nullptr) const;
+
+    /**
+     * Similar to \ref predict_at "query_time_near(RJ::Time)", but for a
+     * duration in the future
+     */
+    [[nodiscard]] RJ::Seconds query_seconds_near(
+        Geometry2d::Point near_to, Geometry2d::Point* out = nullptr) const;
+
+    /**
+     * Predict the stop time of the ball.
+     * @param out will be filled with the stopping position,
+     *  if it is not nullptr.
+     * @return the duration until the ball stops.
+     */
+    [[nodiscard]] RJ::Seconds query_stop_time(
+        Geometry2d::Point* out = nullptr) const;
+
+    /**
+     * Query the time before the ball goes a certain distance.
+     */
+    [[nodiscard]] std::optional<RJ::Seconds> query_seconds_to_dist(
+        double distance) const;
+
+    /**
+     * Create a trajectory for the ball.
+     */
+    [[nodiscard]] Planning::Trajectory make_trajectory() const;
 };
 
 struct WorldState {
@@ -36,7 +110,7 @@ struct WorldState {
         }
     }
 
-    const RobotState& get_robot(bool ours, int shell) const {
+    [[nodiscard]] RobotState get_robot(bool ours, int shell) const {
         if (ours) {
             return our_robots.at(shell);
         } else {

--- a/soccer/gameplay/GameplayModule.cpp
+++ b/soccer/gameplay/GameplayModule.cpp
@@ -311,8 +311,8 @@ void Gameplay::GameplayModule::run() {
         cout << "Starting GameplayModule::run()" << endl;
     }
 
-    _ballMatrix =
-        Geometry2d::TransformMatrix::translate(_context->state.ball.pos);
+    _ballMatrix = Geometry2d::TransformMatrix::translate(
+        _context->world_state.ball.position);
 
     /// prepare each bot for the next iteration by resetting temporary things
     for (OurRobot* robot : _context->state.self) {
@@ -415,9 +415,10 @@ void Gameplay::GameplayModule::run() {
     PyGILState_Release(state);
 
     /// visualize
-    if (_context->game_state.stayAwayFromBall() && _context->state.ball.valid) {
+    if (_context->game_state.stayAwayFromBall() &&
+        _context->world_state.ball.visible) {
         _context->debug_drawer.drawCircle(
-            _context->state.ball.pos,
+            _context->world_state.ball.position,
             Field_Dimensions::Current_Dimensions.CenterRadius(), Qt::black,
             "Rules");
     }

--- a/soccer/planning/DynamicObstacle.hpp
+++ b/soccer/planning/DynamicObstacle.hpp
@@ -1,54 +1,13 @@
 #pragma once
-
-#include <Geometry2d/Point.hpp>
 #include <Geometry2d/Circle.hpp>
-#include "planning/MotionInstant.hpp"
-#include "Utils.hpp"
-#include "Geometry2d/Shape.hpp"
+#include <memory>
 
 namespace Planning {
-
-class Path;
-
-/*
- * This is a superclass for different MotionCommands.
- * Currently implemented are PathTarget, WorldVel, Pivot, DirectPathtarget, None
- */
-class DynamicObstacle {
-private:
-    const Path* const path;
-    const float radius;
-    const Geometry2d::Point staticPoint;
-    const std::shared_ptr<Geometry2d::Circle> staticObstacle;
-
-public:
-    DynamicObstacle(Geometry2d::Point staticPoint, float radius,
-                    const Path* path = nullptr)
-        : staticPoint(staticPoint),
-          path(path),
-          radius(radius),
-          staticObstacle(
-              std::make_shared<Geometry2d::Circle>(staticPoint, radius)) {}
-
-    DynamicObstacle(Geometry2d::Circle circle)
-        : staticPoint(circle.center),
-          path(nullptr),
-          radius(circle.radius()),
-          staticObstacle(std::make_shared<Geometry2d::Circle>(circle)) {}
-
-    DynamicObstacle(const Path* path, float radius);
-
-    virtual ~DynamicObstacle() = default;
-
-    bool hasPath() const { return path != nullptr; }
-
-    const Path* getPath() const { return path; }
-
-    // Radius = radius of obstacle
-    float getRadius() const { return radius; }
-
-    std::shared_ptr<Geometry2d::Circle> getStaticObstacle() const {
-        return staticObstacle;
-    }
+class Trajectory;
+struct DynamicObstacle {
+    DynamicObstacle(const Geometry2d::Circle& circle, const Trajectory* path)
+        : circle(circle), path(path) {}
+    Geometry2d::Circle circle;
+    const Trajectory* path;
 };
 }  // namespace Planning

--- a/soccer/ui/MainWindow.cpp
+++ b/soccer/ui/MainWindow.cpp
@@ -896,7 +896,7 @@ void MainWindow::on_actionStopBall_triggered() {
         simPacket.mutable_replacement()->mutable_ball();
 
     Geometry2d::Point ballPos =
-        _ui.fieldView->getTeamToWorld() * state()->ball.pos;
+        _ui.fieldView->getTeamToWorld() * state()->ball->position;
     ball_replace->set_x(ballPos.x());
     ball_replace->set_y(ballPos.y());
     ball_replace->set_vx(0);

--- a/soccer/vision/VisionFilter.cpp
+++ b/soccer/vision/VisionFilter.cpp
@@ -28,33 +28,31 @@ void VisionFilter::addFrames(const std::vector<CameraFrame>& frames) {
     frameBuffer.insert(frameBuffer.end(), frames.begin(), frames.end());
 }
 
-void VisionFilter::fillBallState(SystemState& state) {
+void VisionFilter::fillBallState(WorldState* state) {
     std::lock_guard<std::mutex> lock(worldLock);
     const WorldBall& wb = world.getWorldBall();
 
     if (wb.getIsValid()) {
-        state.ball.valid = true;
-        state.ball.pos = wb.getPos();
-        state.ball.vel = wb.getVel();
-        state.ball.time = wb.getTime();
+        state->ball.visible = true;
+        state->ball.position = wb.getPos();
+        state->ball.velocity = wb.getVel();
+        state->ball.timestamp = wb.getTime();
     } else {
-        state.ball.valid = false;
+        state->ball.visible = false;
     }
 }
 
-void VisionFilter::fillRobotState(SystemState& state, bool usBlue) {
+void VisionFilter::fillRobotState(WorldState* state, bool usBlue) {
     std::lock_guard<std::mutex> lock(worldLock);
     const auto& ourWorldRobot = usBlue ? world.getRobotsBlue() : world.getRobotsYellow();
     const auto& oppWorldRobot = usBlue ? world.getRobotsYellow() : world.getRobotsBlue();
 
     // Fill our robots
     for (int i = 0; i < Num_Shells; i++) {
-        OurRobot* robot = state.self.at(i);
         const WorldRobot& wr = ourWorldRobot.at(i);
 
         RobotState robot_state;
         robot_state.visible = wr.getIsValid();
-        robot_state.velocity_valid = wr.getIsValid();
 
         if (wr.getIsValid()) {
             robot_state.pose = Geometry2d::Pose(wr.getPos(), wr.getTheta());
@@ -63,17 +61,15 @@ void VisionFilter::fillRobotState(SystemState& state, bool usBlue) {
             robot_state.timestamp = wr.getTime();
         }
 
-        robot->mutable_state() = robot_state;
+        state->our_robots.at(i) = robot_state;
     }
 
     // Fill opp robots
     for (int i = 0; i < Num_Shells; i++) {
-        OpponentRobot* robot = state.opp.at(i);
         const WorldRobot& wr = oppWorldRobot.at(i);
 
         RobotState robot_state;
         robot_state.visible = wr.getIsValid();
-        robot_state.velocity_valid = wr.getIsValid();
 
         if (wr.getIsValid()) {
             robot_state.pose = Geometry2d::Pose(wr.getPos(), wr.getTheta());
@@ -82,7 +78,7 @@ void VisionFilter::fillRobotState(SystemState& state, bool usBlue) {
             robot_state.timestamp = wr.getTime();
         }
 
-        robot->mutable_state() = robot_state;
+        state->their_robots.at(i) = robot_state;
     }
 }
 

--- a/soccer/vision/VisionFilter.hpp
+++ b/soccer/vision/VisionFilter.hpp
@@ -1,12 +1,10 @@
 #pragma once
 
+#include <WorldState.hpp>
 #include <atomic>
 #include <mutex>
-#include <vector>
-#include <vector>
 #include <thread>
-
-#include <SystemState.hpp>
+#include <vector>
 
 #include "vision/camera/CameraFrame.hpp"
 #include "vision/camera/World.hpp"
@@ -41,7 +39,7 @@ public:
      *
      * @param state Current system state pointer
      */
-    void fillBallState(SystemState& state);
+    void fillBallState(WorldState* state);
 
     /**
      * Fills system state with the robots pos/vel
@@ -49,7 +47,7 @@ public:
      * @param state Current system state pointer
      * @param usBlue True if we are blue
      */
-    void fillRobotState(SystemState& state, bool usBlue);
+    void fillRobotState(WorldState* state, bool usBlue);
 
 private:
     void updateLoop();


### PR DESCRIPTION
This substantially cleans up the ball state code, and moves it from
`SystemState` (which we are moving away from in general) to `WorldState`
(which is restricted to physics-only information.

This is not expected to pass CI.