### PR TITLE
Revert "Remove old PR template"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Description
+Describe your pull request.
+
+## Associated Issue
+Issue #???
+
+## Design Documents
+[Link](link-to-design-doc)
+
+## Steps to test
+### Test Case 1
+1. Step 1
+2. Step 2
+3. Step 3
+
+Expected result: ???
+
+## (Optional) Sub-issues (for drafts)
+_Note: if you find yourself breaking this PR into many smaller features, it may make sense to break up the PR into logical units based on these features._
+- [ ] Step 1
+- [ ] Step 2


### PR DESCRIPTION
Reverts RoboJackets/robocup-software#1508.

Apparently we need a single default template (:cry:) and the rest are optional and can only be accessed using links, i.e. https://github.com/robojackets/robocup-software/compare/master...staging?quick_pull=1&template=minor_change.md

https://stackoverflow.com/questions/52139192/github-pull-requests-template-not-showing/52139815