### PR TITLE
build + install ROSIDL stuff at configure time so that cross-package dependencies work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,3 +93,9 @@ install(DIRECTORY launch
 install(FILES
         external/sdlcontrollerdb/gamecontrollerdb.txt
         DESTINATION share/${CMAKE_PROJECT_NAME})
+
+#======================================================================
+# Ament packaging
+#======================================================================
+find_package(ament_cmake REQUIRED)
+ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,10 +64,16 @@ endif()
 #======================================================================
 # Subdirectories
 #======================================================================
+include(AddROSIDLSubdirectory)
+
+# First call add_idl_subdirectory on all ROSIDL subdirectories.
+# This will build + install them at configure time so that find_package will work on them.
+add_rosidl_subdirectory(rj_geometry_msgs)
+add_rosidl_subdirectory(rj_msgs)
+
+
 # This is manually topologically sorted because we're not using colcon
 add_subdirectory(external)
-add_subdirectory(rj_geometry_msgs)
-add_subdirectory(rj_msgs)
 add_subdirectory(rj_protos)
 add_subdirectory(rj_constants)
 add_subdirectory(rj_utils)

--- a/Geometry2d/CMakeLists.txt
+++ b/Geometry2d/CMakeLists.txt
@@ -9,6 +9,7 @@ project(geometry2d LANGUAGES CXX)
 #======================================================================
 find_package(Eigen3 REQUIRED)
 find_package(Qt5 COMPONENTS Core REQUIRED)
+find_package(rj_geometry_msgs REQUIRED)
 
 #======================================================================
 # Define Targets
@@ -48,8 +49,7 @@ target_link_libraries(geometry2d
     ${GEOMETRY2D_DEPS_SYSTEM_LIBRARIES}
     ${GEOMETRY2D_DEPS_LIBRARIES})
 
-include(ROSIDLUtils)
-rosidl_target_link_interfaces(geometry2d PUBLIC rj_geometry_msgs)
+ament_target_dependencies(geometry2d PUBLIC rj_geometry_msgs)
 
 #======================================================================
 # Testing

--- a/cmake/AddROSIDLSubdirectory.cmake
+++ b/cmake/AddROSIDLSubdirectory.cmake
@@ -1,0 +1,32 @@
+#
+# A version of add_subdirectory() that is specialized for ROS2 packages that only contain message files.
+# Instead of performing a normal add_subdirectory(), add_rosidl_subdirectory() will build and install the subdirectory
+# at CONFIG time instead of BUILD / INSTALL time, so that dependents of that subdirectory are able to call
+# find_package successfully.
+#
+function(add_rosidl_subdirectory subdirectory)
+    # First create the subdirectory in the build folder
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${subdirectory})
+
+    # Command for configuring the cmake project inside the subdirectory
+    set(configure_command ${CMAKE_COMMAND}
+        -S ${CMAKE_CURRENT_SOURCE_DIR}/${subdirectory}
+        -B ${CMAKE_CURRENT_BINARY_DIR}/${subdirectory}
+        -G ${CMAKE_GENERATOR}
+        -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+
+    set(build_and_install_command ${CMAKE_COMMAND}
+        --build ${CMAKE_CURRENT_BINARY_DIR}/${subdirectory}
+        --target install)
+
+    # Then call cmake on the subdirectory
+    execute_process(COMMAND ${configure_command})
+
+    # Finally build + install it
+    execute_process(COMMAND ${build_and_install_command})
+
+    # Also create a target so that it will be invoked on all builds (This is what rosidl_generate_interfaces also does
+    # internally).
+    add_custom_target(${subdirectory} ALL
+        COMMAND ${build_and_install_command})
+endfunction()

--- a/rj_common/CMakeLists.txt
+++ b/rj_common/CMakeLists.txt
@@ -9,6 +9,7 @@ project(rj_common LANGUAGES CXX)
 #======================================================================
 find_package(Qt5 COMPONENTS Core Network Widgets REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rj_msgs REQUIRED)
 
 #======================================================================
 # Define Targets
@@ -53,9 +54,7 @@ target_link_libraries(rj_common
     ${RJ_COMMON_DEPS_SYSTEM_LIBRARIES}
     ${RJ_COMMON_DEPS_LIBRARIES})
 
-ament_target_dependencies(rj_common PUBLIC rclcpp)
-include(ROSIDLUtils)
-rosidl_target_link_interfaces(rj_common PRIVATE rj_msgs)
+ament_target_dependencies(rj_common PUBLIC rclcpp rj_msgs)
 
 #======================================================================
 # Packaging

--- a/rj_config/CMakeLists.txt
+++ b/rj_config/CMakeLists.txt
@@ -8,6 +8,7 @@ project(rj_config)
 # Find package
 #======================================================================
 find_package(rclcpp REQUIRED)
+find_package(rj_msgs REQUIRED)
 
 #======================================================================
 # Define Targets
@@ -47,12 +48,8 @@ target_link_libraries(config_server
     PRIVATE
     ${RJ_CONFIG_DEPS_LIBRARIES})
 
-ament_target_dependencies(config_client PUBLIC rclcpp)
-ament_target_dependencies(config_server PUBLIC rclcpp)
-
-include(ROSIDLUtils)
-rosidl_target_link_interfaces(config_client PUBLIC rj_msgs)
-rosidl_target_link_interfaces(config_server PRIVATE rj_msgs)
+ament_target_dependencies(config_client PUBLIC rclcpp rj_msgs)
+ament_target_dependencies(config_server PUBLIC rclcpp rj_msgs)
 
 #======================================================================
 # Packaging

--- a/rj_utils/CMakeLists.txt
+++ b/rj_utils/CMakeLists.txt
@@ -8,6 +8,7 @@ project(rj_utils LANGUAGES CXX)
 # Find package
 #======================================================================
 find_package(rclcpp REQUIRED)
+find_package(rj_msgs REQUIRED)
 
 #======================================================================
 # Define Targets
@@ -33,10 +34,7 @@ set(RJ_UTILS_DEPS_LIBRARIES
 #======================================================================
 target_include_directories(rj_utils PUBLIC ${RJ_UTILS_DEPS_INCLUDE_DIRS})
 target_link_libraries(rj_utils PUBLIC ${RJ_UTILS_DEPS_LIBRARIES})
-ament_target_dependencies(rj_utils PUBLIC rclcpp)
-
-include(ROSIDLUtils)
-rosidl_target_link_interfaces(rj_utils PUBLIC rj_msgs)
+ament_target_dependencies(rj_utils PUBLIC rclcpp rj_msgs)
 
 #======================================================================
 # Packaging

--- a/rj_utils/CMakeLists.txt
+++ b/rj_utils/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(rj_msgs REQUIRED)
 #======================================================================
 # Define Targets
 #======================================================================
-add_library(rj_utils)
+add_library(rj_utils STATIC)
 
 # position-independent-code flag
 target_compile_options(rj_utils PRIVATE "-fPIC")
@@ -41,3 +41,9 @@ ament_target_dependencies(rj_utils PUBLIC rclcpp rj_msgs)
 #======================================================================
 install(DIRECTORY include/
     DESTINATION include/)
+
+install( TARGETS rj_utils
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    )

--- a/rj_vision_receiver/CMakeLists.txt
+++ b/rj_vision_receiver/CMakeLists.txt
@@ -9,6 +9,7 @@ project(rj_vision_receiver)
 #======================================================================
 find_package(rclcpp REQUIRED)
 find_package(Boost REQUIRED)
+find_package(rj_msgs REQUIRED)
 
 #======================================================================
 # Define Targets
@@ -42,10 +43,7 @@ target_link_libraries(vision_receiver
     PRIVATE
     ${RJ_VISION_RECEIVER_DEPS_LIBRARIES})
 
-ament_target_dependencies(vision_receiver PUBLIC rclcpp)
-
-include(ROSIDLUtils)
-rosidl_target_link_interfaces(vision_receiver PRIVATE rj_msgs)
+ament_target_dependencies(vision_receiver PUBLIC rclcpp rj_msgs)
 
 #======================================================================
 # Packaging


### PR DESCRIPTION
## Description
This PR creates `cmake/AddROSIDLSubdirectory.cmake` which builds + installs things at configure time, so that `find_package()` of things like ROSIDL messages work.

## Steps to test
### Everything still works
1. Follow the same steps as in #1527

Expected result: Everything still works.
