### PR TITLE
[MP Rewrite Part 13] Stop play fixes and holding trajectory

### DIFF
--- a/soccer/gameplay/skills/move.py
+++ b/soccer/gameplay/skills/move.py
@@ -51,6 +51,10 @@ class Move(single_robot_behavior.SingleRobotBehavior):
         if self.pos != None:
             self.robot.move_to(self.pos)
 
+    def execute_completed(self):
+        if self.pos != None:
+            self.robot.move_to(self.pos)
+
     def role_requirements(  # type: ignore
             self) -> role_assignment.RoleRequirements:
         reqs = super().role_requirements()

--- a/soccer/gameplay/tactics/stopped/circle_near_ball.py
+++ b/soccer/gameplay/tactics/stopped/circle_near_ball.py
@@ -157,5 +157,5 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
         # set robot attributes
         for b in self.all_subbehaviors():
             if b.robot is not None:
-                b.robot.set_avoid_ball_radius(constants.Field.CenterRadius)
+                b.robot.add_local_obstacle(robocup.Circle(main.ball().pos, constants.Field.CenterRadius))
                 b.robot.face(main.ball().pos)

--- a/soccer/gameplay/tactics/stopped/circle_near_ball.py
+++ b/soccer/gameplay/tactics/stopped/circle_near_ball.py
@@ -157,5 +157,7 @@ class CircleNearBall(composite_behavior.CompositeBehavior):
         # set robot attributes
         for b in self.all_subbehaviors():
             if b.robot is not None:
-                b.robot.add_local_obstacle(robocup.Circle(main.ball().pos, constants.Field.CenterRadius))
+                b.robot.add_local_obstacle(
+                    robocup.Circle(main.ball().pos,
+                                   constants.Field.CenterRadius))
                 b.robot.face(main.ball().pos)

--- a/soccer/planning/Trajectory.cpp
+++ b/soccer/planning/Trajectory.cpp
@@ -241,6 +241,22 @@ bool Trajectory::nearly_equal(const Trajectory& a, const Trajectory& b,
     // Otherwise, they are identical.
     return a_it == a.instants_end() && b_it == b.instants_end();
 }
+void Trajectory::HoldFor(RJ::Seconds duration) {
+    RobotInstant instant = last();
+    if (duration <= RJ::Seconds(0)) {
+        throw std::invalid_argument("Hold duration must be positive");
+    }
+
+    if (!Twist::nearly_equals(instant.velocity, Twist::Zero())) {
+        throw std::runtime_error("Cannot hold nonzero velocity");
+    }
+
+    instant.velocity = Twist::Zero();
+    instant.stamp = instant.stamp + duration;
+
+    // Does not invalidate angle planning.
+    instants_.push_back(instant);
+}
 
 Trajectory::Cursor::Cursor(const Trajectory& trajectory,
                            RobotInstantSequence::const_iterator iterator)

--- a/soccer/planning/Trajectory.hpp
+++ b/soccer/planning/Trajectory.hpp
@@ -66,6 +66,15 @@ public:
     void AppendInstant(RobotInstant instant);
 
     /**
+     * @brief Hold the final position for a set time.
+     *
+     * Note that this will not hold forever. That would be bad, because iterating over a trajectory would always hang.
+     *
+     * @param seconds the duration after the end of the trajectory to hold pose.
+     */
+    void HoldFor(RJ::Seconds duration);
+
+    /**
      * @brief Check that the given point in time is within bounds.
      */
     [[nodiscard]] bool CheckTime(RJ::Time time) const;

--- a/soccer/planning/Trajectory.hpp
+++ b/soccer/planning/Trajectory.hpp
@@ -68,7 +68,8 @@ public:
     /**
      * @brief Hold the final position for a set time.
      *
-     * Note that this will not hold forever. That would be bad, because iterating over a trajectory would always hang.
+     * Note that this will not hold forever. That would be bad, because
+     * iterating over a trajectory would always hang.
      *
      * @param seconds the duration after the end of the trajectory to hold pose.
      */

--- a/soccer/planning/planner/PathTargetPlanner.cpp
+++ b/soccer/planning/planner/PathTargetPlanner.cpp
@@ -43,8 +43,9 @@ Trajectory PathTargetPlanner::plan(const PlanRequest& request) {
     Trajectory trajectory = Replanner::CreatePlan(
         Replanner::PlanParams{request.start, goalInstant, static_obstacles,
                               dynamic_obstacles, request.constraints,
-                              angle_function},
+                              angle_function, RJ::Seconds(3.0)},
         std::move(previous));
+
     previous = trajectory;
     return trajectory;
 }

--- a/soccer/planning/planner/PivotPathPlanner.cpp
+++ b/soccer/planning/planner/PivotPathPlanner.cpp
@@ -82,11 +82,8 @@ Trajectory PivotPathPlanner::plan(const PlanRequest& request) {
     Trajectory path =
         ProfileVelocity(pathBezier, start_instant.linear_velocity().mag(), 0,
                         linear_constraints, start_instant.stamp);
-    {
-        // Stay in place
-        RobotInstant instant = path.last();
-        instant.stamp = instant.stamp + RJ::Seconds(5.0);
-        path.AppendInstant(instant);
+    if (Twist::nearly_equals(path.last().velocity, Twist::Zero())) {
+        path.HoldFor(RJ::Seconds(3.0));
     }
 
     AngleFunction function = [pivot_point, pivot_target](

--- a/soccer/planning/planner/PlanRequest.hpp
+++ b/soccer/planning/planner/PlanRequest.hpp
@@ -22,7 +22,7 @@ namespace Planning {
  * robot path to be planned.
  */
 struct PlanRequest {
-    PlanRequest(RobotInstant start, MotionCommand command,
+    PlanRequest(RobotInstant start, MotionCommand command, // NOLINT
                 RobotConstraints constraints,
                 Geometry2d::ShapeSet field_obstacles,
                 Geometry2d::ShapeSet virtual_obstacles,

--- a/soccer/planning/planner/PlanRequest.hpp
+++ b/soccer/planning/planner/PlanRequest.hpp
@@ -22,7 +22,7 @@ namespace Planning {
  * robot path to be planned.
  */
 struct PlanRequest {
-    PlanRequest(RobotInstant start, MotionCommand command, // NOLINT
+    PlanRequest(RobotInstant start, MotionCommand command,  // NOLINT
                 RobotConstraints constraints,
                 Geometry2d::ShapeSet field_obstacles,
                 Geometry2d::ShapeSet virtual_obstacles,

--- a/soccer/planning/primitives/Replanner.cpp
+++ b/soccer/planning/primitives/Replanner.cpp
@@ -21,7 +21,8 @@ ConfigDouble* Replanner::_offPathErrorThreshold;
 REGISTER_CONFIGURABLE(Replanner);
 
 void applyHold(Trajectory* trajectory, std::optional<RJ::Seconds> hold_time) {
-    if (hold_time.has_value() && !trajectory->empty() && Twist::nearly_equals(trajectory->last().velocity, Twist::Zero())) {
+    if (hold_time.has_value() && !trajectory->empty() &&
+        Twist::nearly_equals(trajectory->last().velocity, Twist::Zero())) {
         trajectory->HoldFor(hold_time.value());
     }
 }

--- a/soccer/planning/primitives/Replanner.hpp
+++ b/soccer/planning/primitives/Replanner.hpp
@@ -25,6 +25,7 @@ public:
         const std::vector<DynamicObstacle>& dynamic_obstacles;
         RobotConstraints constraints;
         const AngleFunction& angle_function;
+        std::optional<RJ::Seconds> hold_time = std::nullopt;
     };
 
     /**


### PR DESCRIPTION
## Description
Hold position at the end of the trajectory. This prevents "jumpy" behavior (also change the default move behavior to respect the planner's new requirement for the command to be newly set each frame).

Make a local obstacle for the ball in planning for each of the robots.