### PR TITLE
Set default build type to relwithdebinfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,7 @@ if(NOT NO_WALL AND CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Cl
 endif()
 
 # Set a default build type if none was specified
-set(default_build_type "Release")
-if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
-    set(default_build_type "RelWithDebInfo")
-endif()
+set(default_build_type "RelWithDebInfo")
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     message(STATUS "Setting build type to '${default_build_type}' as none was specified.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,21 @@ if(NOT NO_WALL AND CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Cl
     add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# Set a default build type if none was specified
+set(default_build_type "Release")
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    set(default_build_type "RelWithDebInfo")
+endif()
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+        STRING "Choose the type of build." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+        "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 #======================================================================
 # CMake things
 #======================================================================


### PR DESCRIPTION
## Description
Fixes another performance issue that was noticed in #1543 by ensuring that we default to `RelWithDebInfo` if no build type is specified.