### PR TITLE
All style things. Part 1 - Config files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,25 @@
-external/style-configs/.clang-format
+---
+BasedOnStyle: Google
+DerivePointerAlignment: false
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+AccessModifierOffset: -4
+SpaceAfterCStyleCast: false
+
+SortIncludes: true
+IncludeBlocks: Regroup
+IncludeCategories:
+  # External Libraries
+  - Regex:           '^<(Eigen|rclcpp|ament_index_cpp|boost|gtest|Q(.*)|google|gtest|SDL)(\/)?([A-Za-z0-9.\/-_])+>'
+    Priority:        2
+  # stdlib. These includes are all lowercase
+  - Regex:           '^<([a-z0-9\/-_])+>'
+    Priority:        1
+  # Project headers from other modules' .hpp. These should be prefixed with rj.
+  - Regex:           '^<([A-Za-z0-9.\/-_])+>'
+    Priority:        3
+  # Project headers from this module's .hpp. These should also be prefixed with rj.
+  - Regex:           '^"([A-Za-z0-9.\/-_])+"'
+    Priority:        4
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,23 +30,26 @@ Checks:          '-*,
 AnalyzeTemporaryDtors: false
 # Use Google style guide.
 CheckOptions:
-# Classes / Structs / Enums are CamelCase.
+  # Classes / Structs / Enums are CamelCase.
   - { key: readability-identifier-naming.ClassCase,               value: CamelCase  }
   - { key: readability-identifier-naming.StructCase,              value: CamelCase  }
   - { key: readability-identifier-naming.EnumCase,                value: CamelCase  }
-# Variables / Parameters are lower_case.
+  # Variables / Parameters are lower_case.
   - { key: readability-identifier-naming.VariableCase,            value: lower_case }
   - { key: readability-identifier-naming.ParameterCase,           value: lower_case }
   - { key: readability-identifier-naming.PublicMemberCase,        value: lower_case }
-# Constexpr / const things are kCamelCase.
+  # Private members are lower_case_
+  - { key: readability-identifier-naming.PrivateMemberCase,       value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,     value: "_" }
+  # Constexpr / const things are kCamelCase.
   - { key: readability-identifier-naming.ConstexprVariablePrefix, value: "k" }
   - { key: readability-identifier-naming.ConstexprVariableCase,   value: CamelCase }
-  - { key: readability-identifier-naming.ClassConstantPrefix, value: "k" }
-  - { key: readability-identifier-naming.ClassConstantCase,   value: CamelCase }
-  - { key: readability-identifier-naming.GlobalConstantPrefix, value: "k" }
-  - { key: readability-identifier-naming.GlobalConstantCase,   value: CamelCase }
-# Functions are CamelCase.
-  - { key: readability-identifier-naming.FunctionCase,            value: CamelBack  }
-  - { key: readability-identifier-naming.PublicMethodCase,        value: CamelBack  }
-  - { key: readability-identifier-naming.PrivateMethodCase,       value: CamelBack  }
+  - { key: readability-identifier-naming.ClassConstantPrefix,     value: "k" }
+  - { key: readability-identifier-naming.ClassConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.GlobalConstantPrefix,    value: "k" }
+  - { key: readability-identifier-naming.GlobalConstantCase,      value: CamelCase }
+  # Functions are CamelCase.
+  - { key: readability-identifier-naming.FunctionCase,            value: CamelCase  }
+  - { key: readability-identifier-naming.PublicMethodCase,        value: CamelCase  }
+  - { key: readability-identifier-naming.PrivateMethodCase,       value: CamelCase  }
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -28,4 +28,25 @@ Checks:          '-*,
                   '
 #WarningsAsErrors: '*'
 AnalyzeTemporaryDtors: false
+# Use Google style guide.
+CheckOptions:
+# Classes / Structs / Enums are CamelCase.
+  - { key: readability-identifier-naming.ClassCase,               value: CamelCase  }
+  - { key: readability-identifier-naming.StructCase,              value: CamelCase  }
+  - { key: readability-identifier-naming.EnumCase,                value: CamelCase  }
+# Variables / Parameters are lower_case.
+  - { key: readability-identifier-naming.VariableCase,            value: lower_case }
+  - { key: readability-identifier-naming.ParameterCase,           value: lower_case }
+  - { key: readability-identifier-naming.PublicMemberCase,        value: lower_case }
+# Constexpr / const things are kCamelCase.
+  - { key: readability-identifier-naming.ConstexprVariablePrefix, value: "k" }
+  - { key: readability-identifier-naming.ConstexprVariableCase,   value: CamelCase }
+  - { key: readability-identifier-naming.ClassConstantPrefix, value: "k" }
+  - { key: readability-identifier-naming.ClassConstantCase,   value: CamelCase }
+  - { key: readability-identifier-naming.GlobalConstantPrefix, value: "k" }
+  - { key: readability-identifier-naming.GlobalConstantCase,   value: CamelCase }
+# Functions are CamelCase.
+  - { key: readability-identifier-naming.FunctionCase,            value: CamelBack  }
+  - { key: readability-identifier-naming.PublicMethodCase,        value: CamelBack  }
+  - { key: readability-identifier-naming.PrivateMethodCase,       value: CamelBack  }
 ...

--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -3,8 +3,7 @@
 # ----------------------------------
 with section("parse"):
     # Specify structure for custom cmake functions
-    additional_commands = {'foo': {'flags': ['BAR', 'BAZ'],
-                                   'kwargs': {'DEPENDS': '*', 'HEADERS': '*', 'SOURCES': '*'}}}
+    additional_commands = {}
 
     # Override configurations per-command where available
     override_spec = {}
@@ -34,7 +33,7 @@ with section("format"):
 
     # If a positional argument group contains more than this many arguments, then
     # force it to a vertical layout.
-    max_pargs_hwrap = 6
+    max_pargs_hwrap = 3
 
     # If a cmdline positional group consumes more than this many lines without
     # nesting, then invalidate the layout (and nest)

--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,221 @@
+# ----------------------------------
+# Options affecting listfile parsing
+# ----------------------------------
+with section("parse"):
+    # Specify structure for custom cmake functions
+    additional_commands = {'foo': {'flags': ['BAR', 'BAZ'],
+                                   'kwargs': {'DEPENDS': '*', 'HEADERS': '*', 'SOURCES': '*'}}}
+
+    # Override configurations per-command where available
+    override_spec = {}
+
+    # Specify variable tags.
+    vartags = []
+
+    # Specify property tags.
+    proptags = []
+
+# -----------------------------
+# Options affecting formatting.
+# -----------------------------
+with section("format"):
+    # Disable formatting entirely, making cmake-format a no-op
+    disable = False
+
+    # How wide to allow formatted cmake files
+    line_width = 100
+
+    # How many spaces to tab for indent
+    tab_size = 2
+
+    # If an argument group contains more than this many sub-groups (parg or kwarg
+    # groups) then force it to a vertical layout.
+    max_subgroups_hwrap = 2
+
+    # If a positional argument group contains more than this many arguments, then
+    # force it to a vertical layout.
+    max_pargs_hwrap = 6
+
+    # If a cmdline positional group consumes more than this many lines without
+    # nesting, then invalidate the layout (and nest)
+    max_rows_cmdline = 2
+
+    # If true, separate flow control names from their parentheses with a space
+    separate_ctrl_name_with_space = False
+
+    # If true, separate function names from parentheses with a space
+    separate_fn_name_with_space = False
+
+    # If a statement is wrapped to more than one line, than dangle the closing
+    # parenthesis on its own line.
+    dangle_parens = False
+
+    # If the trailing parenthesis must be 'dangled' on its on line, then align it
+    # to this reference: `prefix`: the start of the statement,  `prefix-indent`:
+    # the start of the statement, plus one indentation  level, `child`: align to
+    # the column of the arguments
+    dangle_align = 'prefix'
+
+    # If the statement spelling length (including space and parenthesis) is
+    # smaller than this amount, then force reject nested layouts.
+    min_prefix_chars = 4
+
+    # If the statement spelling length (including space and parenthesis) is larger
+    # than the tab width by more than this amount, then force reject un-nested
+    # layouts.
+    max_prefix_chars = 10
+
+    # If a candidate layout is wrapped horizontally but it exceeds this many
+    # lines, then reject the layout.
+    max_lines_hwrap = 2
+
+    # What style line endings to use in the output.
+    line_ending = 'unix'
+
+    # Format command names consistently as 'lower' or 'upper' case
+    command_case = 'canonical'
+
+    # Format keywords consistently as 'lower' or 'upper' case
+    keyword_case = 'unchanged'
+
+    # A list of command names which should always be wrapped
+    always_wrap = []
+
+    # If true, the argument lists which are known to be sortable will be sorted
+    # lexicographicall
+    enable_sort = True
+
+    # If true, the parsers may infer whether or not an argument list is sortable
+    # (without annotation).
+    autosort = False
+
+    # By default, if cmake-format cannot successfully fit everything into the
+    # desired linewidth it will apply the last, most agressive attempt that it
+    # made. If this flag is True, however, cmake-format will print error, exit
+    # with non-zero status code, and write-out nothing
+    require_valid_layout = False
+
+    # A dictionary mapping layout nodes to a list of wrap decisions. See the
+    # documentation for more information.
+    layout_passes = {}
+
+# ------------------------------------------------
+# Options affecting comment reflow and formatting.
+# ------------------------------------------------
+with section("markup"):
+    # What character to use for bulleted lists
+    bullet_char = '*'
+
+    # What character to use as punctuation after numerals in an enumerated list
+    enum_char = '.'
+
+    # If comment markup is enabled, don't reflow the first comment block in each
+    # listfile. Use this to preserve formatting of your copyright/license
+    # statements.
+    first_comment_is_literal = False
+
+    # If comment markup is enabled, don't reflow any comment block which matches
+    # this (regex) pattern. Default is `None` (disabled).
+    literal_comment_pattern = None
+
+    # Regular expression to match preformat fences in comments default=
+    # ``r'^\s*([`~]{3}[`~]*)(.*)$'``
+    fence_pattern = '^\\s*([`~]{3}[`~]*)(.*)$'
+
+    # Regular expression to match rulers in comments default=
+    # ``r'^\s*[^\w\s]{3}.*[^\w\s]{3}$'``
+    ruler_pattern = '^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$'
+
+    # If a comment line matches starts with this pattern then it is explicitly a
+    # trailing comment for the preceeding argument. Default is '#<'
+    explicit_trailing_pattern = '#<'
+
+    # If a comment line starts with at least this many consecutive hash
+    # characters, then don't lstrip() them off. This allows for lazy hash rulers
+    # where the first hash char is not separated by space
+    hashruler_min_length = 10
+
+    # If true, then insert a space between the first hash char and remaining hash
+    # chars in a hash ruler, and normalize its length to fill the column
+    canonicalize_hashrulers = True
+
+    # enable comment markup parsing and reflow
+    enable_markup = True
+
+# ----------------------------
+# Options affecting the linter
+# ----------------------------
+with section("lint"):
+    # a list of lint codes to disable
+    disabled_codes = []
+
+    # regular expression pattern describing valid function names
+    function_pattern = '[0-9a-z_]+'
+
+    # regular expression pattern describing valid macro names
+    macro_pattern = '[0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for variables with global
+    # (cache) scope
+    global_var_pattern = '[A-Z][0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for variables with global
+    # scope (but internal semantic)
+    internal_var_pattern = '_[A-Z][0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for variables with local
+    # scope
+    local_var_pattern = '[a-z][a-z0-9_]+'
+
+    # regular expression pattern describing valid names for privatedirectory
+    # variables
+    private_var_pattern = '_[0-9a-z_]+'
+
+    # regular expression pattern describing valid names for public directory
+    # variables
+    public_var_pattern = '[A-Z][0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for function/macro
+    # arguments and loop variables.
+    argument_var_pattern = '[a-z][a-z0-9_]+'
+
+    # regular expression pattern describing valid names for keywords used in
+    # functions or macros
+    keyword_pattern = '[A-Z][0-9A-Z_]+'
+
+    # In the heuristic for C0201, how many conditionals to match within a loop in
+    # before considering the loop a parser.
+    max_conditionals_custom_parser = 2
+
+    # Require at least this many newlines between statements
+    min_statement_spacing = 1
+
+    # Require no more than this many newlines between statements
+    max_statement_spacing = 2
+    max_returns = 6
+    max_branches = 12
+    max_arguments = 5
+    max_localvars = 15
+    max_statements = 50
+
+# -------------------------------
+# Options affecting file encoding
+# -------------------------------
+with section("encode"):
+    # If true, emit the unicode byte-order mark (BOM) at the start of the file
+    emit_byteorder_mark = False
+
+    # Specify the encoding of the input file. Defaults to utf-8
+    input_encoding = 'utf-8'
+
+    # Specify the encoding of the output file. Defaults to utf-8. Note that cmake
+    # only claims to support utf-8 so be careful when using anything else
+    output_encoding = 'utf-8'
+
+# -------------------------------------
+# Miscellaneous configurations options.
+# -------------------------------------
+with section("misc"):
+    # A dictionary containing any per-command configuration overrides. Currently
+    # only `command_case` is supported.
+    per_command = {}

--- a/util/reformat_all.sh
+++ b/util/reformat_all.sh
@@ -1,0 +1,51 @@
+if ! command -v clang-tidy-10 &> /dev/null
+then
+    echo "clang-tidy-10 could not be found. Install it by running"
+    echo "    sudo apt install clang-tidy-10"
+    exit
+fi
+
+if ! command -v clang-apply-replacements-10 &> /dev/null
+then
+    echo "clang-apply-replacements-10 could not be found. Install it by running"
+    echo "    sudo apt install clang-tidy-10"
+    exit
+fi
+
+if ! command -v clang-format-10 &> /dev/null
+then
+    echo "clang-format-10 could not be found. Install it by running"
+    echo "    sudo apt install clang-format-10"
+    exit
+fi
+
+if ! command -v cmake-format &> /dev/null
+then
+    echo "cmake-format could not be found. Install it by running"
+    echo "    pip3 install cmake-format"
+    exit
+fi
+
+echo "Filtering precompiled headers in build/compile_commands.json..."
+sed -i 's/-include [^ ]*cmake_pch\.hxx//' build/compile_commands.json
+
+echo "Running run-clang-tidy..."
+python3 util/run-clang-tidy.py \
+  -clang-tidy-binary clang-tidy-10 \
+  -clang-apply-replacements-binary clang-apply-replacements-10 \
+  -checks="-*,readability-identifier-naming" \
+  -p build \
+  -fix \
+  "^(?!build)(?!external).*$"
+
+echo "Running run-clang-format..."
+python3 util/run-clang-format.py \
+  -clang-format-binary clang-format-10 \
+  -i \
+  -p build \
+  "^(?!build)(?!external).*$"
+
+echo "Running run-cmake-format..."
+python3 util/run-cmake-format.py \
+  -i \
+  "^(?!cmake-)(?!build)(?!external).*$"

--- a/util/run-clang-format.py
+++ b/util/run-clang-format.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import multiprocessing
+import os
+import re
+import subprocess
+import sys
+import threading
+from pathlib import Path
+import queue as queue
+
+
+def get_format_invocation(f, clang_format_binary):
+    """Gets a command line for clang-tidy."""
+    start = [clang_format_binary, "-i", f]
+    return start
+
+
+def run_format(args, file_queue, lock):
+    """Takes filenames out of queue and runs clang-tidy on them."""
+    while True:
+        name = file_queue.get()
+        invocation = get_format_invocation(name, args.clang_format_binary)
+
+        proc = subprocess.Popen(invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output, err = proc.communicate()
+        with lock:
+            sys.stdout.write(' '.join(invocation) + '\n' + output.decode('utf-8'))
+            if len(err) > 0:
+                sys.stdout.flush()
+                sys.stderr.write(err.decode('utf-8'))
+        file_queue.task_done()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Runs clang-format over all files '
+                                                 'in a compilation database.')
+    parser.add_argument('-clang-format-binary', metavar='PATH',
+                        default='clang-format',
+                        help='path to clang-format binary')
+    parser.add_argument('-i', action='store_true',
+                        help='Inplace edit <file>s, if specified')
+    parser.add_argument('-j', type=int, default=0,
+                        help='number of format instances to be run in parallel.')
+    parser.add_argument('files', nargs='*', default=['.*'],
+                        help='files to be processed (regex on path)')
+    parser.add_argument('-p', dest='build_path',
+                        help='Path used to read a compile command database.')
+    args = parser.parse_args()
+
+    db_path = 'compile_commands.json'
+
+    build_path = args.build_path
+
+    # Load the database and extract all files.
+    database = json.load(open(os.path.join(build_path, db_path)))
+
+    cwd = Path.cwd()
+
+    # Build up a big regexy filter from all command line arguments.
+    file_name_re = re.compile('|'.join(args.files))
+
+    files = []
+    for entry in database:
+        directory = Path(entry['directory'])
+        file = directory / entry['file']
+        relative_path = file.relative_to(cwd)
+
+        if file_name_re.search(str(relative_path)):
+            files.append(str(file))
+            print(relative_path)
+
+    max_task = args.j
+    if max_task == 0:
+        max_task = multiprocessing.cpu_count()
+
+    try:
+        # Spin up a bunch of tidy-launching threads.
+        task_queue = queue.Queue(max_task)
+        # List of files with a non-zero return code.
+        lock = threading.Lock()
+        for _ in range(max_task):
+            t = threading.Thread(target=run_format,
+                                 args=(args, task_queue, lock))
+            t.daemon = True
+            t.start()
+
+        # Fill the queue with files.
+        for name in files:
+            task_queue.put(name)
+
+        # Wait for all threads to be done.
+        task_queue.join()
+
+    except KeyboardInterrupt:
+        # This is a sad hack. Unfortunately subprocess goes
+        # bonkers with ctrl-c and we start forking merrily.
+        print('\nCtrl-C detected, goodbye.')
+        os.kill(0, 9)
+
+
+if __name__ == '__main__':
+    main()

--- a/util/run-clang-tidy.py
+++ b/util/run-clang-tidy.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python
+#
+# ===- run-clang-tidy.py - Parallel clang-tidy runner --------*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===-----------------------------------------------------------------------===#
+# FIXME: Integrate with clang-tidy-diff.py
+
+
+"""
+Parallel clang-tidy runner
+==========================
+
+Runs clang-tidy over all files in a compilation database. Requires clang-tidy
+and clang-apply-replacements in $PATH.
+
+Example invocations.
+- Run clang-tidy on all files in the current working directory with a default
+  set of checks and show warnings in the cpp files and all project headers.
+    run-clang-tidy.py $PWD
+
+- Fix all header guards.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard
+
+- Fix all header guards included from clang-tidy and header guards
+  for clang-tidy headers.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard extra/clang-tidy \
+                      -header-filter=extra/clang-tidy
+
+Compilation database setup:
+http://clang.llvm.org/docs/HowToSetupToolingForLLVM.html
+"""
+
+from __future__ import print_function
+
+import argparse
+import glob
+import json
+import multiprocessing
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import traceback
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+is_py2 = sys.version[0] == '2'
+
+if is_py2:
+    import Queue as queue
+else:
+    import queue as queue
+
+
+def find_compilation_database(path):
+    """Adjusts the directory until a compilation database is found."""
+    result = './'
+    while not os.path.isfile(os.path.join(result, path)):
+        if os.path.realpath(result) == '/':
+            print('Error: could not find compilation database.')
+            sys.exit(1)
+        result += '../'
+    return os.path.realpath(result)
+
+
+def make_absolute(f, directory):
+    if os.path.isabs(f):
+        return f
+    return os.path.normpath(os.path.join(directory, f))
+
+
+def get_tidy_invocation(f, clang_tidy_binary, checks, tmpdir, build_path,
+                        header_filter, allow_enabling_alpha_checkers,
+                        extra_arg, extra_arg_before, quiet, config):
+    """Gets a command line for clang-tidy."""
+    start = [clang_tidy_binary]
+    if allow_enabling_alpha_checkers is not None:
+        start.append('-allow-enabling-analyzer-alpha-checkers')
+    if header_filter is not None:
+        start.append('-header-filter=' + header_filter)
+    if checks:
+        start.append('-checks=' + checks)
+    if tmpdir is not None:
+        start.append('-export-fixes')
+        # Get a temporary file. We immediately close the handle so clang-tidy can
+        # overwrite it.
+        (handle, name) = tempfile.mkstemp(suffix='.yaml', dir=tmpdir)
+        os.close(handle)
+        start.append(name)
+    for arg in extra_arg:
+        start.append('-extra-arg=%s' % arg)
+    for arg in extra_arg_before:
+        start.append('-extra-arg-before=%s' % arg)
+    start.append('-p=' + build_path)
+    if quiet:
+        start.append('-quiet')
+    if config:
+        start.append('-config=' + config)
+    start.append(f)
+    return start
+
+
+def merge_replacement_files(tmpdir, mergefile):
+    """Merge all replacement files in a directory into a single file"""
+    # The fixes suggested by clang-tidy >= 4.0.0 are given under
+    # the top level key 'Diagnostics' in the output yaml files
+    mergekey = "Diagnostics"
+    merged = []
+    for replacefile in glob.iglob(os.path.join(tmpdir, '*.yaml')):
+        content = yaml.safe_load(open(replacefile, 'r'))
+        if not content:
+            continue  # Skip empty files.
+        merged.extend(content.get(mergekey, []))
+
+    if merged:
+        # MainSourceFile: The key is required by the definition inside
+        # include/clang/Tooling/ReplacementsYaml.h, but the value
+        # is actually never used inside clang-apply-replacements,
+        # so we set it to '' here.
+        output = {'MainSourceFile': '', mergekey: merged}
+        with open(mergefile, 'w') as out:
+            yaml.safe_dump(output, out)
+    else:
+        # Empty the file:
+        open(mergefile, 'w').close()
+
+
+def check_clang_apply_replacements_binary(args):
+    """Checks if invoking supplied clang-apply-replacements binary works."""
+    try:
+        subprocess.check_call([args.clang_apply_replacements_binary, '--version'])
+    except:
+        print('Unable to run clang-apply-replacements. Is clang-apply-replacements '
+              'binary correctly specified?', file=sys.stderr)
+        traceback.print_exc()
+        sys.exit(1)
+
+
+def apply_fixes(args, tmpdir):
+    """Calls clang-apply-fixes on a given directory."""
+    invocation = [args.clang_apply_replacements_binary]
+    if args.format:
+        invocation.append('-format')
+    if args.style:
+        invocation.append('-style=' + args.style)
+    invocation.append(tmpdir)
+    subprocess.call(invocation)
+
+
+def run_tidy(args, tmpdir, build_path, queue, lock, failed_files):
+    """Takes filenames out of queue and runs clang-tidy on them."""
+    while True:
+        name = queue.get()
+        invocation = get_tidy_invocation(name, args.clang_tidy_binary, args.checks,
+                                         tmpdir, build_path, args.header_filter,
+                                         args.allow_enabling_alpha_checkers,
+                                         args.extra_arg, args.extra_arg_before,
+                                         args.quiet, args.config)
+
+        proc = subprocess.Popen(invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output, err = proc.communicate()
+        if proc.returncode != 0:
+            failed_files.append(name)
+        with lock:
+            sys.stdout.write(' '.join(invocation) + '\n' + output.decode('utf-8'))
+            if len(err) > 0:
+                sys.stdout.flush()
+                sys.stderr.write(err.decode('utf-8'))
+        queue.task_done()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Runs clang-tidy over all files '
+                                                 'in a compilation database. Requires '
+                                                 'clang-tidy and clang-apply-replacements in '
+                                                 '$PATH.')
+    parser.add_argument('-allow-enabling-alpha-checkers',
+                        action='store_true', help='allow alpha checkers from '
+                                                  'clang-analyzer.')
+    parser.add_argument('-clang-tidy-binary', metavar='PATH',
+                        default='clang-tidy',
+                        help='path to clang-tidy binary')
+    parser.add_argument('-clang-apply-replacements-binary', metavar='PATH',
+                        default='clang-apply-replacements',
+                        help='path to clang-apply-replacements binary')
+    parser.add_argument('-checks', default=None,
+                        help='checks filter, when not specified, use clang-tidy '
+                             'default')
+    parser.add_argument('-config', default=None,
+                        help='Specifies a configuration in YAML/JSON format: '
+                             '  -config="{Checks: \'*\', '
+                             '                       CheckOptions: [{key: x, '
+                             '                                       value: y}]}" '
+                             'When the value is empty, clang-tidy will '
+                             'attempt to find a file named .clang-tidy for '
+                             'each source file in its parent directories.')
+    parser.add_argument('-header-filter', default=None,
+                        help='regular expression matching the names of the '
+                             'headers to output diagnostics from. Diagnostics from '
+                             'the main file of each translation unit are always '
+                             'displayed.')
+    if yaml:
+        parser.add_argument('-export-fixes', metavar='filename', dest='export_fixes',
+                            help='Create a yaml file to store suggested fixes in, '
+                                 'which can be applied with clang-apply-replacements.')
+    parser.add_argument('-j', type=int, default=0,
+                        help='number of tidy instances to be run in parallel.')
+    parser.add_argument('files', nargs='*', default=['.*'],
+                        help='files to be processed (regex on path)')
+    parser.add_argument('-fix', action='store_true', help='apply fix-its')
+    parser.add_argument('-format', action='store_true', help='Reformat code '
+                                                             'after applying fixes')
+    parser.add_argument('-style', default='file', help='The style of reformat '
+                                                       'code after applying fixes')
+    parser.add_argument('-p', dest='build_path',
+                        help='Path used to read a compile command database.')
+    parser.add_argument('-extra-arg', dest='extra_arg',
+                        action='append', default=[],
+                        help='Additional argument to append to the compiler '
+                             'command line.')
+    parser.add_argument('-extra-arg-before', dest='extra_arg_before',
+                        action='append', default=[],
+                        help='Additional argument to prepend to the compiler '
+                             'command line.')
+    parser.add_argument('-quiet', action='store_true',
+                        help='Run clang-tidy in quiet mode')
+    args = parser.parse_args()
+
+    db_path = 'compile_commands.json'
+
+    if args.build_path is not None:
+        build_path = args.build_path
+    else:
+        # Find our database
+        build_path = find_compilation_database(db_path)
+
+    try:
+        invocation = [args.clang_tidy_binary, '-list-checks']
+        if args.allow_enabling_alpha_checkers:
+            invocation.append('-allow-enabling-analyzer-alpha-checkers')
+        invocation.append('-p=' + build_path)
+        if args.checks:
+            invocation.append('-checks=' + args.checks)
+        invocation.append('-')
+        if args.quiet:
+            # Even with -quiet we still want to check if we can call clang-tidy.
+            with open(os.devnull, 'w') as dev_null:
+                subprocess.check_call(invocation, stdout=dev_null)
+        else:
+            subprocess.check_call(invocation)
+    except:
+        print("Unable to run clang-tidy.", file=sys.stderr)
+        sys.exit(1)
+
+    # Load the database and extract all files.
+    database = json.load(open(os.path.join(build_path, db_path)))
+
+    cwd = Path.cwd()
+
+    # Build up a big regexy filter from all command line arguments.
+    file_name_re = re.compile('|'.join(args.files))
+
+    files = []
+    for entry in database:
+        directory = Path(entry['directory'])
+        file = directory / entry['file']
+        relative_path = file.relative_to(cwd)
+
+        if file_name_re.search(str(relative_path)):
+            files.append(str(file))
+            print(relative_path)
+
+    max_task = args.j
+    if max_task == 0:
+        max_task = multiprocessing.cpu_count()
+
+    tmpdir = None
+    if args.fix or (yaml and args.export_fixes):
+        check_clang_apply_replacements_binary(args)
+        tmpdir = tempfile.mkdtemp()
+
+    return_code = 0
+    try:
+        # Spin up a bunch of tidy-launching threads.
+        task_queue = queue.Queue(max_task)
+        # List of files with a non-zero return code.
+        failed_files = []
+        lock = threading.Lock()
+        for _ in range(max_task):
+            t = threading.Thread(target=run_tidy,
+                                 args=(args, tmpdir, build_path, task_queue, lock, failed_files))
+            t.daemon = True
+            t.start()
+
+        # Fill the queue with files.
+        for name in files:
+            task_queue.put(name)
+
+        # Wait for all threads to be done.
+        task_queue.join()
+        if len(failed_files):
+            return_code = 1
+
+    except KeyboardInterrupt:
+        # This is a sad hack. Unfortunately subprocess goes
+        # bonkers with ctrl-c and we start forking merrily.
+        print('\nCtrl-C detected, goodbye.')
+        if tmpdir:
+            shutil.rmtree(tmpdir)
+        os.kill(0, 9)
+
+    if yaml and args.export_fixes:
+        print('Writing fixes to ' + args.export_fixes + ' ...')
+        try:
+            merge_replacement_files(tmpdir, args.export_fixes)
+        except:
+            print('Error exporting fixes.\n', file=sys.stderr)
+            traceback.print_exc()
+            return_code = 1
+
+    if args.fix:
+        print('Applying fixes ...')
+        try:
+            apply_fixes(args, tmpdir)
+        except:
+            print('Error applying fixes.\n', file=sys.stderr)
+            traceback.print_exc()
+            return_code = 1
+
+    if tmpdir:
+        shutil.rmtree(tmpdir)
+    sys.exit(return_code)
+
+
+if __name__ == '__main__':
+    main()

--- a/util/run-cmake-format.py
+++ b/util/run-cmake-format.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import multiprocessing
+import os
+import re
+import subprocess
+import sys
+import threading
+from pathlib import Path
+import queue as queue
+
+
+def get_format_invocation(f, cmake_format_binary):
+    """Gets a command line for cmake-format."""
+    start = [cmake_format_binary, "-i", f]
+    return start
+
+
+def run_format(args, file_queue, lock):
+    """Takes filenames out of queue and runs clang-format on them."""
+    while True:
+        name = file_queue.get()
+        invocation = get_format_invocation(name, args.cmake_format_binary)
+
+        proc = subprocess.Popen(invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output, err = proc.communicate()
+        with lock:
+            sys.stdout.write(' '.join(invocation) + '\n' + output.decode('utf-8'))
+            if len(err) > 0:
+                sys.stdout.flush()
+                sys.stderr.write(err.decode('utf-8'))
+        file_queue.task_done()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Runs cmake-format over all CMakeLists.txt')
+    parser.add_argument('-cmake-format-binary', metavar='PATH',
+                        default='cmake-format',
+                        help='path to cmake-format binary')
+    parser.add_argument('-i', action='store_true',
+                        help='Inplace edit <file>s, if specified')
+    parser.add_argument('-j', type=int, default=0,
+                        help='number of format instances to be run in parallel.')
+    parser.add_argument('files', nargs='*', default=['.*'],
+                        help='files to be processed (regex on path)')
+    parser.add_argument('-p', dest='build_path',
+                        help='Path used to read a compile command database.')
+    args = parser.parse_args()
+
+    cwd = Path.cwd()
+
+    # Build up a big regexy filter from all command line arguments.
+    file_name_re = re.compile('|'.join(args.files))
+
+    files = []
+    for file in cwd.glob("**/CMakeLists.txt"):
+        relative_file = file.relative_to(cwd)
+        if file_name_re.search(str(relative_file)):
+            files.append(str(file))
+            print(relative_file)
+            # print(file)
+
+    max_task = args.j
+    if max_task == 0:
+        max_task = multiprocessing.cpu_count()
+
+    try:
+        # Spin up a bunch of tidy-launching threads.
+        task_queue = queue.Queue(max_task)
+        # List of files with a non-zero return code.
+        lock = threading.Lock()
+        for _ in range(max_task):
+            t = threading.Thread(target=run_format,
+                                 args=(args, task_queue, lock))
+            t.daemon = True
+            t.start()
+
+        # Fill the queue with files.
+        for name in files:
+            task_queue.put(name)
+
+        # Wait for all threads to be done.
+        task_queue.join()
+
+    except KeyboardInterrupt:
+        # This is a sad hack. Unfortunately subprocess goes
+        # bonkers with ctrl-c and we start forking merrily.
+        print('\nCtrl-C detected, goodbye.')
+        os.kill(0, 9)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description
This PR sets up:
1. Naming conventions in `.clang-tidy`
2. Include order stuff in `.clang-format`
3. cmake styling stuff using `cmake-format` tool in `.cmake-format.py`

Note: I changed the symlink for `.clang-format` to [style-configs](https://github.com/RoboJackets/style-configs) to just the actual file.

Changes based on these config files can be seen [here](https://github.com/RoboJackets/robocup-software/pull/1568/files)

## Associated Issue
Issue #1483 