### PR TITLE
Makefile and launch files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ save_workspace: &save_workspace
   persist_to_workspace:
     root: ~/robocup-software
     paths:
-      - build/*
+      - build-debug/*
       - install/*
 
 load_workspace: &load_workspace
@@ -37,14 +37,14 @@ jobs:
       - checkout
       - <<: *install_deps
       - run: |
-          mkdir -p build && cd build
+          mkdir -p build-debug && cd build-debug
           source /opt/ros/foxy/setup.bash
           export CMAKE_PREFIX_PATH=/opt/ros/foxy
           cmake -GNinja -Wno-dev -DNO_WALL=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_INSTALL_PREFIX=../install --target -DBUILD_TESTS=ON ..
           ninja -j2 install
       - <<: *save_workspace
 
-  # Use the saved build folder for testing
+  # Use the saved build-debug folder for testing
   test-all:
     <<: *dir
     <<: *image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
             DIFFBRANCH=$(curl -s "$PR_API_URL" | python3 -c "import sys, json; print(json.load(sys.stdin)['base']['sha'])")
           fi
           echo "Removing GCC precompiled headers from compile_commands.json so that clang-tidy will work"
-          sed -i 's/-include [^ ]*cmake_pch\.hxx//' build/compile_commands.json
+          sed -i 's/-include [^ ]*cmake_pch\.hxx//' build-debug/compile_commands.json
           echo "Diffing against $DIFFBRANCH for clang-tidy..."
           DIFFBRANCH=$DIFFBRANCH make checktidy-lines
           cat /tmp/checktidy.patch

--- a/launch/sim.launch.py
+++ b/launch/sim.launch.py
@@ -3,47 +3,40 @@ from pathlib import Path
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 
-from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable, Shutdown
+from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable, Shutdown, DeclareLaunchArgument
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 
+from launch.substitutions import LaunchConfiguration
 
 def generate_launch_description():
     bringup_dir = Path(get_package_share_directory('rj_robocup'))
     launch_dir = bringup_dir / 'launch'
+
+    team_flag = LaunchConfiguration('team_flag', default='-b')
+    ref_flag = LaunchConfiguration('ref_flag', default='-noref')
+    headless_flag = LaunchConfiguration('headless_flag', default='')
 
     stdout_linebuf_envvar = SetEnvironmentVariable(
         'RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1')
 
     grsim = Node(package='rj_robocup',
                  executable='grSim',
-                 arguments=['--headless'])
+                 arguments=[headless_flag])
 
-    soccer = Node(package='rj_robocup',
-                  executable='soccer',
-                  output='screen',
-                  arguments=['-b', '-sim', '-noref'],
-                  on_exit=Shutdown())
-
-    config_server = Node(package='rj_robocup',
-                         executable='config_server',
-                         output='screen',
-                         on_exit=Shutdown())
-
-    vision_receiver_launch_path = str(launch_dir / "vision_receiver.launch.py")
-    vision_receiver = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(vision_receiver_launch_path))
-
-    ref_receiver = Node(package='rj_robocup',
-                        executable='internal_referee_node',
-                        output='screen',
-                        on_exit=Shutdown())
-
-    vision_filter_launch_path = str(launch_dir / "vision_filter.launch.py")
-    vision_filter = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(vision_filter_launch_path))
+    soccer_launch_path = str(launch_dir / "soccer.launch.py")
+    soccer = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(soccer_launch_path),
+        launch_arguments={
+            'team_flag': team_flag,
+            'sim_flag': '-sim',
+            'ref_flag': ref_flag
+        }.items())
 
     return LaunchDescription([
-        stdout_linebuf_envvar, config_server, soccer, grsim, vision_receiver,
-        vision_filter, ref_receiver
+        DeclareLaunchArgument('team_flag', default_value='-y'),
+        DeclareLaunchArgument('ref_flag', default_value='-noref'),
+        DeclareLaunchArgument('headless_flag', default_value=''),
+        DeclareLaunchArgument('direction_flag', default_value='plus'),
+        stdout_linebuf_envvar, grsim, soccer
     ])

--- a/launch/sim.launch.py
+++ b/launch/sim.launch.py
@@ -9,6 +9,7 @@ from launch_ros.actions import Node
 
 from launch.substitutions import LaunchConfiguration
 
+
 def generate_launch_description():
     bringup_dir = Path(get_package_share_directory('rj_robocup'))
     launch_dir = bringup_dir / 'launch'

--- a/launch/sim2play.launch.py
+++ b/launch/sim2play.launch.py
@@ -9,6 +9,7 @@ from launch_ros.actions import PushRosNamespace, Node
 
 from launch.substitutions import LaunchConfiguration
 
+
 def generate_launch_description():
     bringup_dir = Path(get_package_share_directory('rj_robocup'))
     launch_dir = bringup_dir / 'launch'
@@ -34,10 +35,7 @@ def generate_launch_description():
             'direction_flag': 'plus'
         }.items())
 
-    yellow = GroupAction([
-        PushRosNamespace("yellow"),
-        soccer_yellow
-    ])
+    yellow = GroupAction([PushRosNamespace("yellow"), soccer_yellow])
 
     soccer_blue = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(soccer_launch_path),
@@ -48,11 +46,6 @@ def generate_launch_description():
             'direction_flag': 'minus'
         }.items())
 
-    blue = GroupAction([
-        PushRosNamespace("blue"),
-        soccer_blue
-    ])
+    blue = GroupAction([PushRosNamespace("blue"), soccer_blue])
 
-    return LaunchDescription([
-        stdout_linebuf_envvar, grsim, yellow, blue
-    ])
+    return LaunchDescription([stdout_linebuf_envvar, grsim, yellow, blue])

--- a/launch/sim2play.launch.py
+++ b/launch/sim2play.launch.py
@@ -1,0 +1,58 @@
+import os
+from pathlib import Path
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+
+from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable, Shutdown, GroupAction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import PushRosNamespace, Node
+
+from launch.substitutions import LaunchConfiguration
+
+def generate_launch_description():
+    bringup_dir = Path(get_package_share_directory('rj_robocup'))
+    launch_dir = bringup_dir / 'launch'
+
+    stdout_linebuf_envvar = SetEnvironmentVariable(
+        'RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1')
+
+    ref_flag = LaunchConfiguration('ref_flag', default='-noref')
+    headless_flag = LaunchConfiguration('headless_flag', default='')
+
+    grsim = Node(package='rj_robocup',
+                 executable='grSim',
+                 arguments=['--headless'])
+
+    soccer_launch_path = str(launch_dir / "soccer.launch.py")
+
+    soccer_yellow = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(soccer_launch_path),
+        launch_arguments={
+            'team_flag': '-y',
+            'sim_flag': '-sim',
+            'ref_flag': ref_flag,
+            'direction_flag': 'plus'
+        }.items())
+
+    yellow = GroupAction([
+        PushRosNamespace("yellow"),
+        soccer_yellow
+    ])
+
+    soccer_blue = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(soccer_launch_path),
+        launch_arguments={
+            'team_flag': '-b',
+            'sim_flag': '-sim',
+            'ref_flag': ref_flag,
+            'direction_flag': 'minus'
+        }.items())
+
+    blue = GroupAction([
+        PushRosNamespace("blue"),
+        soccer_blue
+    ])
+
+    return LaunchDescription([
+        stdout_linebuf_envvar, grsim, yellow, blue
+    ])

--- a/launch/soccer.launch.py
+++ b/launch/soccer.launch.py
@@ -60,9 +60,9 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(vision_filter_launch_path))
 
     return LaunchDescription([
-        DeclareLaunchArgument('team_flag'),
-        DeclareLaunchArgument('sim_flag'),
-        DeclareLaunchArgument('ref_flag'),
-        DeclareLaunchArgument('direction_flag'),
+        DeclareLaunchArgument('team_flag', default_value=''),
+        DeclareLaunchArgument('sim_flag', default_value=''),
+        DeclareLaunchArgument('ref_flag', default_value=''),
+        DeclareLaunchArgument('direction_flag', default_value='plus'),
         stdout_linebuf_envvar, config_server, soccer, vision_receiver, vision_filter, ref_receiver
     ])

--- a/launch/soccer.launch.py
+++ b/launch/soccer.launch.py
@@ -1,0 +1,68 @@
+import os
+from pathlib import Path
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+
+from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable, Shutdown, DeclareLaunchArgument
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+
+from launch.substitutions import LaunchConfiguration
+
+
+def generate_launch_description():
+    bringup_dir = Path(get_package_share_directory('rj_robocup'))
+    launch_dir = bringup_dir / 'launch'
+
+    team_flag = LaunchConfiguration('team_flag', default='-b')
+    sim_flag = LaunchConfiguration('sim_flag', default='-sim')
+    ref_flag = LaunchConfiguration('ref_flag', default='-noref')
+    direction_flag = LaunchConfiguration('direction_flag', default='plus')
+
+    stdout_linebuf_envvar = SetEnvironmentVariable(
+        'RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1')
+
+    soccer = Node(package='rj_robocup',
+                  executable='soccer',
+                  output='screen',
+                  arguments=[
+                      team_flag,
+                      sim_flag,
+                      ref_flag,
+                      '-defend',
+                      direction_flag
+                  ],
+                  on_exit=Shutdown())
+
+    config_server = Node(package='rj_robocup',
+                         executable='config_server',
+                         output='screen',
+                         arguments=[
+                             team_flag,
+                             sim_flag,
+                             ref_flag,
+                             '-defend',
+                             direction_flag
+                         ],
+                         on_exit=Shutdown())
+
+    vision_receiver_launch_path = str(launch_dir / "vision_receiver.launch.py")
+    vision_receiver = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(vision_receiver_launch_path))
+
+    ref_receiver = Node(package='rj_robocup',
+                        executable='internal_referee_node',
+                        output='screen',
+                        on_exit=Shutdown())
+
+    vision_filter_launch_path = str(launch_dir / "vision_filter.launch.py")
+    vision_filter = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(vision_filter_launch_path))
+
+    return LaunchDescription([
+        DeclareLaunchArgument('team_flag'),
+        DeclareLaunchArgument('sim_flag'),
+        DeclareLaunchArgument('ref_flag'),
+        DeclareLaunchArgument('direction_flag'),
+        stdout_linebuf_envvar, config_server, soccer, vision_receiver, vision_filter, ref_receiver
+    ])

--- a/launch/soccer.launch.py
+++ b/launch/soccer.launch.py
@@ -22,29 +22,19 @@ def generate_launch_description():
     stdout_linebuf_envvar = SetEnvironmentVariable(
         'RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1')
 
-    soccer = Node(package='rj_robocup',
-                  executable='soccer',
-                  output='screen',
-                  arguments=[
-                      team_flag,
-                      sim_flag,
-                      ref_flag,
-                      '-defend',
-                      direction_flag
-                  ],
-                  on_exit=Shutdown())
+    soccer = Node(
+        package='rj_robocup',
+        executable='soccer',
+        output='screen',
+        arguments=[team_flag, sim_flag, ref_flag, '-defend', direction_flag],
+        on_exit=Shutdown())
 
-    config_server = Node(package='rj_robocup',
-                         executable='config_server',
-                         output='screen',
-                         arguments=[
-                             team_flag,
-                             sim_flag,
-                             ref_flag,
-                             '-defend',
-                             direction_flag
-                         ],
-                         on_exit=Shutdown())
+    config_server = Node(
+        package='rj_robocup',
+        executable='config_server',
+        output='screen',
+        arguments=[team_flag, sim_flag, ref_flag, '-defend', direction_flag],
+        on_exit=Shutdown())
 
     vision_receiver_launch_path = str(launch_dir / "vision_receiver.launch.py")
     vision_receiver = IncludeLaunchDescription(
@@ -63,6 +53,7 @@ def generate_launch_description():
         DeclareLaunchArgument('team_flag', default_value=''),
         DeclareLaunchArgument('sim_flag', default_value=''),
         DeclareLaunchArgument('ref_flag', default_value=''),
-        DeclareLaunchArgument('direction_flag', default_value='plus'),
-        stdout_linebuf_envvar, config_server, soccer, vision_receiver, vision_filter, ref_receiver
+        DeclareLaunchArgument('direction_flag',
+                              default_value='plus'), stdout_linebuf_envvar,
+        config_server, soccer, vision_receiver, vision_filter, ref_receiver
     ])

--- a/makefile
+++ b/makefile
@@ -2,6 +2,7 @@ SHELL=/bin/bash -o pipefail
 MAKE_FLAGS = --no-print-directory
 TESTS = *
 FIRMWR_TESTS = -i2c -io-expander -fpga -piezo -neopixel -attiny -led -radio-sender -radio-receiver
+export CMAKE_PREFIX_PATH=/opt/ros/foxy
 
 # circleci has 2 cores, but advertises 32, which causes OOMs
 ifeq ($(CIRCLECI), true)
@@ -15,18 +16,18 @@ CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=$(shell pwd)/install"
 # build a specified target with CMake and Ninja
 # usage: $(call cmake_build_target, target, extraCmakeFlags)
 define cmake_build_target
-	mkdir -p build
-	cd build && cmake -GNinja -Wno-dev -DCMAKE_BUILD_TYPE=Debug $(DEBUG_FLAGS) $(CMAKE_FLAGS) --target $1 $2 .. && ninja $(NINJA_FLAGS) $1 install
+	mkdir -p build-debug
+ 	cd build-debug && cmake -GNinja -Wno-dev -DNO_WALL=ON -DCMAKE_BUILD_TYPE=Debug $(DEBUG_FLAGS) $(CMAKE_FLAGS) --target -DBUILD_TESTS=ON .. && ninja $(NINJA_FLAGS) $1 install
 endef
 
 define cmake_build_target_release
-	mkdir -p build
-	cd build && cmake -GNinja -Wno-dev -DCMAKE_BUILD_TYPE=Release $(CMAKE_FLAGS) --target $1 $2 .. && ninja $(NINJA_FLAGS) $1 install
+	mkdir -p build-release
+ 	cd build-release && cmake -GNinja -Wno-dev -DNO_WALL=ON -DCMAKE_BUILD_TYPE=Release $(CMAKE_FLAGS) --target -DBUILD_TESTS=ON .. && ninja $(NINJA_FLAGS) $1 install
 endef
 
 define cmake_build_target_perf
-	mkdir -p build
-	cd build && cmake -GNinja -Wno-dev -DCMAKE_BUILD_TYPE=RelWithDebInfo $(CMAKE_FLAGS) --target $1 $2 .. && ninja $(NINJA_FLAGS) $1 install
+	mkdir -p build-release-debug
+ 	cd build-release-debug && cmake -GNinja -Wno-dev -DNO_WALL=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo $(CMAKE_FLAGS) --target -DBUILD_TESTS=ON .. && ninja $(NINJA_FLAGS) $1 install
 endef
 
 all:
@@ -53,12 +54,7 @@ run-sim: all backend-headless-simulator-soccer
 run-headmore: all backend-simulator-soccer
 
 run-sim2play: all
-	-pkill -f './grSim'
-	-(cd run && ./grSim) &
-	@echo '!!![WARNING]!!! Multiple soccer instances will not work unless your grSim is broadcasting over the proper IP.'
-	@echo 'Please set your grSim broadcast IP to "224.5.23.2:10020", or you will experience issues.'
-	./run/soccer -sim -b & sleep 2 && ./run/soccer -sim -y -defend plus
-	-pkill -f './grSim'
+	ros2 launch rj_robocup sim2play.launch.py
 
 run-release: all-release
 	./run/soccer
@@ -71,19 +67,11 @@ view:
 
 # backend targets to launch soccer with grSim in headless
 backend-headless-simulator-soccer:
-	-pkill -f './grSim'
-	-(cd run && ./grSim --headless) &
-	./run/soccer -sim -pbk testing.pbk
-# Kill grSim once we unblock
-	-pkill -f './grSim'
+	ros2 launch rj_robocup sim.launch.py headless_flag:=--headless
 
 # backend targets to launch soccer with a grSim window
 backend-simulator-soccer:
-	-pkill -f './grSim'
-	-(cd run && ./grSim) &
-	./run/soccer -sim -pbk testing.pbk
-# Kill grSim once we unblock
-	-pkill -f './grSim'
+	ros2 launch rj_robocup sim.launch.py
 
 
 debug: all

--- a/makefile
+++ b/makefile
@@ -122,8 +122,7 @@ behavior-diagrams: all
 	@echo -e "\n=> Open up 'soccer/gameplay/diagrams' to view behavior state machine diagrams"
 
 clean:
-	cd build && ninja clean || true
-	rm -rf build
+	cd build-debug && ninja clean || true
 
 static-analysis:
 	mkdir -p build/static-analysis

--- a/makefile
+++ b/makefile
@@ -45,7 +45,7 @@ all-perf:
 perf: all-perf
 
 run: all
-	./run/soccer
+	ros2 launch rj_robocup soccer.launch.py
 run-comp:
 	./runcomp.sh
 r:	run
@@ -57,13 +57,11 @@ run-sim2play: all
 	ros2 launch rj_robocup sim2play.launch.py
 
 run-release: all-release
-	./run/soccer
+	ros2 launch rj_robocup soccer.launch.py
 run-sim-release: all-release backend-headless-simulator-soccer
 rsr: run-sim-release
 rrs: rsr
 rr: run-release
-view:
-	./run/soccer -vlog $(file)
 
 # backend targets to launch soccer with grSim in headless
 backend-headless-simulator-soccer:

--- a/rj_config/include/config_server/config_server.hpp
+++ b/rj_config/include/config_server/config_server.hpp
@@ -29,7 +29,7 @@ public:
      * @brief Constructor.
      * @param node_options
      */
-    ConfigServer(const rclcpp::NodeOptions& node_options);
+    ConfigServer(const rclcpp::NodeOptions& node_options, const GameSettingsMsg& game_settings);
 
 private:
     /**

--- a/rj_config/src/config_server/config_server.cpp
+++ b/rj_config/src/config_server/config_server.cpp
@@ -6,11 +6,12 @@
 #include <rj_utils/logging_macros.hpp>
 
 namespace config_server {
-ConfigServer::ConfigServer(const rclcpp::NodeOptions& node_options)
+ConfigServer::ConfigServer(const rclcpp::NodeOptions& node_options,
+                           const GameSettingsMsg& game_settings)
     : Node{"config_server", node_options},
+      game_settings_{game_settings},
       field_dimensions_{rj_convert::convert_to_ros(FieldDimensions::kDefaultDimensions)} {
     const auto latching_qos = rclcpp::QoS(1).transient_local();
-
     // Game Settings
     game_settings_publisher_ =
         create_publisher<GameSettingsMsg>(topics::kGameSettingsPub, latching_qos);

--- a/rj_config/src/config_server/main.cpp
+++ b/rj_config/src/config_server/main.cpp
@@ -1,7 +1,7 @@
+#include <fmt/format.h>
 #include <rclcpp/rclcpp.hpp>
 
 #include <config_server/config_server.hpp>
-#include <fmt/format.h>
 
 using config_server::ConfigServer;
 using config_server::GameSettingsMsg;

--- a/rj_config/src/config_server/main.cpp
+++ b/rj_config/src/config_server/main.cpp
@@ -1,12 +1,53 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <config_server/config_server.hpp>
+#include <fmt/format.h>
 
 using config_server::ConfigServer;
+using config_server::GameSettingsMsg;
+
+/**
+ * Parse game settings from the arguments. TODO: Unify this with the parsing in main().
+ * @param args the arguments, with ROS args removed.
+ * @return the game settings struct.
+ */
+GameSettingsMsg parse_game_settings(const std::vector<std::string>& args) {
+    GameSettingsMsg game_settings;
+    for (int i = 1; i < args.size(); i++) {
+        const std::string& arg = args.at(i);
+        if (arg == "-b") {
+            game_settings.request_blue_team = true;
+        } else if (arg == "-y") {
+            game_settings.request_blue_team = false;
+        } else if (arg == "-sim") {
+            game_settings.simulation = false;
+        } else if (arg == "-defend") {
+            i++;
+            const std::string& direction = args.at(i);
+            if (direction == "plus") {
+                game_settings.defend_plus_x = true;
+            } else if (direction == "minus") {
+                game_settings.defend_plus_x = false;
+            } else {
+                throw std::invalid_argument(fmt::format("Invalid defend direction: {}", direction));
+            }
+        }
+    }
+    return game_settings;
+}
 
 int main(int argc, char** argv) {
-    rclcpp::init(argc, argv);
-    rclcpp::spin(std::make_shared<ConfigServer>(rclcpp::NodeOptions()));
+    std::vector<std::string> args = rclcpp::init_and_remove_ros_arguments(argc, argv);
+
+    try {
+        GameSettingsMsg game_settings = parse_game_settings(args);
+        rclcpp::spin(std::make_shared<ConfigServer>(rclcpp::NodeOptions(), game_settings));
+    } catch (const std::invalid_argument& e) {
+        std::cerr << e.what() << std::endl;
+        return -1;
+    }
+
     rclcpp::shutdown();
+
     return 0;
 }

--- a/rj_config/src/config_server/main.cpp
+++ b/rj_config/src/config_server/main.cpp
@@ -7,7 +7,7 @@ using config_server::ConfigServer;
 using config_server::GameSettingsMsg;
 
 /**
- * Parse game settings from the arguments. TODO: Unify this with the parsing in main().
+ * Parse game settings from the arguments. TODO(#1592): Unify this with the parsing in main().
  * @param args the arguments, with ROS args removed.
  * @return the game settings struct.
  */

--- a/soccer/src/soccer/radio/sim_radio.cpp
+++ b/soccer/src/soccer/radio/sim_radio.cpp
@@ -114,6 +114,10 @@ void SimRadio::stop_robots() {
 }
 
 void SimRadio::switch_team(bool blue_team) {
+    if (blue_team == blue_team_) {
+        return;
+    }
+
     blue_team_ = blue_team;
 
     if (socket_.is_open()) {

--- a/soccer/src/soccer/referee/referee_base.cpp
+++ b/soccer/src/soccer/referee/referee_base.cpp
@@ -75,6 +75,8 @@ void RefereeBase::set_team_info(const TeamInfo& blue, const TeamInfo& yellow) {
 }
 
 void RefereeBase::set_team_color(bool is_blue) {
+    has_any_info_ = true;
+
     bool valid = true;
     update_cache(blue_team_, is_blue, &valid);
 
@@ -97,6 +99,10 @@ void RefereeBase::set_goalie(uint8_t goalie_id) {
 }
 
 void RefereeBase::send() {
+    if (!has_any_info_) {
+        return;
+    }
+
     if (!goalie_valid_) {
         GoalieMsg msg;
         msg.goalie_id = blue_team_ ? blue_info_.goalie : yellow_info_.goalie;

--- a/soccer/src/soccer/referee/referee_base.hpp
+++ b/soccer/src/soccer/referee/referee_base.hpp
@@ -149,6 +149,13 @@ private:
     bool blue_team_ = false;
     bool blue_team_valid_ = false;
 
+    /**
+     * @brief Whether we at least have an accurate blue_team value.
+     *
+     * @details If we don't we shouldn't send out anything at all.
+     */
+    bool has_any_info_ = false;
+
     rclcpp::Publisher<TeamColorMsg>::SharedPtr team_color_pub_;
     rclcpp::Publisher<GoalieMsg>::SharedPtr goalie_id_pub_;
     rclcpp::Publisher<TeamInfoMsg>::SharedPtr our_team_info_pub_;

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -634,7 +634,7 @@ void MainWindow::updateViews() {
         // If the request fails, we want to resend it, so mark game settings as invalid.
         _set_game_settings->async_send_request(
             game_settings_request,
-            [this] (rclcpp::Client<rj_msgs::srv::SetGameSettings>::SharedFuture result) {
+            [this](rclcpp::Client<rj_msgs::srv::SetGameSettings>::SharedFuture result) {  // NOLINT
                 if (!result.get()) {
                     _game_settings_valid = false;
                 }


### PR DESCRIPTION
## Description
Makefile and launch support for ROS.

This adds sim2play launch file, in which two ROS graphs are instanced under the `/yellow` and `/blue` namespaces.

## Associated Issue
Issue #1521

## Design
New ROS graph:
![image](https://user-images.githubusercontent.com/9097872/96505960-d95ff800-1224-11eb-9551-003f579e9ef2.png)

## Steps to test
### Standard sim launch

Run `make run-sim`

Expected result: a soccer window should appear. Soccer should work in simulation.

### 2-player sim launch

Run `make run-sim2play`

Expected result: two soccer windows should show up. Closing either should kill off all programs.

### Other targets
 - `make`: builds code
 - `make run-headmore`: runs sim with grSim visible
 - `make run`: runs soccer only, without simulator (in non-sim mode)

You can also use `make` followed by `ros2 launch` directly.