### PR TITLE
referee_module_enums (replaces RefereeModuleEnums) Issue #1590

### DIFF
--- a/rj_common/include/rj_common/referee_enums.hpp
+++ b/rj_common/include/rj_common/referee_enums.hpp
@@ -4,7 +4,7 @@
 
 #include <string>
 
-namespace RefereeModuleEnums {
+namespace referee_module_enums {
 
 using Stage = SSL_Referee_Stage;
 using Command = SSL_Referee_Command;
@@ -12,4 +12,4 @@ using Command = SSL_Referee_Command;
 std::string string_from_stage(Stage s);
 std::string string_from_command(Command c);
 
-}  // namespace RefereeModuleEnums
+}  // namespace referee_module_enums

--- a/rj_common/src/referee_enums.cpp
+++ b/rj_common/src/referee_enums.cpp
@@ -1,9 +1,9 @@
 #include "rj_common/referee_enums.hpp"
 
-namespace RefereeModuleEnums {
+namespace referee_module_enums {
 
 std::string string_from_stage(Stage s) { return SSL_Referee_Stage_Name(s); }
 
 std::string string_from_command(Command c) { return SSL_Referee_Command_Name(c); }
 
-}  // namespace RefereeModuleEnums
+}  // namespace referee_module_enums

--- a/soccer/src/soccer/gameplay/gameplay_module.cpp
+++ b/soccer/src/soccer/gameplay/gameplay_module.cpp
@@ -26,7 +26,7 @@ using namespace boost;
 using namespace boost::python;
 
 using namespace rj_geometry;
-using namespace RefereeModuleEnums;
+using namespace referee_module_enums;
 
 ConfigDouble* GameplayModule::field_edge_inset;
 

--- a/soccer/src/soccer/gameplay/robocup-py.cpp
+++ b/soccer/src/soccer/gameplay/robocup-py.cpp
@@ -1117,7 +1117,7 @@ BOOST_PYTHON_MODULE(robocup) {
         .def_readonly("MaxRobotSpeed", &MotionConstraints::max_speed_config)
         .def_readonly("MaxRobotAccel", &MotionConstraints::max_acceleration_config);
 
-    enum_<RefereeModuleEnums::Command>("Command")
+    enum_<referee_module_enums::Command>("Command")
         .value("halt", SSL_Referee_Command_HALT)
         .value("stop", SSL_Referee_Command_STOP)
         .value("normal_start", SSL_Referee_Command_NORMAL_START)

--- a/soccer/src/soccer/referee/external_referee.cpp
+++ b/soccer/src/soccer/referee/external_referee.cpp
@@ -20,8 +20,8 @@
 
 namespace referee {
 
-using RefereeModuleEnums::Command;
-using RefereeModuleEnums::Stage;
+using referee_module_enums::Command;
+using referee_module_enums::Stage;
 
 /// Distance in meters that the ball must travel for a kick to be detected
 static const float kKickThreshold = kBallRadius * 3;

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -512,9 +512,9 @@ void MainWindow::updateViews() {
     _ui.refStage->setText("");
     _ui.refCommand->setText("");
     //    _ui.refStage->setText(
-    //        RefereeModuleEnums::stringFromStage(game_state.raw_stage).c_str());
+    //        referee_module_enums::stringFromStage(game_state.raw_stage).c_str());
     //    _ui.refCommand->setText(
-    //        RefereeModuleEnums::stringFromCommand(game_state.raw_command).c_str());
+    //        referee_module_enums::stringFromCommand(game_state.raw_command).c_str());
 
     // Convert time left from ms to s and display it to two decimal places
     int timeSeconds = static_cast<int>(game_state.stage_time_left.count());


### PR DESCRIPTION
## Description
Namespace changed to referee_module_enums from RefereeModuleEnums

## Associated Issue
Issue #1590 

## Design Documents
[Link](link-to-design-doc)

## Steps to test

