### PR TITLE
Convert incoming parameter requests from . to ::

### DIFF
--- a/rj_param_utils/include/rj_param_utils/ros2_param_provider.hpp
+++ b/rj_param_utils/include/rj_param_utils/ros2_param_provider.hpp
@@ -34,6 +34,13 @@ private:
      */
     static std::string ConvertFullNameToROS2(const std::string& full_name);
 
+    /**
+     * @brief Converts the full name of a parameter from using periods (.) as the namespace separator to using double colons (::). Inverts @ref ConvertFullNameToROS2.
+     * @param ros2_name The ros2 name to convert.
+     * @return The full name of the parameter in ROS2 parameter convention.
+     */
+    static std::string ConvertFullNameFromROS2(const std::string& ros2_name);
+
     rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr
         callback_handle_;
 };

--- a/rj_param_utils/src/ros2_param_provider.cpp
+++ b/rj_param_utils/src/ros2_param_provider.cpp
@@ -108,6 +108,7 @@ void ROS2ParamProvider::InitUpdateParamCallbacks(rclcpp::Node* node) {
             //  - The parameter does not exist
             //  - The parameter's type as declared does not match the parameter's current type
             if (!success) {
+                // NOLINTNEXTLINE(bugprone-lambda-function-name)
                 SPDLOG_WARN("Failed to set parameter {}", param.get_name());
                 all_succeeded = false;
             }


### PR DESCRIPTION
## Description
This fixes a crash when attempting to set namespaced parameters. The names were not being converted correctly from ros2-style (using `.` as a separator) to our internal C++-style naming (using `::` as a separator). We would then attempt to lookup an invalid parameter, and, when it was not found, would crash.

This also fixes the crashing by using `TryUpdate` rather than `Update` so that we give sane default behavior when attempting to set an invalid or incorrectly-typed parameter.

## Associated Issue
N/A

## Design Documents
N/A

## Steps to test
### Namespaced parameters
1. Run any node with namespaced parameters (i.e. vision filter)
2. Attempt to set a namespaced parameter (i.e. `ros2 param set /vision_filter ball.observation_noise 0.01`)

Expected result: previously this would crash. It should now succeed.

### Invalid requests
1. Run any node with parameters (i.e. vision filter)
2. Attempt to set a nonexistent parameter (i.e. `ros2 param set /vision_filter adfssdfa 1`)

Expected result: previously this would crash. It should now fail on the setting end, by returning a result with success=false.