### PR TITLE
Use clang and LLD to speed up compile times.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 # Because we use ninja, we have to explicitly turn on color output for the compiler
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics -Werror=return-stack-address")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
 else()
+  message(WARNING "You are using GCC; prefer to use clang if it is installed with the flags `-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++`.")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always -Werror=return-local-addr")
 endif()
 

--- a/makefile
+++ b/makefile
@@ -11,23 +11,23 @@ endif
 
 # Tell CMake to create compile_commands.json for debug builds for clang-tidy
 DEBUG_FLAGS=-DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=$(shell pwd)/install"
+CMAKE_FLAGS=-DCMAKE_INSTALL_PREFIX="$(shell pwd)/install" -DNO_WALL=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 
 # build a specified target with CMake and Ninja
 # usage: $(call cmake_build_target, target, extraCmakeFlags)
 define cmake_build_target
 	mkdir -p build-debug
- 	cd build-debug && cmake -GNinja -Wno-dev -DNO_WALL=ON -DCMAKE_BUILD_TYPE=Debug $(DEBUG_FLAGS) $(CMAKE_FLAGS) --target -DBUILD_TESTS=ON .. && ninja $(NINJA_FLAGS) $1 install
+ 	cd build-debug && cmake -GNinja -Wno-dev -DCMAKE_BUILD_TYPE=Debug $(DEBUG_FLAGS) $(CMAKE_FLAGS) --target -DBUILD_TESTS=ON .. && ninja $(NINJA_FLAGS) $1 install
 endef
 
 define cmake_build_target_release
 	mkdir -p build-release
- 	cd build-release && cmake -GNinja -Wno-dev -DNO_WALL=ON -DCMAKE_BUILD_TYPE=Release $(CMAKE_FLAGS) --target -DBUILD_TESTS=ON .. && ninja $(NINJA_FLAGS) $1 install
+ 	cd build-release && cmake -GNinja -Wno-dev -DCMAKE_BUILD_TYPE=Release $(CMAKE_FLAGS) --target -DBUILD_TESTS=ON .. && ninja $(NINJA_FLAGS) $1 install
 endef
 
 define cmake_build_target_perf
 	mkdir -p build-release-debug
- 	cd build-release-debug && cmake -GNinja -Wno-dev -DNO_WALL=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo $(CMAKE_FLAGS) --target -DBUILD_TESTS=ON .. && ninja $(NINJA_FLAGS) $1 install
+ 	cd build-release-debug && cmake -GNinja -Wno-dev -DCMAKE_BUILD_TYPE=RelWithDebInfo $(CMAKE_FLAGS) --target -DBUILD_TESTS=ON .. && ninja $(NINJA_FLAGS) $1 install
 endef
 
 all:
@@ -122,7 +122,8 @@ behavior-diagrams: all
 	@echo -e "\n=> Open up 'soccer/gameplay/diagrams' to view behavior state machine diagrams"
 
 clean:
-	cd build-debug && ninja clean || true
+	((cd build-debug && ninja clean); (cd build-release && ninja clean); (cd build-release-debug && ninja clean)) || true
+	rm -rf install/bin install/lib install/share install/include
 
 static-analysis:
 	mkdir -p build/static-analysis

--- a/rj_geometry/CMakeLists.txt
+++ b/rj_geometry/CMakeLists.txt
@@ -22,11 +22,6 @@ add_library(geometry2d STATIC)
 add_subdirectory(src)
 
 # ======================================================================
-# Precompiled headers
-# ======================================================================
-target_precompile_headers(geometry2d PUBLIC include/rj_geometry/point.hpp)
-
-# ======================================================================
 # Dependencies List
 # ======================================================================
 set(GEOMETRY2D_DEPS_SYSTEM_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})


### PR DESCRIPTION
## Description
Use clang and LLD to speed up compile times. It turns out that these alternatives (especially LLD) cut out the bulk of our compile time.

Unfortunately clang/CMake don't interact nicely with precompiled headers, so this commit also disables the precompiled geometry header. That said, this was originally just a compilation speedup technique, so this is acceptable given that it results in a net compile time decrease.

On my machine this diff reduces compile times from ~2 minutes to under 30 seconds.

## Associated Issue
N/A (General improvement)

## Design Documents
N/A

## Steps to test
### Test Case 1
1. `make clean`
2. `make`

Expected result: compile times should be improved.