### PR TITLE
Make target to run the new gameplay tests (doesn't work, pleas help)

### DIFF
--- a/makefile
+++ b/makefile
@@ -124,6 +124,9 @@ behavior-diagrams: all
 clean:
 	cd build-debug && ninja clean || true
 
+test-python-new:
+	source /opt/ros/foxy/setup.sh && source install/setup.bash && PYTHONPATH="$(readlink -f rj_gameplay):$PYTHONPATH" python3 -m pytest --cov rj_gameplay --cov stp rj_gameplay --cov-report xml
+
 static-analysis:
 	mkdir -p build/static-analysis
 	cd build/static-analysis; scan-build cmake ../.. -Wno-dev -DSTATIC_ANALYSIS=ON && scan-build -o output make $(MAKE_FLAGS)


### PR DESCRIPTION
## Description
I might be dumb, but I don't think there is a maketarget that actually runs all the new python tests that CI runs. It should be trivial to create one as I have done here, except it doesn't work. Running the command regularly by copy-pasting into the command prompt runs the tests as expected, but I can't get it to work from the makefile. I'm not super experienced with the build system but if someone could tell me why this doesn't work that would be great. More info blow.

Where I'm getting the command from in CI:
![image](https://user-images.githubusercontent.com/8135314/118735063-a65b0280-b80d-11eb-84eb-ad24302ced21.png)

What the issue with the make target is:
![image](https://user-images.githubusercontent.com/8135314/118735095-ba066900-b80d-11eb-9d5b-d8aff999756a.png)
