### PR TITLE
Fix vision filter timing bugs and synchronize to vision receiver

### DIFF
--- a/soccer/include/rj_vision_filter/camera/world.hpp
+++ b/soccer/include/rj_vision_filter/camera/world.hpp
@@ -1,12 +1,13 @@
 #include <list>
+#include <vector>
+
 #include <rj_vision_filter/ball/world_ball.hpp>
 #include <rj_vision_filter/camera/camera.hpp>
 #include <rj_vision_filter/camera/camera_frame.hpp>
-#include <rj_vision_filter/kick/kick_event.hpp>
 #include <rj_vision_filter/kick/detector/fast_kick_detector.hpp>
 #include <rj_vision_filter/kick/detector/slow_kick_detector.hpp>
+#include <rj_vision_filter/kick/kick_event.hpp>
 #include <rj_vision_filter/robot/world_robot.hpp>
-#include <vector>
 
 namespace vision_filter {
 /**
@@ -22,11 +23,22 @@ public:
      *
      * @param calc_time Current iteration time
      * @param new_frames List of new frames from ssl vision
+     * @param update_all Whether to update the cameras without vision measurements
      *
      * @note Call this OR update_without_camera_frame ONCE an iteration
      */
-    void update_with_camera_frame(RJ::Time calc_time,
-                               const std::vector<CameraFrame>& new_frames);
+    void update_with_camera_frame(RJ::Time calc_time, const std::vector<CameraFrame>& new_frames,
+                                  bool update_all);
+
+    /**
+     * Updates all the child cameras given a set of new camera frames
+     *
+     * @param calc_time Current iteration time
+     * @param frame new frame for a single camera, from vision
+     *
+     * @note Call this once per camera per iteration
+     */
+    void update_single_camera(RJ::Time calc_time, const CameraFrame& frame);
 
     /**
      * Updates all the child cameras when there are no new camera frames
@@ -61,9 +73,7 @@ public:
      * @return Timestamp of the latest vision receiver message that was used to
      * updated the states. Initialized with RJ::Time::min().
      */
-    [[nodiscard]] RJ::Time last_update_time() const {
-        return last_update_time_;
-    }
+    [[nodiscard]] RJ::Time last_update_time() const { return last_update_time_; }
 
 private:
     /**

--- a/soccer/src/rj_vision_filter/camera/world.cpp
+++ b/soccer/src/rj_vision_filter/camera/world.cpp
@@ -20,8 +20,12 @@ World::World()
       robots_yellow_(kNumShells, WorldRobot()),
       robots_blue_(kNumShells, WorldRobot()) {}
 
-void World::update_with_camera_frame(RJ::Time calc_time,
-                                     const std::vector<CameraFrame>& new_frames) {
+void World::update_single_camera(RJ::Time calc_time, const CameraFrame& frame) {
+    update_with_camera_frame(calc_time, {frame}, false);
+}
+
+void World::update_with_camera_frame(RJ::Time calc_time, const std::vector<CameraFrame>& new_frames,
+                                     bool update_all) {
     calc_ball_bounce();
 
     std::vector<bool> camera_updated(PARAM_max_num_cameras, false);
@@ -57,9 +61,11 @@ void World::update_with_camera_frame(RJ::Time calc_time,
         last_update_time_ = std::max(last_update_time_, frame.t_capture);
     }
 
-    for (int i = 0; i < cameras_.size(); i++) {
-        if (!camera_updated.at(i) && cameras_.at(i).get_is_valid()) {
-            cameras_.at(i).update_without_frame(calc_time);
+    if (update_all) {
+        for (int i = 0; i < cameras_.size(); i++) {
+            if (!camera_updated.at(i) && cameras_.at(i).get_is_valid()) {
+                cameras_.at(i).update_without_frame(calc_time);
+            }
         }
     }
 

--- a/soccer/src/rj_vision_filter/filter/kalman_filter3_d.cpp
+++ b/soccer/src/rj_vision_filter/filter/kalman_filter3_d.cpp
@@ -8,7 +8,7 @@ namespace vision_filter {
 DEFINE_NS_FLOAT64(kVisionFilterParamModule, robot, init_covariance, 100.0,
                   "Initial covariance of the filter. Controls how fast it gets "
                   "to the target.")
-DEFINE_NS_FLOAT64(kVisionFilterParamModule, robot, process_noise, 0.1,
+DEFINE_NS_FLOAT64(kVisionFilterParamModule, robot, process_noise, 0.5,
                   "Controls how quickly it reacts to changes in ball accelerations.")
 DEFINE_NS_FLOAT64(kVisionFilterParamModule, robot, observation_noise, 2.0,
                   "Controls how much it trusts measurements from the camera.")

--- a/soccer/src/rj_vision_filter/params.cpp
+++ b/soccer/src/rj_vision_filter/params.cpp
@@ -1,7 +1,7 @@
 #include <rj_vision_filter/params.hpp>
 
 namespace vision_filter {
-DEFINE_FLOAT64(kVisionFilterParamModule, vision_loop_dt, 1.0 / 100.0,
+DEFINE_FLOAT64(kVisionFilterParamModule, vision_loop_dt, 1.0 / 60.0,
                "1/freq of the vision loop. In seconds.")
 
 DEFINE_INT64(kVisionFilterParamModule, max_num_cameras, 12,

--- a/soccer/testing/rj_vision_filter/kalman_robot_test.cpp
+++ b/soccer/testing/rj_vision_filter/kalman_robot_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <rj_vision_filter/params.hpp>
 #include <rj_vision_filter/robot/kalman_robot.hpp>
 #include <rj_vision_filter/robot/world_robot.hpp>
 
@@ -234,14 +235,14 @@ TEST(KalmanRobot, wrap_theta_up) {
 
     double ut = 0;
     for (int i = 0; i < 800; i++) {
-        pose.heading() += 1.0 / 100.0;
-        ut += 1.0 / 100.0;
+        pose.heading() += 1 * PARAM_vision_loop_dt;
+        ut += 1 * PARAM_vision_loop_dt;
 
         if (pose.heading() > M_PI) {
             pose.heading() -= 2 * M_PI;
         }
 
-        pose.position() += rj_geometry::Point(1, 1) * 1.0 / 100.0;
+        pose.position() += rj_geometry::Point(1, 1) * PARAM_vision_loop_dt;
 
         b = CameraRobot(t, pose, robot_id);
         kb.predict_and_update(RJ::now() + RJ::Seconds(10), b);
@@ -274,14 +275,14 @@ TEST(KalmanRobot, wrap_theta_down) {
 
     double ut = 0;
     for (int i = 0; i < 800; i++) {
-        pose.heading() -= 1.0 / 100.0;
-        ut -= 1.0 / 100.0;
+        pose.heading() -= 1.0 * PARAM_vision_loop_dt;
+        ut -= 1.0 * PARAM_vision_loop_dt;
 
         if (pose.heading() < -M_PI) {
             pose.heading() += 2 * M_PI;
         }
 
-        pose.position() -= rj_geometry::Point(1, 1) * 1.0 / 100.0;
+        pose.position() -= rj_geometry::Point(1, 1) * PARAM_vision_loop_dt;
 
         b = CameraRobot(t, pose, robot_id);
         kb.predict_and_update(RJ::now() + RJ::Seconds(10), b);


### PR DESCRIPTION
## Description
Synchronize the vision receiver to the incoming packet frequency.

This essentially inverts the triggering scheme for the vision receiver: instead of updating on a set frequency with all packets from an interval, we now update whenever we get a new packet and publish at a set frequency.


## Associated Issue
ClickUp: https://app.clickup.com/t/wbagen

## Design Documents
N/A

## Steps to test
### Emperical verification
1. Run code in manual control mode
2. Open rqt and plot robot velocity
3. Move a robot around

Expected result: velocity is smooth

Before:
![image](https://user-images.githubusercontent.com/9097872/119617321-bbb4cb80-bdcf-11eb-88e0-4aeab3bba52a.png)

After:
![image](https://user-images.githubusercontent.com/9097872/119616787-fff39c00-bdce-11eb-83de-7c8852a3ca9f.png)