### PR TITLE
(Partially) fix python static

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,8 @@ jobs:
       - checkout
       - <<: *install_deps
       - run: |
+          source /opt/ros/foxy/setup.bash && source install/setup.bash
           mkdir -p build-debug && cd build-debug
-          source /opt/ros/foxy/setup.bash
           export CMAKE_PREFIX_PATH=/opt/ros/foxy
           cmake -GNinja -Wno-dev -DNO_WALL=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_INSTALL_PREFIX=../install --target -DBUILD_TESTS=ON ..
           ninja -j2 install

--- a/cmake/run_setup_py.cmake
+++ b/cmake/run_setup_py.cmake
@@ -1,5 +1,5 @@
 #
-# Runs setup.py during installation time to install a python package.
+# Runs pip install -e . during installation time to install a python package.
 #
 # run_setup_py(<setup.py_dir> <build_dir> <install_dir>)
 #
@@ -10,8 +10,8 @@ function(run_setup_py setup_py_dir build_dir install_dir)
     find_program(PYTHON3 "python3" REQUIRED)
 
     set(SETUP_PY    "${setup_py_dir}/setup.py")
-    set(SETUP_ARGS  "develop --prefix ${install_dir} --build-directory ${build_dir} --no-deps")
-    set(SETUP_COMMAND "${PYTHON3} ${SETUP_PY} ${SETUP_ARGS} WORKING_DIRECTORY ${setup_py_dir}")
+    set(SETUP_ARGS  "--prefix ${install_dir} --build ${build_dir} --no-deps -e .")
+    set(SETUP_COMMAND "${PYTHON3} -m pip install ${SETUP_ARGS} WORKING_DIRECTORY ${setup_py_dir}")
 
     install(CODE "
     execute_process(COMMAND ${SETUP_COMMAND} OUTPUT_VARIABLE out ERROR_VARIABLE err RESULT_VARIABLE res)
@@ -19,3 +19,4 @@ function(run_setup_py setup_py_dir build_dir install_dir)
         message(FATAL_ERROR \"out: \${out}, err: \${err}, res: \${res}\")
     endif()")
 endfunction()
+


### PR DESCRIPTION
## Description
This PR fixes the broken `make pylint` step on python static introduced in #1650 by adding the `rj_gameplay/__init__.py` file.

## Steps to test
### Test Case 1
1. Observe CircleCI

Expected result: No long breaks on the `make pylint` step. Instead it fails `mypy` because of existing typechecking errors.