### PR TITLE
fix indentation that crashes sim

### DIFF
--- a/rj_gameplay/rj_gameplay/skill/capture.py
+++ b/rj_gameplay/rj_gameplay/skill/capture.py
@@ -31,7 +31,7 @@ class Capture(ICapture):
         self.root.setup_with_descendants()
 
     def tick(self, robot: rc.Robot, world_state: rc.WorldState):
-    	self.robot = robot
+        self.robot = robot
         return self.root.tick_once(robot, world_state)
 
     def is_done(self, world_state) -> bool:


### PR DESCRIPTION
## Description
Sim crashes on launch due to an indentation issue in skill/capture.py, likely from #1656. Fixed here.