### PR TITLE
Use cached pivot point in pivot even when target is constantly changing

### DIFF
--- a/soccer/src/soccer/planning/planner/pivot_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/pivot_path_planner.cpp
@@ -33,12 +33,23 @@ Trajectory PivotPathPlanner::plan(const PlanRequest& request) {
     auto pivot_point = command.pivot_point;
     auto pivot_target = command.pivot_target;
 
-    // TODO(Kyle): These need real constants
-    if (cached_pivot_target_.has_value() &&
-        cached_pivot_target_.value().dist_to(pivot_target) < kRobotMouthWidth / 2 &&
+    const bool pivot_target_unchanged =
+        cached_pivot_target_.has_value() &&
+        cached_pivot_target_.value().dist_to(pivot_target) < kRobotMouthWidth / 2;
+    bool pivot_point_unchanged =
         cached_pivot_point_.has_value() &&
-        cached_pivot_point_.value().dist_to(pivot_point) < kRobotMouthWidth / 2) {
+        cached_pivot_point_.value().dist_to(pivot_point) < kRobotMouthWidth / 2;
+
+    // TODO(Kyle): These need real constants
+    if (pivot_target_unchanged && pivot_point_unchanged) {
         return previous_;
+    }
+
+    if (pivot_point_unchanged) {
+        pivot_point = *cached_pivot_point_;
+    }
+    if (pivot_target_unchanged) {
+        pivot_target = *cached_pivot_target_;
     }
 
     cached_pivot_target_ = pivot_target;
@@ -95,8 +106,9 @@ Trajectory PivotPathPlanner::plan(const PlanRequest& request) {
         auto angle_to_target = position.angle_to(target_point);
 
         if (jacobian != nullptr) {
-            // The angle to the point changes with the dot product of the tangent vector to the circle with the robot's velocity, divided by the radius.
-            // Therefore, the rotated vector needs to be divided by the radius twice to get the jacobian.
+            // The angle to the point changes with the dot product of the tangent vector to the
+            // circle with the robot's velocity, divided by the radius. Therefore, the rotated
+            // vector needs to be divided by the radius twice to get the jacobian.
             *jacobian = (position - target_point).rotate(M_PI / 2);
             *jacobian /= jacobian->squaredNorm();
         }


### PR DESCRIPTION
Title. Fixes the thing where we push the ball across the field when the target point is changing (still does a replan but uses the old target in that case).