### PR TITLE
Organize gameplay

### DIFF
--- a/rj_gameplay/rj_gameplay/basic_play_selector.py
+++ b/rj_gameplay/rj_gameplay/basic_play_selector.py
@@ -4,7 +4,7 @@ import stp.rc as rc
 import rj_gameplay.situation.decision_tree.analyzer as analyzer
 import rj_gameplay.situation.decision_tree.plays as situations
 import rj_gameplay.play as plays
-from rj_gameplay.play import basic122, basic_defense, basic_scramble, defensive_clear, defend_restart, restart, kickoff_play, penalty_defense, penalty_offense, prep_penalty_offense
+from rj_gameplay.play import basic122, basic_defense, defensive_clear, defend_restart, restart, kickoff_play, penalty_defense, penalty_offense, prep_penalty_offense
 from typing import Tuple, Dict
 
 #TODO: Put new plays into the dict properly

--- a/rj_gameplay/rj_gameplay/basic_play_selector.py
+++ b/rj_gameplay/rj_gameplay/basic_play_selector.py
@@ -51,6 +51,10 @@ PLAY_DICT[situations.GoalieClear] = [defensive_clear.DefensiveClear]
 PLAY_DICT[situations.Stop] = [defend_restart.DefendRestart]
 
 class BasicPlaySelector(situation.IPlaySelector):
+    """Play selector that returns a play based on the situation from analyzer.
+
+    Currently configured to take in only one play per situation. Situation to play mapping is determined in PLAY_DICT constant above. (This means using this class requires importing the whole file, rather than just the class.)
+    """
 
     def __init__(self):
         self.analyzer = analyzer.Analyzer()

--- a/rj_gameplay/rj_gameplay/gameplay_node.py
+++ b/rj_gameplay/rj_gameplay/gameplay_node.py
@@ -97,7 +97,7 @@ class GameplayNode(Node):
         self.debug_text_pub = self.create_publisher(StringMsg,
                                                     '/gameplay/debug_text', 10)
         self.play_selector = play_selector
-        self.gameplay = coordinator.Coordinator(play_selector,
+        self.coordinator = coordinator.Coordinator(play_selector,
                                                 self.debug_callback)
 
     def set_play_state(self, play_state: msg.PlayState):
@@ -175,9 +175,11 @@ class GameplayNode(Node):
             self.world_state = None
 
         if self.world_state is not None:
-            intents = self.gameplay.tick(self.world_state)
+            intents = self.coordinator.tick(self.world_state)
             for i in range(NUM_ROBOTS):
                 self.robot_intent_pubs[i].publish(intents[i])
+
+            # TODO: separate these geometry calculations
 
             # create our_penalty rect
             our_penalty = geo_msg.Rect()

--- a/rj_gameplay/rj_gameplay/gameplay_node.py
+++ b/rj_gameplay/rj_gameplay/gameplay_node.py
@@ -15,24 +15,21 @@ import stp.local_parameters as local_parameters
 from stp.global_parameters import GlobalParameterClient
 import numpy as np
 from rj_gameplay.action.move import Move
-from rj_gameplay.play import basic_defense, basic_scramble, passing_tactic_play, defend_restart, restart, kickoff_play, \
+from rj_gameplay.play import basic_defense, passing_tactic_play, defend_restart, restart, kickoff_play, \
     basic122, penalty_defense
 from typing import List, Optional, Tuple
 from std_msgs.msg import String as StringMsg
 
-import stp.basic_play_selector as basic_play_selector
+import rj_gameplay.basic_play_selector as basic_play_selector
 
 NUM_ROBOTS = 16
 
 
-class EmptyPlaySelector(situation.IPlaySelector):
-    # an empty play selector, replace with actual one when created
-
-    def select(self, world_state: rc.WorldState) -> None:
-        return None
-
-
 class TestPlaySelector(situation.IPlaySelector):
+    """Convenience class for testing individual plays in gameplay without having to go through the play selection system.
+
+    Import a new play, then change the select() method's return below to force gameplay to always use the selected type.
+    """
     def select(self, world_state: rc.WorldState) -> Tuple[situation.ISituation, stp.play.IPlay]:
         self.curr_situation = None
         return (None, penalty_defense.PenaltyDefense())

--- a/rj_gameplay/rj_gameplay/play/defend_restart.py
+++ b/rj_gameplay/rj_gameplay/play/defend_restart.py
@@ -1,7 +1,7 @@
 import stp.play as play
 import stp.tactic as tactic
 
-from rj_gameplay.tactic import capture_tactic, nmark_tactic, goalie_tactic, wall_tactic
+from rj_gameplay.tactic import nmark_tactic, goalie_tactic, wall_tactic
 import stp.skill as skill
 import stp.role as role
 from stp.role.assignment.naive import NaiveRoleAssignment

--- a/rj_gameplay/rj_gameplay/skill/mark.py
+++ b/rj_gameplay/rj_gameplay/skill/mark.py
@@ -83,10 +83,6 @@ class Mark(IMark):
             self.move.target_point = mark_point
             self.move.face_point = world_state.ball.pos
 
-            # TODO: horrible hack for defending restarts
-            if self.is_def_restart:
-                self.move.is_def_restart = True
-
         actions = self.root.tick_once(robot, world_state)
         return actions
 

--- a/rj_gameplay/stp/coordinator.py
+++ b/rj_gameplay/stp/coordinator.py
@@ -17,7 +17,6 @@ class Coordinator:
     all of the resulting skills."""
 
     __slots__ = [
-        "_play_registry",
         "_play_selector",
         "_prev_situation",
         "_prev_play",


### PR DESCRIPTION
## Description
Light refactoring of the gameplay code that's being merged in from comp. Full changes:

 * rm imports of files that were deleted in `comp2021-merge`
 * rm hack for defending restarts in `move.py` that was patched
 * move basic_play_selector from stp/ to rj_gameplay/\*
 * rm unused field in stp/coordinator
 * rename field in gameplay_node that references the coordinator


\**it had dependencies in rj_gameplay, should be files in rj_gameplay import from files in stp/, not the other way around*

## Steps to test
Run sim. 

Expected result: Play selection still works as it did from comp.
