### PR TITLE
restore internal ref, grSim

### DIFF
--- a/config/sim.yaml
+++ b/config/sim.yaml
@@ -101,7 +101,8 @@
 
 /vision_receiver:
   ros__parameters:
-    port: 10020
+    port: 10060 # 10020 comp setup 
+    hz: 120.0
     use_sim_time: false
 
 /vision_filter:

--- a/launch/soccer.launch.py
+++ b/launch/soccer.launch.py
@@ -70,7 +70,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(vision_receiver_launch_path))
 
     ref_receiver = Node(package='rj_robocup',
-                        executable='external_referee_node',
+                        executable='internal_referee_node',
                         output='screen',
                         parameters=[config],
                         on_exit=Shutdown())

--- a/launch/vision_receiver.launch.py
+++ b/launch/vision_receiver.launch.py
@@ -7,13 +7,8 @@ from launch.actions import Shutdown
 
 
 def generate_launch_description():
-    sim_vision_port = 10020
     config = os.path.join(get_package_share_directory('rj_robocup'), 'config',
                           'sim.yaml')
-    shared_vision_port_single_primary = 10002
-
-    hz = 120.0
-    port = sim_vision_port
 
     return LaunchDescription([
         Node(

--- a/rj_vision_receiver/src/vision_receiver.cpp
+++ b/rj_vision_receiver/src/vision_receiver.cpp
@@ -16,7 +16,7 @@ constexpr auto kVisionReceiverParamModule = "vision_receiver";
 
 DEFINE_INT64(kVisionReceiverParamModule, port, kSimVisionPort,
              "The port used for the vision receiver.")
-DEFINE_STRING(kVisionReceiverParamModule, vision_interface, "127.0.0.1",
+DEFINE_STRING(kVisionReceiverParamModule, vision_interface, "",
               "The hardware interface to use.")
 
 namespace vision_receiver {


### PR DESCRIPTION
## Description
Mini PR that reverts our sim to grSim, and internal_referee_node instead of external_referee_node so that our code builds. (These can be changed to the [new ERForce sim](https://github.com/RoboJackets/robocup-software/pull/1657) and [external ref](https://github.com/RoboCup-SSL/ssl-game-controller) later.)

Roughly follows the changes made here: https://github.com/RoboJackets/robocup-software/commit/685ff77c3eb0a048a0d775ca2cede662a561eb4d