### PR TITLE
Split wall tactic

### DIFF
--- a/rj_gameplay/rj_gameplay/calculations/calculations.py
+++ b/rj_gameplay/rj_gameplay/calculations/calculations.py
@@ -1,0 +1,59 @@
+"""Holds calculation to find wall points."""
+
+from dataclasses import dataclass
+from typing import List, Optional
+from typing import Dict, Generic, List, Optional, Tuple, Type, TypeVar
+
+import stp.action as action
+import stp.rc as rc
+import stp.tactic as tactic
+import stp.role as role
+
+import rj_gameplay.eval
+import rj_gameplay.skill as skills
+from rj_gameplay.skill import move
+import stp.skill as skill
+import numpy as np
+# TODO: replace w/ global param server
+from stp.utils.constants import RobotConstants, BallConstants
+import stp.global_parameters as global_parameters
+
+MIN_WALL_RAD = None
+
+
+def find_wall_pts(num_wallers: int,
+                  world_state: rc.WorldState) -> List[np.ndarray]:
+    global MIN_WALL_RAD
+    """Calculates num_wallers points to form a wall between the ball and goal.
+    :return list of wall_pts (as numpy arrays)
+    """
+    # TODO: param server this const
+    # TODO: param server any constant from stp/utils/constants.py (this includes BallConstants)
+    ball_pt = world_state.ball.pos
+    goal_pt = world_state.field.our_goal_loc
+
+    WALL_SPACING = BallConstants.RADIUS
+
+    # dist is slightly greater than def_area box bounds
+    box_w = world_state.field.def_area_long_dist_m
+    box_h = world_state.field.def_area_short_dist_m
+    line_w = world_state.field.line_width_m * 2
+    MIN_WALL_RAD = RobotConstants.RADIUS + line_w + np.hypot(box_w / 2, box_h)
+
+    # get direction vec
+    dir_vec = (ball_pt - goal_pt) / np.linalg.norm(ball_pt - goal_pt)
+    wall_vec = np.array([dir_vec[1], -dir_vec[0]])
+
+    # find mid_pt
+    mid_pt = goal_pt + (dir_vec * MIN_WALL_RAD)
+    wall_pts = [mid_pt]
+
+    # set wall points in middle out pattern, given wall dir vector and WALL_SPACING constant
+    wall_pts = [mid_pt]
+    for i in range(num_wallers - 1):
+        mult = i // 2 + 1
+        delta = (mult * (2 * RobotConstants.RADIUS + WALL_SPACING)) * wall_vec
+        if i % 2: delta = -delta
+        wall_pts.append(mid_pt + delta)
+
+    return wall_pts

--- a/rj_gameplay/rj_gameplay/calculations/calculations.py
+++ b/rj_gameplay/rj_gameplay/calculations/calculations.py
@@ -1,4 +1,4 @@
-"""Holds calculation to find wall points."""
+"""Holds functions used by many gameplay files."""
 
 from dataclasses import dataclass
 from typing import List, Optional

--- a/rj_gameplay/rj_gameplay/calculations/wall_calculations.py
+++ b/rj_gameplay/rj_gameplay/calculations/wall_calculations.py
@@ -1,4 +1,4 @@
-"""Holds functions used by many gameplay files."""
+"""Holds functions used by plays that use the wall tactic."""
 
 from dataclasses import dataclass
 from typing import List, Optional

--- a/rj_gameplay/rj_gameplay/gameplay_node.py
+++ b/rj_gameplay/rj_gameplay/gameplay_node.py
@@ -341,7 +341,7 @@ def main():
     # uncomment this line to use the test play selector
     # play_selector = TestPlaySelector()
 
-    # comment out this line to when using the test play selector
+    # comment out this line when using the test play selector
     play_selector = basic_play_selector.BasicPlaySelector()
 
     gameplay = GameplayNode(play_selector)

--- a/rj_gameplay/rj_gameplay/gameplay_node.py
+++ b/rj_gameplay/rj_gameplay/gameplay_node.py
@@ -32,7 +32,7 @@ class TestPlaySelector(situation.IPlaySelector):
     """
     def select(self, world_state: rc.WorldState) -> Tuple[situation.ISituation, stp.play.IPlay]:
         self.curr_situation = None
-        return (None, basic_defense.BasicDefense())
+        return (None, restart.RestartPlay())
 
 
 class GameplayNode(Node):

--- a/rj_gameplay/rj_gameplay/gameplay_node.py
+++ b/rj_gameplay/rj_gameplay/gameplay_node.py
@@ -16,7 +16,7 @@ from stp.global_parameters import GlobalParameterClient
 import numpy as np
 from rj_gameplay.action.move import Move
 from rj_gameplay.play import basic_defense, passing_tactic_play, defend_restart, restart, kickoff_play, \
-    basic122, penalty_defense
+    basic122, penalty_defense, wall_ball
 from typing import List, Optional, Tuple
 from std_msgs.msg import String as StringMsg
 
@@ -32,7 +32,7 @@ class TestPlaySelector(situation.IPlaySelector):
     """
     def select(self, world_state: rc.WorldState) -> Tuple[situation.ISituation, stp.play.IPlay]:
         self.curr_situation = None
-        return (None, restart.RestartPlay())
+        return (None, penalty_defense.PenaltyDefense())
 
 
 class GameplayNode(Node):
@@ -338,7 +338,11 @@ class GameplayNode(Node):
 
 
 def main():
-    play_selector = TestPlaySelector()
-    # play_selector = basic_play_selector.BasicPlaySelector()
+    # uncomment this line to use the test play selector
+    # play_selector = TestPlaySelector()
+
+    # comment out this line to when using the test play selector
+    play_selector = basic_play_selector.BasicPlaySelector()
+
     gameplay = GameplayNode(play_selector)
     rclpy.spin(gameplay)

--- a/rj_gameplay/rj_gameplay/gameplay_node.py
+++ b/rj_gameplay/rj_gameplay/gameplay_node.py
@@ -32,7 +32,7 @@ class TestPlaySelector(situation.IPlaySelector):
     """
     def select(self, world_state: rc.WorldState) -> Tuple[situation.ISituation, stp.play.IPlay]:
         self.curr_situation = None
-        return (None, penalty_defense.PenaltyDefense())
+        return (None, basic_defense.BasicDefense())
 
 
 class GameplayNode(Node):
@@ -94,9 +94,9 @@ class GameplayNode(Node):
 
         # publish def_area_obstacles, global obstacles
         self.def_area_obstacles_pub = self.create_publisher(
-          geo_msg.ShapeSet, 'planning/def_area_obstacles', 10)
+            geo_msg.ShapeSet, 'planning/def_area_obstacles', 10)
         self.global_obstacles_pub = self.create_publisher(
-          geo_msg.ShapeSet, 'planning/global_obstacles', 10)
+            geo_msg.ShapeSet, 'planning/global_obstacles', 10)
 
         timer_period = 1 / 60  # seconds
         self.timer = self.create_timer(timer_period, self.gameplay_tick)
@@ -210,23 +210,28 @@ class GameplayNode(Node):
 
         # create Rect for our def_area box
         our_def_area = geo_msg.Rect()
-        top_left = geo_msg.Point(x=self.field.def_area_long_dist_m / 2 + self.field.line_width_m, y=0.0)
-        bot_right = geo_msg.Point(x=-self.field.def_area_long_dist_m / 2 - self.field.line_width_m,
+        top_left = geo_msg.Point(x=self.field.def_area_long_dist_m / 2 +
+                                 self.field.line_width_m,
+                                 y=0.0)
+        bot_right = geo_msg.Point(x=-self.field.def_area_long_dist_m / 2 -
+                                  self.field.line_width_m,
                                   y=self.field.def_area_short_dist_m)
         our_def_area.pt = [top_left, bot_right]
 
         # slack for distance (m) in Stop situations
         # https://robocup-ssl.github.io/ssl-rules/sslrules.html#_robot_too_close_to_opponent_defense_area
         add_stop_dist = game_info is None or game_info.state == rc.GameState.STOP or (
-                    game_info.is_restart() and not game_info.is_penalty())
+            game_info.is_restart() and not game_info.is_penalty())
         DIST_FOR_STOP = 0.3 if add_stop_dist else 0.0
 
         # create Rect for their def_area box
         their_def_area = geo_msg.Rect()
         left_x = self.field.def_area_long_dist_m / 2 + self.field.line_width_m + DIST_FOR_STOP
         bot_left = geo_msg.Point(x=left_x, y=self.field.length_m)
-        top_right = geo_msg.Point(x=-left_x, y=self.field.length_m - (
-                self.field.def_area_short_dist_m + self.field.line_width_m + DIST_FOR_STOP))
+        top_right = geo_msg.Point(x=-left_x,
+                                  y=self.field.length_m -
+                                  (self.field.def_area_short_dist_m +
+                                   self.field.line_width_m + DIST_FOR_STOP))
         their_def_area.pt = [bot_left, top_right]
 
         # publish Rect shape to def_area_obstacles topic
@@ -237,32 +242,48 @@ class GameplayNode(Node):
         physical_goal_board_width = 0.1
         our_goal = [
             geo_msg.Rect(pt=[
-                geo_msg.Point(x=self.field.goal_width_m / 2, y=-self.field.goal_depth_m),
+                geo_msg.Point(x=self.field.goal_width_m / 2,
+                              y=-self.field.goal_depth_m),
                 geo_msg.Point(x=-self.field.goal_width_m / 2,
-                              y=-self.field.goal_depth_m - physical_goal_board_width),
+                              y=-self.field.goal_depth_m -
+                              physical_goal_board_width),
             ]),
             geo_msg.Rect(pt=[
-                geo_msg.Point(x=self.field.goal_width_m / 2, y=-self.field.goal_depth_m),
-                geo_msg.Point(x=self.field.goal_width_m / 2 + physical_goal_board_width, y=0.),
+                geo_msg.Point(x=self.field.goal_width_m / 2,
+                              y=-self.field.goal_depth_m),
+                geo_msg.Point(x=self.field.goal_width_m / 2 +
+                              physical_goal_board_width,
+                              y=0.),
             ]),
             geo_msg.Rect(pt=[
-                geo_msg.Point(x=-self.field.goal_width_m / 2, y=-self.field.goal_depth_m),
-                geo_msg.Point(x=-self.field.goal_width_m / 2 - physical_goal_board_width, y=0.),
+                geo_msg.Point(x=-self.field.goal_width_m / 2,
+                              y=-self.field.goal_depth_m),
+                geo_msg.Point(x=-self.field.goal_width_m / 2 -
+                              physical_goal_board_width,
+                              y=0.),
             ]),
         ]
         their_goal = [
             geo_msg.Rect(pt=[
-                geo_msg.Point(x=self.field.goal_width_m / 2, y=self.field.length_m + self.field.goal_depth_m),
+                geo_msg.Point(x=self.field.goal_width_m / 2,
+                              y=self.field.length_m + self.field.goal_depth_m),
                 geo_msg.Point(x=-self.field.goal_width_m / 2,
-                              y=self.field.length_m + self.field.goal_depth_m + physical_goal_board_width),
+                              y=self.field.length_m + self.field.goal_depth_m +
+                              physical_goal_board_width),
             ]),
             geo_msg.Rect(pt=[
-                geo_msg.Point(x=self.field.goal_width_m / 2, y=self.field.length_m + self.field.goal_depth_m),
-                geo_msg.Point(x=self.field.goal_width_m / 2 + physical_goal_board_width, y=self.field.length_m),
+                geo_msg.Point(x=self.field.goal_width_m / 2,
+                              y=self.field.length_m + self.field.goal_depth_m),
+                geo_msg.Point(x=self.field.goal_width_m / 2 +
+                              physical_goal_board_width,
+                              y=self.field.length_m),
             ]),
             geo_msg.Rect(pt=[
-                geo_msg.Point(x=-self.field.goal_width_m / 2, y=self.field.length_m + self.field.goal_depth_m),
-                geo_msg.Point(x=-self.field.goal_width_m / 2 - physical_goal_board_width, y=self.field.length_m),
+                geo_msg.Point(x=-self.field.goal_width_m / 2,
+                              y=self.field.length_m + self.field.goal_depth_m),
+                geo_msg.Point(x=-self.field.goal_width_m / 2 -
+                              physical_goal_board_width,
+                              y=self.field.length_m),
             ]),
         ]
 
@@ -275,20 +296,28 @@ class GameplayNode(Node):
             if game_info.is_stopped() or game_info.their_restart and (
                     game_info.is_indirect() or game_info.is_direct()):
                 global_obstacles.circles.append(
-                    geo_msg.Circle(center=geo_msg.Point(x=ball_point[0], y=ball_point[1]), radius=0.6))
+                    geo_msg.Circle(center=geo_msg.Point(x=ball_point[0],
+                                                        y=ball_point[1]),
+                                   radius=0.6))
             if game_info.is_kickoff() and game_info.their_restart:
                 global_obstacles.circles.append(
-                    geo_msg.Circle(center=geo_msg.Point(x=ball_point[0], y=ball_point[1]), radius=0.3))
-            if game_info.is_kickoff() and game_info.is_setup() and game_info.our_restart:
+                    geo_msg.Circle(center=geo_msg.Point(x=ball_point[0],
+                                                        y=ball_point[1]),
+                                   radius=0.3))
+            if game_info.is_kickoff() and game_info.is_setup(
+            ) and game_info.our_restart:
                 global_obstacles.circles.append(
-                    geo_msg.Circle(center=geo_msg.Point(x=ball_point[0], y=ball_point[1]), radius=0.1))
+                    geo_msg.Circle(center=geo_msg.Point(x=ball_point[0],
+                                                        y=ball_point[1]),
+                                   radius=0.1))
             if game_info.is_free_placement():
                 for t in np.linspace(0.0, 1.0, 20):
                     placement = game_info.ball_placement()
 
                     pt = ball_point * t + (1 - t) * placement
                     global_obstacles.circles.append(
-                        geo_msg.Circle(center=geo_msg.Point(x=pt[0], y=pt[1]), radius=0.8))
+                        geo_msg.Circle(center=geo_msg.Point(x=pt[0], y=pt[1]),
+                                       radius=0.8))
 
     def tick_override_actions(self, world_state) -> None:
         for i in range(0, NUM_ROBOTS):
@@ -309,6 +338,7 @@ class GameplayNode(Node):
 
 
 def main():
-    play_selector = basic_play_selector.BasicPlaySelector()
+    play_selector = TestPlaySelector()
+    # play_selector = basic_play_selector.BasicPlaySelector()
     gameplay = GameplayNode(play_selector)
     rclpy.spin(gameplay)

--- a/rj_gameplay/rj_gameplay/play/basic122.py
+++ b/rj_gameplay/rj_gameplay/play/basic122.py
@@ -8,7 +8,7 @@ from stp.role.assignment.naive import NaiveRoleAssignment
 import stp.rc as rc
 from typing import Dict, Generic, Iterator, List, Optional, Tuple, Type, TypeVar
 import numpy as np
-from rj_gameplay.calculations import calculations
+from rj_gameplay.calculations import wall_calculations
 
 
 class Basic122(play.IPlay):
@@ -52,7 +52,8 @@ class Basic122(play.IPlay):
     ) -> Tuple[Dict[Type[tactic.SkillEntry], List[role.RoleRequest]],
                List[tactic.SkillEntry]]:
         # pre-calculate wall points and store in numpy array
-        wall_pts = calculations.find_wall_pts(self.num_wallers, world_state)
+        wall_pts = wall_calculations.find_wall_pts(self.num_wallers,
+                                                   world_state)
 
         # Get role requests from all tactics and put them into a dictionary
 

--- a/rj_gameplay/rj_gameplay/play/basic122.py
+++ b/rj_gameplay/rj_gameplay/play/basic122.py
@@ -26,7 +26,7 @@ class Basic122(play.IPlay):
         self.wall_tactic_2 = wall_tactic.WallTactic(role.Priority.LOW,
                                                     cost_scale=0.1)
 
-        # assuming number of wallers is fixed since this is a 1-2-2 play.
+        # number of wallers for finding wall_pts
         self.num_wallers = 2
 
         left_pt = np.array([1.5, 7.5])

--- a/rj_gameplay/rj_gameplay/play/basic122.py
+++ b/rj_gameplay/rj_gameplay/play/basic122.py
@@ -21,9 +21,10 @@ class Basic122(play.IPlay):
         self.striker_tactic = striker_tactic.LineKickStrikerTactic(
             target_point=self.target_point)
         self.goalie_tactic = goalie_tactic.GoalieTactic()
-        self.wall_tactic_1 = wall_tactic.WallTactic(role.Priority.LOW, cost_scale=0.1)
+        self.wall_tactic_1 = wall_tactic.WallTactic(role.Priority.LOW,
+                                                    cost_scale=0.1)
         self.wall_tactic_2 = wall_tactic.WallTactic(role.Priority.LOW,
-                                                  cost_scale=0.1)
+                                                    cost_scale=0.1)
 
         # assuming number of wallers is fixed since this is a 1-2-2 play.
         self.num_wallers = 2
@@ -89,7 +90,7 @@ class Basic122(play.IPlay):
         skills += self.goalie_tactic.tick(world_state,
                                           role_results[self.goalie_tactic])
         skills += self.wall_tactic_1.tick(world_state,
-                                        role_results[self.wall_tactic_1])
+                                          role_results[self.wall_tactic_1])
         skills += self.wall_tactic_2.tick(world_state,
                                           role_results[self.wall_tactic_2])
 

--- a/rj_gameplay/rj_gameplay/play/basic122.py
+++ b/rj_gameplay/rj_gameplay/play/basic122.py
@@ -26,7 +26,6 @@ class Basic122(play.IPlay):
         self.wall_tactic_2 = wall_tactic.WallTactic(role.Priority.LOW,
                                                     cost_scale=0.1)
 
-        # number of wallers for finding wall_pts
         self.num_wallers = 2
 
         left_pt = np.array([1.5, 7.5])

--- a/rj_gameplay/rj_gameplay/play/basic_defense.py
+++ b/rj_gameplay/rj_gameplay/play/basic_defense.py
@@ -6,7 +6,7 @@ import stp.role as role
 from stp.role.assignment.naive import NaiveRoleAssignment
 import stp.rc as rc
 from typing import Dict, List, Tuple, Type
-from rj_gameplay.calculations import calculations
+from rj_gameplay.calculations import wall_calculations
 
 
 class BasicDefense(play.IPlay):
@@ -38,7 +38,8 @@ class BasicDefense(play.IPlay):
                List[tactic.SkillEntry]]:
 
         # pre-calculate wall points and store in numpy array
-        wall_pts = calculations.find_wall_pts(self.num_wallers, world_state)
+        wall_pts = wall_calculations.find_wall_pts(self.num_wallers,
+                                                   world_state)
 
         # Get role requests from all tactics and put them into a dictionary
         role_requests: play.RoleRequests = {}

--- a/rj_gameplay/rj_gameplay/play/basic_defense.py
+++ b/rj_gameplay/rj_gameplay/play/basic_defense.py
@@ -21,7 +21,6 @@ class BasicDefense(play.IPlay):
             goalie_tactic.GoalieTactic()
         ]
 
-        # might need to change to for-loop
         self.num_wallers = 3
 
         self.role_assigner = NaiveRoleAssignment()

--- a/rj_gameplay/rj_gameplay/play/basic_defense.py
+++ b/rj_gameplay/rj_gameplay/play/basic_defense.py
@@ -45,6 +45,7 @@ class BasicDefense(play.IPlay):
         i = 0
         for tactic in self.tactics:
             if type(tactic) == type(wall_tactic.WallTactic()):
+                # TODO : change to choose closest one
                 role_requests[tactic] = tactic.get_requests(world_state, wall_pts[i], None)
                 i += 1
             else:

--- a/rj_gameplay/rj_gameplay/play/basic_defense.py
+++ b/rj_gameplay/rj_gameplay/play/basic_defense.py
@@ -46,12 +46,11 @@ class BasicDefense(play.IPlay):
         for tactic in self.tactics:
             if type(tactic) == type(wall_tactic.WallTactic()):
                 # TODO : change to choose closest one
-                role_requests[tactic] = tactic.get_requests(world_state, wall_pts[i], None)
+                role_requests[tactic] = tactic.get_requests(
+                    world_state, wall_pts[i], None)
                 i += 1
             else:
                 role_requests[tactic] = tactic.get_requests(world_state, None)
-
-
         """role_requests: play.RoleRequests = {
             tactic: tactic.get_requests(world_state, None)
             for tactic in self.tactics

--- a/rj_gameplay/rj_gameplay/play/defend_restart.py
+++ b/rj_gameplay/rj_gameplay/play/defend_restart.py
@@ -7,7 +7,7 @@ import stp.role as role
 from stp.role.assignment.naive import NaiveRoleAssignment
 import stp.rc as rc
 from typing import Dict, Generic, Iterator, List, Optional, Tuple, Type, TypeVar
-from rj_gameplay.calculations import calculations
+from rj_gameplay.calculations import wall_calculations
 
 
 class DefendRestart(play.IPlay):
@@ -34,7 +34,8 @@ class DefendRestart(play.IPlay):
                List[tactic.SkillEntry]]:
 
         # pre-calculate wall points and store in numpy array
-        wall_pts = calculations.find_wall_pts(self.num_wallers, world_state)
+        wall_pts = wall_calculations.find_wall_pts(self.num_wallers,
+                                                   world_state)
 
         # Get role requests from all tactics and put them into a dictionary
         role_requests: play.RoleRequests = {}

--- a/rj_gameplay/rj_gameplay/play/defend_restart.py
+++ b/rj_gameplay/rj_gameplay/play/defend_restart.py
@@ -7,15 +7,20 @@ import stp.role as role
 from stp.role.assignment.naive import NaiveRoleAssignment
 import stp.rc as rc
 from typing import Dict, Generic, Iterator, List, Optional, Tuple, Type, TypeVar
+from rj_gameplay.calculations import calculations
 
 
 class DefendRestart(play.IPlay):
     def __init__(self):
         # TODO: add chipper tactic here
         self.goalie = goalie_tactic.GoalieTactic()
-        self.markers = nmark_tactic.NMarkTactic(3, True)
-        self.wall = wall_tactic.WallTactic(2)
+        self.markers = nmark_tactic.NMarkTactic(3)
+        self.wall_1 = wall_tactic.WallTactic()
+        self.wall_2 = wall_tactic.WallTactic()
         self.role_assigner = NaiveRoleAssignment()
+
+        # might need to change to for-loop
+        self.num_wallers = 2
 
     def compute_props(self, prev_props):
         pass
@@ -28,13 +33,18 @@ class DefendRestart(play.IPlay):
     ) -> Tuple[Dict[Type[tactic.SkillEntry], List[role.RoleRequest]],
                List[tactic.SkillEntry]]:
 
+        # pre-calculate wall points and store in numpy array
+        wall_pts = calculations.find_wall_pts(self.num_wallers, world_state)
+
         # Get role requests from all tactics and put them into a dictionary
         role_requests: play.RoleRequests = {}
         role_requests[self.markers] = (self.markers.get_requests(
             world_state, None))
         role_requests[self.goalie] = self.goalie.get_requests(
             world_state, None)
-        role_requests[self.wall] = self.wall.get_requests(world_state, None)
+        role_requests[self.wall_1] = self.wall_1.get_requests(world_state, wall_pts[0], None)
+        role_requests[self.wall_2] = self.wall_2.get_requests(world_state,
+                                                              wall_pts[1], None)
 
         # Flatten requests and use role assigner on them
         flat_requests = play.flatten_requests(role_requests)
@@ -47,11 +57,13 @@ class DefendRestart(play.IPlay):
 
         skills = self.markers.tick(world_state, role_results[self.markers])
         skills += self.goalie.tick(world_state, role_results[self.goalie])
-        skills += self.wall.tick(world_state, role_results[self.wall])
+        skills += self.wall_1.tick(world_state, role_results[self.wall_1])
+        skills += self.wall_2.tick(world_state, role_results[self.wall_2])
         skill_dict = {}
         skill_dict.update(role_results[self.markers])
         skill_dict.update(role_results[self.goalie])
-        skill_dict.update(role_results[self.wall])
+        skill_dict.update(role_results[self.wall_1])
+        skill_dict.update(role_results[self.wall_2])
 
         return (skill_dict, skills)
 

--- a/rj_gameplay/rj_gameplay/play/defend_restart.py
+++ b/rj_gameplay/rj_gameplay/play/defend_restart.py
@@ -19,7 +19,6 @@ class DefendRestart(play.IPlay):
         self.wall_2 = wall_tactic.WallTactic()
         self.role_assigner = NaiveRoleAssignment()
 
-        # might need to change to for-loop
         self.num_wallers = 2
 
     def compute_props(self, prev_props):

--- a/rj_gameplay/rj_gameplay/play/defend_restart.py
+++ b/rj_gameplay/rj_gameplay/play/defend_restart.py
@@ -42,9 +42,10 @@ class DefendRestart(play.IPlay):
             world_state, None))
         role_requests[self.goalie] = self.goalie.get_requests(
             world_state, None)
-        role_requests[self.wall_1] = self.wall_1.get_requests(world_state, wall_pts[0], None)
-        role_requests[self.wall_2] = self.wall_2.get_requests(world_state,
-                                                              wall_pts[1], None)
+        role_requests[self.wall_1] = self.wall_1.get_requests(
+            world_state, wall_pts[0], None)
+        role_requests[self.wall_2] = self.wall_2.get_requests(
+            world_state, wall_pts[1], None)
 
         # Flatten requests and use role assigner on them
         flat_requests = play.flatten_requests(role_requests)

--- a/rj_gameplay/rj_gameplay/play/kickoff_play.py
+++ b/rj_gameplay/rj_gameplay/play/kickoff_play.py
@@ -11,7 +11,6 @@ import numpy as np
 from rj_gameplay.calculations import calculations
 
 
-
 class kickoff_cost(role.CostFn):
     def __call__(self, robot: rc.Robot, prev_result: Optional["RoleResult"],
                  world_state: rc.WorldState) -> float:
@@ -61,8 +60,8 @@ class PrepareKickoffPlay(play.IPlay):
         for tactic in self.tactics:
             if type(tactic) == type(wall_tactic.WallTactic()):
                 # TODO : change to choose closest one
-                role_requests[tactic] = tactic.get_requests(world_state,
-                                                            wall_pts[i], None)
+                role_requests[tactic] = tactic.get_requests(
+                    world_state, wall_pts[i], None)
                 i += 1
             else:
                 role_requests[tactic] = tactic.get_requests(world_state, None)
@@ -142,8 +141,8 @@ class DefendKickoffPlay(play.IPlay):
         for tactic in self.tactics:
             if type(tactic) == type(wall_tactic.WallTactic()):
                 # TODO : change to choose closest one
-                role_requests[tactic] = tactic.get_requests(world_state,
-                                                            wall_pts[i], None)
+                role_requests[tactic] = tactic.get_requests(
+                    world_state, wall_pts[i], None)
                 i += 1
             else:
                 role_requests[tactic] = tactic.get_requests(world_state, None)

--- a/rj_gameplay/rj_gameplay/play/kickoff_play.py
+++ b/rj_gameplay/rj_gameplay/play/kickoff_play.py
@@ -8,6 +8,8 @@ from stp.role.assignment.naive import NaiveRoleAssignment
 import stp.rc as rc
 from typing import Dict, Generic, Iterator, List, Optional, Tuple, Type, TypeVar
 import numpy as np
+from rj_gameplay.calculations import calculations
+
 
 
 class kickoff_cost(role.CostFn):
@@ -30,7 +32,10 @@ class PrepareKickoffPlay(play.IPlay):
             for pt in self.points
         ]
         self.tactics.append(goalie_tactic.GoalieTactic())
-        self.tactics.append(wall_tactic.WallTactic(2))
+        self.tactics.append(wall_tactic.WallTactic())
+        self.tactics.append(wall_tactic.WallTactic())
+
+        self.num_wallers = 2
 
         # self.move_left = move_tactic.Move(np.array([self.left_x, self.start_y]))
         self.role_assigner = NaiveRoleAssignment()
@@ -46,11 +51,21 @@ class PrepareKickoffPlay(play.IPlay):
     ) -> Tuple[Dict[Type[tactic.SkillEntry], List[role.RoleRequest]],
                List[tactic.SkillEntry]]:
 
+        # pre-calculate wall points and store in numpy array
+        wall_pts = calculations.find_wall_pts(self.num_wallers, world_state)
+
         # Get role requests from all tactics and put them into a dictionary
-        role_requests: play.RoleRequests = {
-            tactic: tactic.get_requests(world_state, None)
-            for tactic in self.tactics
-        }
+
+        role_requests: play.RoleRequests = {}
+        i = 0
+        for tactic in self.tactics:
+            if type(tactic) == type(wall_tactic.WallTactic()):
+                # TODO : change to choose closest one
+                role_requests[tactic] = tactic.get_requests(world_state,
+                                                            wall_pts[i], None)
+                i += 1
+            else:
+                role_requests[tactic] = tactic.get_requests(world_state, None)
 
         # Flatten requests and use role assigner on them
         flat_requests = play.flatten_requests(role_requests)
@@ -98,7 +113,10 @@ class DefendKickoffPlay(play.IPlay):
             for pt, priority in zip(self.points, self.priorities)
         ]
         self.tactics.append(goalie_tactic.GoalieTactic())
-        self.tactics.append(wall_tactic.WallTactic(2))
+        self.tactics.append(wall_tactic.WallTactic())
+        self.tactics.append(wall_tactic.WallTactic())
+
+        self.num_wallers = 2
 
         # self.move_left = move_tactic.Move(np.array([self.left_x, self.start_y]))
         self.role_assigner = NaiveRoleAssignment()
@@ -114,11 +132,21 @@ class DefendKickoffPlay(play.IPlay):
     ) -> Tuple[Dict[Type[tactic.SkillEntry], List[role.RoleRequest]],
                List[tactic.SkillEntry]]:
 
+        # pre-calculate wall points and store in numpy array
+        wall_pts = calculations.find_wall_pts(self.num_wallers, world_state)
+
         # Get role requests from all tactics and put them into a dictionary
-        role_requests: play.RoleRequests = {
-            tactic: tactic.get_requests(world_state, None)
-            for tactic in self.tactics
-        }
+
+        role_requests: play.RoleRequests = {}
+        i = 0
+        for tactic in self.tactics:
+            if type(tactic) == type(wall_tactic.WallTactic()):
+                # TODO : change to choose closest one
+                role_requests[tactic] = tactic.get_requests(world_state,
+                                                            wall_pts[i], None)
+                i += 1
+            else:
+                role_requests[tactic] = tactic.get_requests(world_state, None)
 
         # Flatten requests and use role assigner on them
         flat_requests = play.flatten_requests(role_requests)

--- a/rj_gameplay/rj_gameplay/play/kickoff_play.py
+++ b/rj_gameplay/rj_gameplay/play/kickoff_play.py
@@ -8,7 +8,7 @@ from stp.role.assignment.naive import NaiveRoleAssignment
 import stp.rc as rc
 from typing import Dict, Generic, Iterator, List, Optional, Tuple, Type, TypeVar
 import numpy as np
-from rj_gameplay.calculations import calculations
+from rj_gameplay.calculations import wall_calculations
 
 
 class kickoff_cost(role.CostFn):
@@ -51,7 +51,8 @@ class PrepareKickoffPlay(play.IPlay):
                List[tactic.SkillEntry]]:
 
         # pre-calculate wall points and store in numpy array
-        wall_pts = calculations.find_wall_pts(self.num_wallers, world_state)
+        wall_pts = wall_calculations.find_wall_pts(self.num_wallers,
+                                                   world_state)
 
         # Get role requests from all tactics and put them into a dictionary
 

--- a/rj_gameplay/rj_gameplay/play/kickoff_play.py
+++ b/rj_gameplay/rj_gameplay/play/kickoff_play.py
@@ -59,7 +59,7 @@ class PrepareKickoffPlay(play.IPlay):
         i = 0
         for tactic in self.tactics:
             if type(tactic) == type(wall_tactic.WallTactic()):
-                # TODO : change to choose closest one
+                # if wall tactic, also pass in a wall point
                 role_requests[tactic] = tactic.get_requests(
                     world_state, wall_pts[i], None)
                 i += 1

--- a/rj_gameplay/rj_gameplay/play/restart.py
+++ b/rj_gameplay/rj_gameplay/play/restart.py
@@ -31,12 +31,10 @@ class RestartPlay(play.IPlay):
             self.target_point, pass_seek.restart_seek,
             pass_seek.SeekCost(self.target_point))
         """
-        self.wall_tactic_1 = wall_tactic.WallTactic(
-                                                  role.Priority.LOW,
-                                                  cost_scale=0.1)
-        self.wall_tactic_2 = wall_tactic.WallTactic(
-                                                role.Priority.LOW,
-                                                cost_scale=0.1)
+        self.wall_tactic_1 = wall_tactic.WallTactic(role.Priority.LOW,
+                                                    cost_scale=0.1)
+        self.wall_tactic_2 = wall_tactic.WallTactic(role.Priority.LOW,
+                                                    cost_scale=0.1)
 
         left_pt = np.array([1.5, 7.5])
         self.seek_left = pass_seek.Seek(left_pt,
@@ -99,7 +97,7 @@ class RestartPlay(play.IPlay):
         skills += self.goalie_tactic.tick(world_state,
                                           role_results[self.goalie_tactic])
         skills += self.wall_tactic_1.tick(world_state,
-                                        role_results[self.wall_tactic_1])
+                                          role_results[self.wall_tactic_1])
         skills += self.wall_tactic_2.tick(world_state,
                                           role_results[self.wall_tactic_2])
         skills += self.seek_left.tick(world_state,
@@ -139,12 +137,10 @@ class DirectRestartPlay(play.IPlay):
             self.target_point, pass_seek.restart_seek,
             pass_seek.SeekCost(self.target_point))
         """
-        self.wall_tactic_1 = wall_tactic.WallTactic(
-            role.Priority.LOW,
-            cost_scale=0.1)
-        self.wall_tactic_2 = wall_tactic.WallTactic(
-            role.Priority.LOW,
-            cost_scale=0.1)
+        self.wall_tactic_1 = wall_tactic.WallTactic(role.Priority.LOW,
+                                                    cost_scale=0.1)
+        self.wall_tactic_2 = wall_tactic.WallTactic(role.Priority.LOW,
+                                                    cost_scale=0.1)
 
         # might need to change to for-loop
         self.num_wallers = 2
@@ -174,7 +170,6 @@ class DirectRestartPlay(play.IPlay):
 
         # pre-calculate wall points and store in numpy array
         wall_pts = calculations.find_wall_pts(self.num_wallers, world_state)
-
 
         # Get role requests from all tactics and put them into a dictionary
         role_requests: play.RoleRequests = {}
@@ -208,7 +203,7 @@ class DirectRestartPlay(play.IPlay):
         skills += self.goalie_tactic.tick(world_state,
                                           role_results[self.goalie_tactic])
         skills += self.wall_tactic_1.tick(world_state,
-                                        role_results[self.wall_tactic_1])
+                                          role_results[self.wall_tactic_1])
         skills += self.wall_tactic_2.tick(world_state,
                                           role_results[self.wall_tactic_2])
         skills += self.seek_left.tick(world_state,

--- a/rj_gameplay/rj_gameplay/play/restart.py
+++ b/rj_gameplay/rj_gameplay/play/restart.py
@@ -8,7 +8,7 @@ from stp.role.assignment.naive import NaiveRoleAssignment
 import stp.rc as rc
 from typing import Dict, Generic, Iterator, List, Optional, Tuple, Type, TypeVar
 import numpy as np
-from rj_gameplay.calculations import calculations
+from rj_gameplay.calculations import wall_calculations
 
 
 class RestartPlay(play.IPlay):
@@ -63,7 +63,8 @@ class RestartPlay(play.IPlay):
                List[tactic.SkillEntry]]:
 
         # pre-calculate wall points and store in numpy array
-        wall_pts = calculations.find_wall_pts(self.num_wallers, world_state)
+        wall_pts = wall_calculations.find_wall_pts(self.num_wallers,
+                                                   world_state)
 
         # Get role requests from all tactics and put them into a dictionary
         role_requests: play.RoleRequests = {}

--- a/rj_gameplay/rj_gameplay/play/restart.py
+++ b/rj_gameplay/rj_gameplay/play/restart.py
@@ -48,7 +48,7 @@ class RestartPlay(play.IPlay):
 
         self.role_assigner = NaiveRoleAssignment()
 
-        # might need to change to for-loop
+        # number of wallers for finding wall_pts
         self.num_wallers = 2
 
     def compute_props(self, prev_props):

--- a/rj_gameplay/rj_gameplay/play/wall_ball.py
+++ b/rj_gameplay/rj_gameplay/play/wall_ball.py
@@ -22,7 +22,6 @@ class WallBall(play.IPlay):
         self.wall_tactic_3 = wall_tactic.WallTactic()
         self.role_assigner = NaiveRoleAssignment()
 
-        # might need to change to for-loop
         self.num_wallers = 3
 
     def compute_props(self, prev_props):

--- a/rj_gameplay/rj_gameplay/play/wall_ball.py
+++ b/rj_gameplay/rj_gameplay/play/wall_ball.py
@@ -8,7 +8,7 @@ from stp.role.assignment.naive import NaiveRoleAssignment
 import stp.rc as rc
 from typing import Dict, Generic, Iterator, List, Optional, Tuple, Type, TypeVar
 import numpy as np
-from rj_gameplay.calculations import calculations
+from rj_gameplay.calculations import wall_calculations
 
 
 class WallBall(play.IPlay):
@@ -36,13 +36,17 @@ class WallBall(play.IPlay):
     ) -> Tuple[Dict[Type[tactic.SkillEntry], List[role.RoleRequest]], List[tactic.SkillEntry]]:
 
         # pre-calculate wall points and store in numpy array
-        wall_pts = calculations.find_wall_pts(self.num_wallers, world_state)
+        wall_pts = wall_calculations.find_wall_pts(self.num_wallers,
+                                                   world_state)
 
         # Get role requests from all tactics and put them into a dictionary
         role_requests: play.RoleRequests = {}
-        role_requests[self.wall_tactic_1] = self.wall_tactic_1.get_requests(world_state, wall_pts[0], None)
-        role_requests[self.wall_tactic_2] = self.wall_tactic_2.get_requests(world_state, wall_pts[1], None)
-        role_requests[self.wall_tactic_3] = self.wall_tactic_3.get_requests(world_state, wall_pts[2], None)
+        role_requests[self.wall_tactic_1] = self.wall_tactic_1.get_requests(
+            world_state, wall_pts[0], None)
+        role_requests[self.wall_tactic_2] = self.wall_tactic_2.get_requests(
+            world_state, wall_pts[1], None)
+        role_requests[self.wall_tactic_3] = self.wall_tactic_3.get_requests(
+            world_state, wall_pts[2], None)
 
         # Flatten requests and use role assigner on them
         flat_requests = play.flatten_requests(role_requests)
@@ -53,19 +57,21 @@ class WallBall(play.IPlay):
         skill_dict = {}
         skills = []
         skills += self.wall_tactic_1.tick(world_state,
-                                       role_results[self.wall_tactic_1])
+                                          role_results[self.wall_tactic_1])
         skill_dict.update(role_results[self.wall_tactic_1])
 
         skills += self.wall_tactic_2.tick(world_state,
-                                       role_results[self.wall_tactic_2])
+                                          role_results[self.wall_tactic_2])
         skill_dict.update(role_results[self.wall_tactic_2])
 
         skills += self.wall_tactic_3.tick(world_state,
-                                       role_results[self.wall_tactic_3])
+                                          role_results[self.wall_tactic_3])
         skill_dict.update(role_results[self.wall_tactic_3])
 
         return (skill_dict, skills)
 
     def is_done(self, world_state):
         # need to check this
-        return self.wall_tactic_1.is_done(world_state) and self.wall_tactic_2.is_done(world_state) and self.wall_tactic_3.is_done(world_state)
+        return self.wall_tactic_1.is_done(
+            world_state) and self.wall_tactic_2.is_done(
+                world_state) and self.wall_tactic_3.is_done(world_state)

--- a/rj_gameplay/rj_gameplay/play/wall_ball.py
+++ b/rj_gameplay/rj_gameplay/play/wall_ball.py
@@ -8,6 +8,7 @@ from stp.role.assignment.naive import NaiveRoleAssignment
 import stp.rc as rc
 from typing import Dict, Generic, Iterator, List, Optional, Tuple, Type, TypeVar
 import numpy as np
+from rj_gameplay.calculations import calculations
 
 
 class WallBall(play.IPlay):
@@ -16,8 +17,13 @@ class WallBall(play.IPlay):
     """
     def __init__(self):
         # defaults to walling between ball pos and goal pos
-        self.wall_tactic = wall_tactic.WallTactic(3)
+        self.wall_tactic_1 = wall_tactic.WallTactic()
+        self.wall_tactic_2 = wall_tactic.WallTactic()
+        self.wall_tactic_3 = wall_tactic.WallTactic()
         self.role_assigner = NaiveRoleAssignment()
+
+        # might need to change to for-loop
+        self.num_wallers = 3
 
     def compute_props(self, prev_props):
         pass
@@ -28,9 +34,15 @@ class WallBall(play.IPlay):
         prev_results: role.assignment.FlatRoleResults,
         props,
     ) -> Tuple[Dict[Type[tactic.SkillEntry], List[role.RoleRequest]], List[tactic.SkillEntry]]:
+
+        # pre-calculate wall points and store in numpy array
+        wall_pts = calculations.find_wall_pts(self.num_wallers, world_state)
+
         # Get role requests from all tactics and put them into a dictionary
         role_requests: play.RoleRequests = {}
-        role_requests[self.wall_tactic] = self.wall_tactic.get_requests(world_state, None)
+        role_requests[self.wall_tactic_1] = self.wall_tactic_1.get_requests(world_state, wall_pts[0], None)
+        role_requests[self.wall_tactic_2] = self.wall_tactic_2.get_requests(world_state, wall_pts[1], None)
+        role_requests[self.wall_tactic_3] = self.wall_tactic_3.get_requests(world_state, wall_pts[2], None)
 
         # Flatten requests and use role assigner on them
         flat_requests = play.flatten_requests(role_requests)
@@ -39,11 +51,21 @@ class WallBall(play.IPlay):
 
         # Get list of all skills with assigned roles from tactics
         skill_dict = {}
-        skills = self.wall_tactic.tick(world_state,
-                                       role_results[self.wall_tactic])
-        skill_dict.update(role_results[self.wall_tactic])
+        skills = []
+        skills += self.wall_tactic_1.tick(world_state,
+                                       role_results[self.wall_tactic_1])
+        skill_dict.update(role_results[self.wall_tactic_1])
+
+        skills += self.wall_tactic_2.tick(world_state,
+                                       role_results[self.wall_tactic_2])
+        skill_dict.update(role_results[self.wall_tactic_2])
+
+        skills += self.wall_tactic_3.tick(world_state,
+                                       role_results[self.wall_tactic_3])
+        skill_dict.update(role_results[self.wall_tactic_3])
 
         return (skill_dict, skills)
 
     def is_done(self, world_state):
-        return self.wall_tactic.is_done(world_state)
+        # need to check this
+        return self.wall_tactic_1.is_done(world_state) and self.wall_tactic_2.is_done(world_state) and self.wall_tactic_3.is_done(world_state)

--- a/rj_gameplay/rj_gameplay/tactic/wall_tactic.py
+++ b/rj_gameplay/rj_gameplay/tactic/wall_tactic.py
@@ -74,8 +74,8 @@ class WallTactic(tactic.ITactic):
         """
         pass
 
-    def get_requests(self, world_state: rc.WorldState,
-                     wall_pt, props) -> List[tactic.RoleRequests]:
+    def get_requests(self, world_state: rc.WorldState, wall_pt,
+                     props) -> List[tactic.RoleRequests]:
         """
         :return: A list of role requests for move skills needed
         """

--- a/rj_gameplay/rj_gameplay/tactic/wall_tactic.py
+++ b/rj_gameplay/rj_gameplay/tactic/wall_tactic.py
@@ -58,11 +58,9 @@ class WallTactic(tactic.ITactic):
     def __init__(self, priority=role.Priority.MEDIUM, cost_scale: float = 1.0):
 
         # create move SkillEntry for every robot
-        # TODO: change to variable from list
-        self.move_list = [tactic.SkillEntry(move.Move())]
-
-        # create empty cost_list (filled in get_requests)
-        self.cost_list = [wall_cost(scale=cost_scale)]
+        self.move_var = tactic.SkillEntry(move.Move())
+        # create empty cost_var (filled in get_requests)
+        self.cost_var = wall_cost(scale=cost_scale)
         self.priority = priority
 
     def compute_props(self):
@@ -85,15 +83,16 @@ class WallTactic(tactic.ITactic):
 
             # assign move skill params and cost funcs to each waller
             # loops through the array and assigns each robot a wall point
-            self.move_list[0].skill.target_point = wall_pt
-            self.move_list[0].skill.face_point = world_state.ball.pos
-            robot = self.move_list[0].skill.robot
-            self.cost_list[0].wall_pt = wall_pt
+            self.move_var.skill.target_point = wall_pt
+            self.move_var.skill.face_point = world_state.ball.pos
+            robot = self.move_var.skill.robot
+            self.cost_var.wall_pt = wall_pt
 
         # create RoleRequest for each SkillEntry
         role_requests = {
-            self.move_list[0]:
-            [role.RoleRequest(self.priority, False, self.cost_list[0])]
+            self.move_var:
+            [role.RoleRequest(self.priority, False, self.cost_var)]
+            for _ in range(1)
         }
 
         return role_requests
@@ -105,10 +104,7 @@ class WallTactic(tactic.ITactic):
         """
 
         # create list of skills based on if RoleResult exists for SkillEntry
-        skills = [
-            move_skill_entry for move_skill_entry in self.move_list
-            if role_results[move_skill_entry][0]
-        ]
+        skills = [self.move_var if role_results[self.move_var] else None]
 
         return skills
 
@@ -116,7 +112,7 @@ class WallTactic(tactic.ITactic):
         """
         :return boolean indicating if tactic is done
         """
-        for move_skill in self.move_list:
+        for move_skill in self.move_var:
             if not move_skill.skill.is_done(world_state):
                 return False
         return True

--- a/rj_gameplay/rj_gameplay/tactic/wall_tactic.py
+++ b/rj_gameplay/rj_gameplay/tactic/wall_tactic.py
@@ -78,11 +78,6 @@ class WallTactic(tactic.ITactic):
         :return: A list of role requests for move skills needed
         """
         if world_state and world_state.ball.visible:
-            # wall_pts = find_wall_pts(self.num_wallers, world_state)
-            # set the wall point?
-
-            # assign move skill params and cost funcs to each waller
-            # loops through the array and assigns each robot a wall point
             self.move_var.skill.target_point = wall_pt
             self.move_var.skill.face_point = world_state.ball.pos
             robot = self.move_var.skill.robot

--- a/rj_gameplay/stp/rc.py
+++ b/rj_gameplay/stp/rc.py
@@ -259,9 +259,9 @@ class Field:
     __slots__ = [
         "__length_m", "__width_m", "__border_m", "__line_width_m",
         "__goal_width_m", "__goal_depth_m", "__goal_height_m",
-        "__def_area_short_dist_m", "__def_area_long_dist_m", "__center_radius_m",
-        "__center_diameter_m", "__goal_flat_m", "__floor_length_m",
-        "__floor_width_m"
+        "__def_area_short_dist_m", "__def_area_long_dist_m",
+        "__center_radius_m", "__center_diameter_m", "__goal_flat_m",
+        "__floor_length_m", "__floor_width_m"
     ]
 
     __length_m: float

--- a/rj_vision_receiver/src/vision_receiver.cpp
+++ b/rj_vision_receiver/src/vision_receiver.cpp
@@ -16,8 +16,7 @@ constexpr auto kVisionReceiverParamModule = "vision_receiver";
 
 DEFINE_INT64(kVisionReceiverParamModule, port, kSimVisionPort,
              "The port used for the vision receiver.")
-DEFINE_STRING(kVisionReceiverParamModule, vision_interface, "",
-              "The hardware interface to use.")
+DEFINE_STRING(kVisionReceiverParamModule, vision_interface, "", "The hardware interface to use.")
 
 namespace vision_receiver {
 using boost::asio::ip::udp;


### PR DESCRIPTION
## Description
Wall tactic should only take one robot per tactic.

## Associated Issue
Issue #???

## Design Documents
n/a

## Steps to test
### Test Case 1
1. make
2. run sim
3. switch to test play selector and choose a play that uses wall tactic
    plays that use wall: basic_122, basic_defense, defend_restart, kickoff_play, restart, wall_ball
4. run sim again

Expected result: should still work
