### PR TITLE
Fixed kickoff_play.py MyPy Errors

### DIFF
--- a/rj_gameplay/rj_gameplay/gameplay_node.py
+++ b/rj_gameplay/rj_gameplay/gameplay_node.py
@@ -32,7 +32,7 @@ class TestPlaySelector(situation.IPlaySelector):
     """
     def select(self, world_state: rc.WorldState) -> Tuple[situation.ISituation, stp.play.IPlay]:
         self.curr_situation = None
-        return (None, penalty_defense.PenaltyDefense())
+        return (None, kickoff_play.PrepareKickoffPlay())
 
 
 class GameplayNode(Node):
@@ -339,10 +339,10 @@ class GameplayNode(Node):
 
 def main():
     # uncomment this line to use the test play selector
-    # play_selector = TestPlaySelector()
+    play_selector = TestPlaySelector()
 
     # comment out this line when using the test play selector
-    play_selector = basic_play_selector.BasicPlaySelector()
+    #play_selector = basic_play_selector.BasicPlaySelector()
 
     gameplay = GameplayNode(play_selector)
     rclpy.spin(gameplay)

--- a/rj_gameplay/rj_gameplay/gameplay_node.py
+++ b/rj_gameplay/rj_gameplay/gameplay_node.py
@@ -32,7 +32,7 @@ class TestPlaySelector(situation.IPlaySelector):
     """
     def select(self, world_state: rc.WorldState) -> Tuple[situation.ISituation, stp.play.IPlay]:
         self.curr_situation = None
-        return (None, kickoff_play.PrepareKickoffPlay())
+        return (None, penalty_defense.PenaltyDefense())
 
 
 class GameplayNode(Node):
@@ -339,10 +339,10 @@ class GameplayNode(Node):
 
 def main():
     # uncomment this line to use the test play selector
-    play_selector = TestPlaySelector()
+    # play_selector = TestPlaySelector()
 
     # comment out this line when using the test play selector
-    #play_selector = basic_play_selector.BasicPlaySelector()
+    play_selector = basic_play_selector.BasicPlaySelector()
 
     gameplay = GameplayNode(play_selector)
     rclpy.spin(gameplay)

--- a/rj_gameplay/rj_gameplay/play/kickoff_play.py
+++ b/rj_gameplay/rj_gameplay/play/kickoff_play.py
@@ -142,7 +142,7 @@ class DefendKickoffPlay(play.IPlay):
                List[tactic.SkillEntry]]:
 
         # pre-calculate wall points and store in numpy array
-        wall_pts = wall_calculations.find_wall_pts(self.num_wallers, 
+        wall_pts = wall_calculations.find_wall_pts(self.num_wallers,
                                                    world_state)
 
         # Get role requests from all tactics and put them into a dictionary

--- a/rj_gameplay/rj_gameplay/play/kickoff_play.py
+++ b/rj_gameplay/rj_gameplay/play/kickoff_play.py
@@ -142,7 +142,8 @@ class DefendKickoffPlay(play.IPlay):
                List[tactic.SkillEntry]]:
 
         # pre-calculate wall points and store in numpy array
-        wall_pts = wall_calculations.find_wall_pts(self.num_wallers, world_state)
+        wall_pts = wall_calculations.find_wall_pts(self.num_wallers, 
+                                                   world_state)
 
         # Get role requests from all tactics and put them into a dictionary
 

--- a/rj_gameplay/rj_gameplay/play/kickoff_play.py
+++ b/rj_gameplay/rj_gameplay/play/kickoff_play.py
@@ -12,13 +12,13 @@ from rj_gameplay.calculations import wall_calculations
 
 
 class kickoff_cost(role.CostFn):
-    def __call__(self, robot: rc.Robot, prev_result: Optional["RoleResult"],
+    def __call__(self, robot: rc.Robot, prev_result: Optional[role.RoleResult],
                  world_state: rc.WorldState) -> float:
         return 0.0
 
     def unassigned_cost_fn(
         self,
-        prev_result: Optional["RoleResult"],
+        prev_result: Optional[role.RoleResult],
         world_state: rc.WorldState,
     ) -> float:
 
@@ -56,7 +56,7 @@ class PrepareKickoffPlay(play.IPlay):
         world_state: rc.WorldState,
         prev_results: role.assignment.FlatRoleResults,
         props,
-    ) -> Tuple[Dict[Type[tactic.SkillEntry], List[role.RoleRequest]],
+    ) -> Tuple[Dict[tactic.SkillEntry, List[role.RoleResult]],
                List[tactic.SkillEntry]]:
 
         # pre-calculate wall points and store in numpy array
@@ -138,11 +138,11 @@ class DefendKickoffPlay(play.IPlay):
         world_state: rc.WorldState,
         prev_results: role.assignment.FlatRoleResults,
         props,
-    ) -> Tuple[Dict[Type[tactic.SkillEntry], List[role.RoleRequest]],
+    ) -> Tuple[Dict[tactic.SkillEntry, List[role.RoleResult]],
                List[tactic.SkillEntry]]:
 
         # pre-calculate wall points and store in numpy array
-        wall_pts = calculations.find_wall_pts(self.num_wallers, world_state)
+        wall_pts = wall_calculations.find_wall_pts(self.num_wallers, world_state)
 
         # Get role requests from all tactics and put them into a dictionary
 

--- a/rj_gameplay/stp/play/__init__.py
+++ b/rj_gameplay/stp/play/__init__.py
@@ -137,7 +137,8 @@ class IPlay(Generic[PropT], ABC):
         world_state: rc.WorldState,
         prev_results: assignment.FlatRoleResults,
         props: PropT,
-    ) -> Tuple[Dict[tactic.SkillEntry, List[role.RoleResult]], List[tactic.SkillEntry]]:
+    ) -> Tuple[Dict[tactic.SkillEntry, 
+                    List[role.RoleResult]], List[tactic.SkillEntry]]:
         """Performs one "tick" of the specified play.
 
         This should:

--- a/rj_gameplay/stp/play/__init__.py
+++ b/rj_gameplay/stp/play/__init__.py
@@ -137,7 +137,7 @@ class IPlay(Generic[PropT], ABC):
         world_state: rc.WorldState,
         prev_results: assignment.FlatRoleResults,
         props: PropT,
-    ) -> Tuple[Dict[tactic.SkillEntry, 
+    ) -> Tuple[Dict[tactic.SkillEntry,
                     List[role.RoleResult]], List[tactic.SkillEntry]]:
         """Performs one "tick" of the specified play.
 

--- a/rj_gameplay/stp/play/__init__.py
+++ b/rj_gameplay/stp/play/__init__.py
@@ -137,7 +137,7 @@ class IPlay(Generic[PropT], ABC):
         world_state: rc.WorldState,
         prev_results: assignment.FlatRoleResults,
         props: PropT,
-    ) -> Tuple[Dict[Type[tactic.SkillEntry], List[role.RoleRequest]], List[tactic.SkillEntry]]:
+    ) -> Tuple[Dict[tactic.SkillEntry, List[role.RoleResult]], List[tactic.SkillEntry]]:
         """Performs one "tick" of the specified play.
 
         This should:


### PR DESCRIPTION
I fixed MyPy errors in kickoff_play.py by replacing "RoleResult" with "role.RoleResult", replacing "calculations" with "wall_calculations" to match an existing class, and modifying the specified return types of some methods to match their actual return types.  I can confirm that the kickoff play still runs on my machine with this code and reports no MyPy errors within the kickoff_play.py file, but I had to change the IPlay class to avoid type incompatibility, and I am not sure if that is what I was supposed to do or if that will destroy other things.