### PR TITLE
add build-release-debug/ to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /.settings
 /api_docs
 *~
+build-*
 
 # sublime-text
 *.sublime-workspace


### PR DESCRIPTION
## Description
Makes it so that build-release-debug/ stops showing up when git status is run.

## Steps to test
Build repo, then run `git status`. Should not show build-release-debug in red.
