### PR TITLE
update debugging cpp for ros2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /api_docs
 *~
 build-*
+cmake-*
 
 # sublime-text
 *.sublime-workspace
@@ -43,3 +44,6 @@ perf.data*
 .coverage
 .coverage.*
 coverage.xml
+
+# Debugging launch files
+launch/debug-*

--- a/makefile
+++ b/makefile
@@ -71,22 +71,8 @@ backend-headless-simulator-soccer:
 backend-simulator-soccer:
 	ros2 launch rj_robocup sim.launch.py
 
-
+# TODO: add debug-sim again
 debug: all
-ifeq ($(shell uname), Linux)
-	gdb ./run/soccer
-else
-	lldb ./run/soccer.app
-endif
-
-debug-sim: all
-	-pkill -f './grSim'
-	-(cd run && ./grSim) &
-ifeq ($(shell uname), Linux)
-	gdb --args ./run/soccer -sim
-else
-	lldb -- ./run/soccer.app -sim
-endif
 
 # Run both C++ and python unit tests
 tests: test-cpp test-python
@@ -117,7 +103,7 @@ coverage:
 
 clean:
 	((rm build-debug -rf); (rm build-release -rf); (rm build-release-debug -rf)) || true
-	git clean -f -e -d cmake*
+	git clean -f -X -d cmake-*
 	rm -rf install/bin install/lib install/share install/include
 
 static-analysis:

--- a/makefile
+++ b/makefile
@@ -71,7 +71,6 @@ backend-headless-simulator-soccer:
 backend-simulator-soccer:
 	ros2 launch rj_robocup sim.launch.py
 
-# TODO: add debug-sim again
 debug: all
 
 # Run both C++ and python unit tests

--- a/util/debug-cpp.sh
+++ b/util/debug-cpp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-HELP_STR="Usage: ./debug-cpp.sh [-n] 
+HELP_STR="Usage: ./debug-cpp.sh [-n] [-h]
 \tn:\t\t\t name of node to debug (default soccer)
 \th:\t\t\t print this message!
 "

--- a/util/debug-cpp.sh
+++ b/util/debug-cpp.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -e
 
-HELP_STR="Usage: ./debug-cpp.sh [-n] [-d] [-h]
+HELP_STR="Usage: ./debug-cpp.sh [-n] 
 \tn:\t\t\t name of node to debug (default soccer)
 \th:\t\t\t print this message!
 "
 
-while getopts ":n:e:d:h" arg; do case "${arg}" in
+while getopts ":n:h" arg; do case "${arg}" in
 	h) printf "$HELP_STR" && exit 1 ;;
 	n) node=${OPTARG} ;;
 	?) printf "Unrecognized/Invalid Option: -${OPTARG}"

--- a/util/debug-cpp.sh
+++ b/util/debug-cpp.sh
@@ -2,25 +2,18 @@
 
 HELP_STR="Usage: ./debug-cpp.sh [-n] [-d] [-h]
 \tn:\t\t\t name of node to debug (default soccer)
-\t #TODO : fix these next 2 features or delete:
-\te:\t\t\t name of executable to debug, may be different than node name (default soccer)
-\td:\t\t\t select either gdb or lldb (default gdb)
 \th:\t\t\t print this message!
 "
 
 while getopts ":n:e:d:h" arg; do case "${arg}" in
 	h) printf "$HELP_STR" && exit 1 ;;
-	d) debugger=${OPTARG} && ([ "$debugger" = gdb ] || [ "$debugger" = lldb ]) || (printf "Unrecognized/Invalid Option: ${OPTARG}" && printf "\n$HELP_STR" exit 1);;
 	n) node=${OPTARG} ;;
-	e) executable=${OPTARG} ;;
 	?) printf "Unrecognized/Invalid Option: -${OPTARG}"
 	   printf "\n$HELP_STR"
 	   exit 1 ;;
 esac done
 
-[ -z "$debugger" ] && debugger="gdb"
 [ -z "$node" ] && node="soccer"
-[ -z "$executable" ] && executable="soccer"
 
 echo -e "for now we will assume the node "$node" is valid...\n"
 
@@ -62,11 +55,5 @@ echo -e "
 	1. ros2 launch rj_robocup debug-sim.launch.py\n
 	in a new terminal tab:\n
 	(recommended debugger is lldb-10 which is already installed by util/ubuntu-setup)  
-	2. ros2 run --prefix debugger_name -ex run --args' rj_robocup executable_name\n
+	2. ros2 run --prefix 'lldb-10 run' rj_robocup executable_name\n
 	"
-	
-# TODO: automatically launch launch file and run executable in new terminal
-# make perf
-#ros2 run --prefix '"$debugger" -ex run --args' rj_robocup "$executable"
-#xterm -hold 'ros2 launch rj_robocup debug-sim.launch.py -n' &
-

--- a/util/debug-cpp.sh
+++ b/util/debug-cpp.sh
@@ -1,0 +1,72 @@
+#!/bin/bash -e
+
+HELP_STR="Usage: ./debug-cpp.sh [-n] [-d] [-h]
+\tn:\t\t\t name of node to debug (default soccer)
+\t #TODO : fix these next 2 features or delete:
+\te:\t\t\t name of executable to debug, may be different than node name (default soccer)
+\td:\t\t\t select either gdb or lldb (default gdb)
+\th:\t\t\t print this message!
+"
+
+while getopts ":n:e:d:h" arg; do case "${arg}" in
+	h) printf "$HELP_STR" && exit 1 ;;
+	d) debugger=${OPTARG} && ([ "$debugger" = gdb ] || [ "$debugger" = lldb ]) || (printf "Unrecognized/Invalid Option: ${OPTARG}" && printf "\n$HELP_STR" exit 1);;
+	n) node=${OPTARG} ;;
+	e) executable=${OPTARG} ;;
+	?) printf "Unrecognized/Invalid Option: -${OPTARG}"
+	   printf "\n$HELP_STR"
+	   exit 1 ;;
+esac done
+
+[ -z "$debugger" ] && debugger="gdb"
+[ -z "$node" ] && node="soccer"
+[ -z "$executable" ] && executable="soccer"
+
+echo -e "for now we will assume the node "$node" is valid...\n"
+
+BASE=$(readlink -f $(dirname $0)/..)
+
+file="$BASE/launch/soccer.launch.py"
+
+FOUND_NODE_FLAG="0"
+FOUND_METHOD_FLAG="0"
+METHOD_NAME="generate_launch_description"
+while read -r line; do
+	if [ ${FOUND_NODE_FLAG} -ne "2" ] && [[ "$line" =~ ^"$node" ]]; then 
+		FOUND_NODE_FLAG="1"
+	elif [ ${FOUND_NODE_FLAG} -eq "1" ]; then
+		if [[ "$line" =~ ")"$ ]]; then
+			FOUND_NODE_FLAG="2"
+		fi
+	else
+		if ! [[ "$line" =~ "$node" ]]; then
+			if [[ "$line" =~ "$METHOD_NAME" ]]; then
+				FOUND_METHOD_FLAG="1"
+				echo -e "$line\n"
+			elif [ ${FOUND_METHOD_FLAG} -eq 1 ]; then
+				echo -e "\t$line\n"
+			else
+				echo -e "$line\n"
+			fi
+		fi
+	fi
+done <$file > "$BASE"/launch/debug-soccer.launch.py 
+
+[ ${FOUND_NODE_FLAG} -eq 2 ] || (printf "invalid node" && exit 1)
+
+sed 's/soccer.launch.py/debug-soccer.launch.py/g' "$BASE"/launch/sim.launch.py > "$BASE"/launch/debug-sim.launch.py
+
+echo -e "
+	done!\n
+	steps to debug now:\n
+	1. ros2 launch rj_robocup debug-sim.launch.py\n
+	in a new terminal tab:\n
+	(recommended debugger is lldb-10 which is already installed by util/ubuntu-setup)  
+	2. ros2 run --prefix debugger_name -ex run --args' rj_robocup executable_name\n
+	"
+	
+# TODO: automatically launch launch file and run executable in new terminal
+# make perf
+#ros2 run --prefix '"$debugger" -ex run --args' rj_robocup "$executable"
+#xterm -hold 'ros2 launch rj_robocup debug-sim.launch.py -n' &
+


### PR DESCRIPTION
## Description
The steps to debug with ros2  were outdated. This pr adds a script to generate separate debugging launch files and describes how to debug. Also, it makes small changes to .gitignore and makefile related to the update.

## Steps to test
### Test Case 1
you may need to chmod +x util/debug-cpp.sh
1. util/debug-cpp.sh -n node_to_debug (example: planner)
2. make perf / make debug
3. follow the steps echoed out by the script in step 1.
4. press r then enter in the debugger to begin running the executable (for planner the executable is called planner_node)

feel free to test any other debugging features, and the regular sim launch file should still work as well.

The todo to add debug-sim back can be deleted if we think it's not really worth thinking about. Also, there is a way to add to the script to both create the new launch files for debugging and launch and run the other node in a new terminal (but I couldn't figure it out in the short time I spent on this, what I tried is commented out at the bottom of the script). So if that is worth adding it can be done also (in a different pr I would think).

Expected result: should still work