### PR TITLE
Magic fix to trajectory splicing issue

### DIFF
--- a/soccer/src/soccer/planning/trajectory.cpp
+++ b/soccer/src/soccer/planning/trajectory.cpp
@@ -23,8 +23,7 @@ Trajectory::Trajectory(Trajectory a, const Trajectory& b) {
     if (!a_end.position().near_point(b_begin.position(), 1e-6) ||
         !a_end.linear_velocity().near_point(b_begin.linear_velocity(), 1e-6) ||
         a_end.stamp != b_begin.stamp) {
-        throw std::invalid_argument(
-            "Cannot splice trajectories a and b, where a.last() != b.first()");
+        a_end = b.first();
     }
 
     instants_ = std::move(a.instants_);


### PR DESCRIPTION
## Description
I am sorry if anyone noticed the total mess I made with Git while trying to make this PR.  I believe I have undone all of my damage outside of this branch (most of the "mess" was actually me just getting annoying errors locally, but I did accidentally commit to the role-assignment-update-2022 branch, and then "git revert" didn't work so I just manually reverted the changes).  But anyway, I changed a line of code super suspiciously and it made the error that occurred during the passing plays with trajectory splicing disappear.  The idea is basically that, since re-planning is known to sometimes cause a request for trajectories to be merged with different start/end points, that as a fail-safe, instead of crashing completely, we just append the first point of the second trajectory to the first one (basically adding a connecting line segment).  There is no guarantee that the line segment can be pursued safely, but it seems extremely likely, because both trajectories are safe and the space between them should be very small unless there is a more serious glitch elsewhere in the code base (in which case, the current behavior of crashing is not necessarily better anyway).  I verified that both the passing play and the basic defense play still work seemingly as intended both with the ball at the center, and with the ball at the locations that caused a crash before.  I do not recommend this fix as a permanent solution unless someone with a better understanding of the trajectory generation endorses it (which seems incredibly unlikely), but for now... fewer crashes is better than many crashes, right?

## Associated Issue
Issue: No number found, but the issue was that passing plays from certain positions somehow led to the generation of disconnected trajectories and the whole simulation crashed when we tried to splice the trajectories anyway.

## Steps to test
### Test Case 1
1. Step 1 `git fetch` then `git checkout role-assignment-update-2022-trajectory-glitch-magic-patch` then `git pull`
2. Step 2 Insert a desired play into the TestPlaySelector and make sure it is enabled
3. Step 3 Run the play

Expected result: The play should work without crashing and function no worse than it did before
