### PR TITLE
Update to Erforce Sim

### DIFF
--- a/config/sim.yaml
+++ b/config/sim.yaml
@@ -101,8 +101,9 @@
 
 /vision_receiver:
   ros__parameters:
-    port: 10060 # 10020 comp setup 
-    hz: 120.0
+    port: 10020
+    # port: 10060 # 10020 comp setup 
+    # hz: 120.0
     use_sim_time: false
 
 /vision_filter:

--- a/launch/sim.launch.py
+++ b/launch/sim.launch.py
@@ -27,12 +27,12 @@ def generate_launch_description():
         "RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED", "1"
     )
 
-    grsim = Node(
-        package="rj_robocup",
-        executable="grSim",
-        arguments=[headless_flag],
-        on_exit=Shutdown(),
-    )
+    #grsim = Node(
+    #    package="rj_robocup",
+    #    executable="grSim",
+    #    arguments=[headless_flag],
+    #    on_exit=Shutdown(),
+    #)
 
     soccer_launch_path = str(launch_dir / "soccer.launch.py")
     soccer = IncludeLaunchDescription(
@@ -52,7 +52,7 @@ def generate_launch_description():
             DeclareLaunchArgument("headless_flag", default_value=""),
             DeclareLaunchArgument("direction_flag", default_value="plus"),
             stdout_linebuf_envvar,
-            grsim,
+            # grsim,
             soccer,
         ]
     )

--- a/rj_vision_receiver/src/vision_receiver.cpp
+++ b/rj_vision_receiver/src/vision_receiver.cpp
@@ -16,7 +16,7 @@ constexpr auto kVisionReceiverParamModule = "vision_receiver";
 
 DEFINE_INT64(kVisionReceiverParamModule, port, kSimVisionPort,
              "The port used for the vision receiver.")
-DEFINE_STRING(kVisionReceiverParamModule, vision_interface, "", "The hardware interface to use.")
+DEFINE_STRING(kVisionReceiverParamModule, vision_interface, "127.0.0.1", "The hardware interface to use.")
 
 namespace vision_receiver {
 using boost::asio::ip::udp;


### PR DESCRIPTION
## Description
Updating the physics sim to use the errforce simulator

## Steps to test
1. Download [Errforce Sim](https://github.com/robotics-erlangen/framework) and run `colcon build` on it
2. Run `./simulator-cli` in framework/build/erforce/bin
3. Call `make perf` on robocup-software and then run sim.launch.py 

Expected result: Run Erforce physics sim when sim.launch.py is called without error
