### PR TITLE
Delete trajectory test that no longer works

### DIFF
--- a/rj_gameplay/rj_gameplay/skill/capture.py
+++ b/rj_gameplay/rj_gameplay/skill/capture.py
@@ -31,7 +31,7 @@ class Capture(skill.Skill):
 
         collect_command = CollectMotionCommand()
         intent.motion_command.collect_command = [collect_command]
-        intent.dribbler_speed = 1.0  #dribbler is on by default 
+        intent.dribbler_speed = 1.0  # dribbler is on by default
         intent.is_active = True
 
         return intent

--- a/rj_gameplay/stp/play/__init__.py
+++ b/rj_gameplay/stp/play/__init__.py
@@ -79,7 +79,7 @@ class Play(ABC):
         """Given that all Roles are in sorted order of priority, greedily assign the highest-priority Role to the lowest-cost robot for that Role. Instantiate Tactics with the correct robots post-assignment. (Note that this behavior is largely handled by the init_roles of each Tactic.)
         Satisfy constraint that all Roles of a Tactic must all be assigned at once. If a Tactic's Roles cannot all be filled, do not fill any of its Roles.
         """
-        
+
         used_robots = set()
         for tactic in self.prioritized_tactics:
             # TODO: handle if tactic requests more roles than exist

--- a/soccer/src/soccer/planning/tests/trajectory_test.cpp
+++ b/soccer/src/soccer/planning/tests/trajectory_test.cpp
@@ -224,18 +224,18 @@ TEST(Trajectory, CombiningFail) {
     Trajectory traj_2{{b2, c}};
 
     // EXPECT_THROW((Trajectory{std::move(traj_1), traj_2}), std::invalid_argument);
-    
-    // This last test is commented out because, right now, the receiver of a pass begins planning a path
-    // as soon as the ball exists the passer, at which point the ball is very close to the passer.
-    // So the receiver, when making its plan to stop after receiving the ball, is forced to decelerate 
-    // extremely rapidly to avoid colliding with the passer, but is limited by our acceleration 
-    // constraints and instead compromises the initial velocity when planning the stop motion to receive a 
-    // pass, which causes a crash because of the discontinuity in velocity it creates.  So we force the
-    // start velocity of the stop trajectory to match the end velocity of the ball pursuit trajectory,
-    // which would force the discontinuity onto our control code, but that doesn't happen because the
-    // problem will resolve itself well before we can actually get the ball.  However, this fix means
-    // that the crash this test expects no longer happens, or else we would see crashes in a high
-    // percentage of our receiving plays.  We are working on a better path planner that will let us
-    // find a cleaner solution to this problem, but for now, this basic solution is the best way to
-    // avoid flaws.
+
+    // This last test is commented out because, right now, the receiver of a pass begins planning a
+    // path as soon as the ball exists the passer, at which point the ball is very close to the
+    // passer. So the receiver, when making its plan to stop after receiving the ball, is forced to
+    // decelerate extremely rapidly to avoid colliding with the passer, but is limited by our
+    // acceleration constraints and instead compromises the initial velocity when planning the stop
+    // motion to receive a pass, which causes a crash because of the discontinuity in velocity it
+    // creates.  So we force the start velocity of the stop trajectory to match the end velocity of
+    // the ball pursuit trajectory, which would force the discontinuity onto our control code, but
+    // that doesn't happen because the problem will resolve itself well before we can actually get
+    // the ball.  However, this fix means that the crash this test expects no longer happens, or
+    // else we would see crashes in a high percentage of our receiving plays.  We are working on a
+    // better path planner that will let us find a cleaner solution to this problem, but for now,
+    // this basic solution is the best way to avoid flaws.
 }

--- a/soccer/src/soccer/planning/tests/trajectory_test.cpp
+++ b/soccer/src/soccer/planning/tests/trajectory_test.cpp
@@ -223,5 +223,19 @@ TEST(Trajectory, CombiningFail) {
     Trajectory traj_1{{a, b1}};
     Trajectory traj_2{{b2, c}};
 
-    EXPECT_THROW((Trajectory{std::move(traj_1), traj_2}), std::invalid_argument);
+    // EXPECT_THROW((Trajectory{std::move(traj_1), traj_2}), std::invalid_argument);
+    
+    // This last test is commented out because, right now, the receiver of a pass begins planning a path
+    // as soon as the ball exists the passer, at which point the ball is very close to the passer.
+    // So the receiver, when making its plan to stop after receiving the ball, is forced to decelerate 
+    // extremely rapidly to avoid colliding with the passer, but is limited by our acceleration 
+    // constraints and instead compromises the initial velocity when planning the stop motion to receive a 
+    // pass, which causes a crash because of the discontinuity in velocity it creates.  So we force the
+    // start velocity of the stop trajectory to match the end velocity of the ball pursuit trajectory,
+    // which would force the discontinuity onto our control code, but that doesn't happen because the
+    // problem will resolve itself well before we can actually get the ball.  However, this fix means
+    // that the crash this test expects no longer happens, or else we would see crashes in a high
+    // percentage of our receiving plays.  We are working on a better path planner that will let us
+    // find a cleaner solution to this problem, but for now, this basic solution is the best way to
+    // avoid flaws.
 }


### PR DESCRIPTION
Because of recent changes to prevent a crash from trajectory splicing in the settle planner, there is a test here that is no longer applicable to our current code.  For now, we have commented it out.