### PR TITLE
Make FSMs in gameplay Enum-based

### DIFF
--- a/rj_gameplay/rj_gameplay/play/basic_defense.py
+++ b/rj_gameplay/rj_gameplay/play/basic_defense.py
@@ -10,6 +10,13 @@ from rj_gameplay.calculations import wall_calculations
 import stp.role.cost
 from rj_msgs.msg import RobotIntent
 
+from enum import Enum, auto
+
+
+class State(Enum):
+    INIT = auto()
+    ACTIVE = auto()
+
 
 class BasicDefense(stp.play.Play):
     """Play that consists of:
@@ -21,23 +28,21 @@ class BasicDefense(stp.play.Play):
     def __init__(self):
         super().__init__()
 
-        # super simple FSM
-        # TODO: use FSM class (or at least don't use string literals)
-        self._state = "init"
+        self._state = State.INIT
 
     def tick(
         self,
         world_state: stp.rc.WorldState,
     ) -> List[RobotIntent]:
 
-        if self._state == "init":
+        if self._state == State.INIT:
             self.prioritized_tactics.append(goalie_tactic.GoalieTactic(world_state, 0))
             self.prioritized_tactics.append(wall_tactic.WallTactic(world_state, 5))
             # TODO: add nmark tactic
             #       and make it go for the ball (rather than stopping in front)
             self.assign_roles(world_state)
-            self._state = "active"
+            self._state = State.ACTIVE
             return self.get_robot_intents(world_state)
-        elif self._state == "active":
+        elif self._state == State.ACTIVE:
             # return robot intents from assigned tactics back to gameplay node
             return self.get_robot_intents(world_state)

--- a/rj_gameplay/rj_gameplay/play/keepaway.py
+++ b/rj_gameplay/rj_gameplay/play/keepaway.py
@@ -23,8 +23,6 @@ class Keepaway(stp.play.Play):
     def __init__(self):
         super().__init__()
 
-        # super simple FSM
-        # TODO: use FSM class (or at least don't use string literals)
         self._state = State.INIT
 
     def tick(

--- a/rj_gameplay/rj_gameplay/play/keepaway.py
+++ b/rj_gameplay/rj_gameplay/play/keepaway.py
@@ -6,6 +6,14 @@ from rj_gameplay.tactic import pass_tactic
 
 from rj_msgs.msg import RobotIntent
 
+from enum import Enum, auto
+
+
+class State(Enum):
+    INIT = auto()
+    ACTIVE = auto()
+    ASSIGN_ROLES = auto()
+
 
 class Keepaway(stp.play.Play):
     """Play that passes repeatedly, effectively playing keepaway.
@@ -17,7 +25,7 @@ class Keepaway(stp.play.Play):
 
         # super simple FSM
         # TODO: use FSM class (or at least don't use string literals)
-        self._state = "init"
+        self._state = State.INIT
 
     def tick(
         self,
@@ -31,15 +39,15 @@ class Keepaway(stp.play.Play):
         (the effect is to pass indefinitely)
         """
 
-        if self._state == "init":
+        if self._state == State.INIT:
             self.prioritized_tactics = [pass_tactic.PassTactic(world_state)]
             # TODO: either add seek tactic(s) or unassigned behavior
 
             self.assign_roles(world_state)
-            self._state = "active"
+            self._state = State.ACTIVE
             return self.get_robot_intents(world_state)
 
-        elif self._state == "active":
+        elif self._state == State.ACTIVE:
             # TODO: this loop's logic is fairly crucial in role assignment
             #
             # is there a way I can force this to happen as a precondition to assign_roles?
@@ -47,17 +55,17 @@ class Keepaway(stp.play.Play):
             # (this works as the method is in Play superclass)
             for tactic in self.prioritized_tactics:
                 if tactic.needs_assign:
-                    self._state = "assign_roles"
+                    self._state = State.ASSIGN_ROLES
 
             # only one tactic in this play
             tactic = self.prioritized_tactics[0]
             if tactic.is_done(world_state):
-                self._state = "init"
+                self._state = State.INIT
 
             return self.get_robot_intents(world_state)
 
-        elif self._state == "assign_roles":
+        elif self._state == State.ASSIGN_ROLES:
             # duplicate code from init
             self.assign_roles(world_state)
-            self._state = "active"
+            self._state = State.ACTIVE
             return self.get_robot_intents(world_state)

--- a/rj_gameplay/rj_gameplay/play/line_up.py
+++ b/rj_gameplay/rj_gameplay/play/line_up.py
@@ -17,6 +17,14 @@ from typing import (
 import numpy as np
 from rj_msgs.msg import RobotIntent
 
+from enum import Enum, auto
+
+
+class State(Enum):
+    INIT = auto()
+    LINE_UP = auto()
+    DONE = auto()
+
 
 class LineUp(stp.play.Play):
     """Lines up all six robots on the side of the field."""
@@ -26,22 +34,22 @@ class LineUp(stp.play.Play):
 
         # super simple FSM
         # TODO: use FSM class (or at least don't use string literals)
-        self._state = "init"
+        self._state = State.INIT
 
     def tick(
         self,
         world_state: stp.rc.WorldState,
     ) -> List[RobotIntent]:
 
-        if self._state == "init":
+        if self._state == State.INIT:
             self.prioritized_tactics.append(line_tactic.LineTactic(world_state))
             self.assign_roles(world_state)
-            self._state = "line_up"
+            self._state = State.LINE_UP
             return self.get_robot_intents(world_state)
-        elif self._state == "line_up":
+        elif self._state == State.LINE_UP:
             if self.prioritized_tactics[0].is_done(world_state):
-                self._state = "done"
+                self._state = State.DONE
             return self.get_robot_intents(world_state)
-        elif self._state == "done":
+        elif self._state == State.DONE:
             # TODO: does this state need to exist?
             return None

--- a/rj_gameplay/rj_gameplay/play/line_up.py
+++ b/rj_gameplay/rj_gameplay/play/line_up.py
@@ -32,8 +32,6 @@ class LineUp(stp.play.Play):
     def __init__(self):
         super().__init__()
 
-        # super simple FSM
-        # TODO: use FSM class (or at least don't use string literals)
         self._state = State.INIT
 
     def tick(

--- a/rj_gameplay/rj_gameplay/role/passer.py
+++ b/rj_gameplay/rj_gameplay/role/passer.py
@@ -5,6 +5,17 @@ from rj_gameplay.skill import receive, pivot_kick  # , line_kick
 
 from rj_msgs.msg import RobotIntent
 
+from enum import Enum, auto
+
+
+class State(Enum):
+    INIT = auto()
+    CAPTURING = auto()
+    PASS_READY = auto()
+    INIT_EXECUTE_PASS = auto()
+    EXECUTE_PASS = auto()
+    KICK_DONE = auto()
+
 
 class PasserRole(stp.role.Role):
     def __init__(self, robot: stp.rc.Robot) -> None:
@@ -13,17 +24,16 @@ class PasserRole(stp.role.Role):
         self.receive_skill = None
         self.pivot_kick_skill = None
 
-        # TODO: make FSM class (or at least use enum instead of str literals)
-        self._state = "init"
+        self._state = State.INIT
 
         self._target_point = None
 
     @property
     def pass_ready(self):
-        return self._state == "pass_ready"
+        return self._state == State.PASS_READY
 
     def set_execute_pass(self, target_point):
-        self._state = "init_execute_pass"
+        self._state = State.INIT_EXECUTE_PASS
         self._target_point = target_point
 
     def tick(self, world_state: stp.rc.WorldState) -> RobotIntent:
@@ -35,19 +45,19 @@ class PasserRole(stp.role.Role):
         """
 
         intent = None
-        if self._state == "init":
+        if self._state == State.INIT:
             self.receive_skill = receive.Receive(robot=self.robot)
             intent = self.receive_skill.tick(world_state)
-            self._state = "capturing"
-        elif self._state == "capturing":
+            self._state = State.CAPTURING
+        elif self._state == State.CAPTURING:
             intent = self.receive_skill.tick(world_state)
             if self.receive_skill.is_done(world_state):
-                self._state = "pass_ready"
-        elif self._state == "pass_ready":
+                self._state = State.PASS_READY
+        elif self._state == State.PASS_READY:
             # TODO: dribble until the receiver is ready
             pass
         # this state transition is done by the PassTactic, which is not canonical FSM
-        elif self._state == "init_execute_pass":
+        elif self._state == State.INIT_EXECUTE_PASS:
             # TODO: make these params configurable
             self.pivot_kick_skill = pivot_kick.PivotKick(
                 robot=self.robot,
@@ -55,15 +65,15 @@ class PasserRole(stp.role.Role):
                 chip=False,
                 kick_speed=4.0,  # TODO: adjust based on dist from target_point
             )
-            self._state = "execute_pass"
-        elif self._state == "execute_pass":
+            self._state = State.EXECUTE_PASS
+        elif self._state == State.EXECUTE_PASS:
             intent = self.pivot_kick_skill.tick(world_state)
 
             if self.pivot_kick_skill.is_done(world_state):
-                self._state = "kick_done"
+                self._state = State.KICK_DONE
                 # end FSM
 
         return intent
 
     def is_done(self, world_state) -> bool:
-        return self._state == "kick_done"
+        return self._state == State.KICK_DONE

--- a/rj_gameplay/rj_gameplay/role/receiver.py
+++ b/rj_gameplay/rj_gameplay/role/receiver.py
@@ -5,6 +5,15 @@ from rj_gameplay.skill import receive
 
 from rj_msgs.msg import RobotIntent
 
+from enum import Enum, auto
+
+
+class State(Enum):
+    INIT = auto()
+    PASS_READY = auto()
+    RECEIVE_PASS = auto()
+    DONE = auto()
+
 
 class ReceiverRole(stp.role.Role):
     def __init__(self, robot: stp.rc.Robot) -> None:
@@ -12,17 +21,16 @@ class ReceiverRole(stp.role.Role):
 
         self.receive_skill = None
 
-        # TODO: make FSM class (or at least use enum instead of str literals)
-        self._state = "init"
+        self._state = State.INIT
 
         self._target_point = None
 
     @property
     def pass_ready(self):
-        return self._state == "pass_ready"
+        return self._state == State.PASS_READY
 
     def set_receive_pass(self):
-        self._state = "receive_pass"
+        self._state = State.RECEIVE_PASS
         self.receive_skill = receive.Receive(robot=self.robot)
 
     def tick(self, world_state: stp.rc.WorldState) -> RobotIntent:
@@ -35,16 +43,16 @@ class ReceiverRole(stp.role.Role):
 
         intent = None
 
-        if self._state == "init":
-            # do seek behavior
+        if self._state == State.INIT:
+            # TODO: do seek behavior
             pass
-        elif self._state == "receive_pass":
+        elif self._state == State.RECEIVE_PASS:
             intent = self.receive_skill.tick(world_state)
             if self.receive_skill.is_done(world_state):
-                self._state = "done"
+                self._state = State.DONE
                 # end FSM
 
         return intent
 
     def is_done(self, world_state) -> bool:
-        return self._state == "done"
+        return self._state == State.DONE

--- a/rj_gameplay/rj_gameplay/skill/pivot_kick.py
+++ b/rj_gameplay/rj_gameplay/skill/pivot_kick.py
@@ -68,7 +68,6 @@ class PivotKick(skill.Skill):  # add ABC if fails
 
     def tick(self, world_state: rc.WorldState) -> RobotIntent:
         super().tick(world_state)
-        print("pivot kick state:", self._state)
 
         intent = None
         if self._state == State.CAPTURE:

--- a/rj_gameplay/rj_gameplay/skill/pivot_kick.py
+++ b/rj_gameplay/rj_gameplay/skill/pivot_kick.py
@@ -14,6 +14,15 @@ import stp.rc as rc
 import numpy as np
 from rj_gameplay.MAX_KICK_SPEED import MAX_KICK_SPEED
 
+from enum import Enum, auto
+
+
+class State(Enum):
+    CAPTURE = auto()
+    PIVOT = auto()
+    KICK = auto()
+    DONE = auto()
+
 
 class PivotKick(skill.Skill):  # add ABC if fails
     """
@@ -55,30 +64,30 @@ class PivotKick(skill.Skill):  # add ABC if fails
         )
         self.capture = capture.Capture(robot)
 
-        self._state = "capture"
+        self._state = State.CAPTURE
 
     def tick(self, world_state: rc.WorldState) -> RobotIntent:
         super().tick(world_state)
         print("pivot kick state:", self._state)
 
         intent = None
-        if self._state == "capture":
+        if self._state == State.CAPTURE:
             intent = self.capture.tick(world_state)
             if self.capture.is_done(world_state):
-                self._state = "pivot"
-        elif self._state == "pivot":
+                self._state = State.PIVOT
+        elif self._state == State.PIVOT:
             intent = self.pivot.tick(world_state)
             if self.pivot.is_done(world_state):
-                self._state = "kick"
-        elif self._state == "kick":
+                self._state = State.KICK
+        elif self._state == State.KICK:
             intent = self.kick.tick(world_state)
             if self.kick.is_done(world_state):
-                self._state = "done"
+                self._state = State.DONE
 
         return intent
 
     def is_done(self, world_state: rc.WorldState) -> bool:
-        return self._state == "done"
+        return self._state == State.DONE
 
     def __str__(self):
         return f"Pivot(robot={self.robot.id if self.robot is not None else '??'}, target={self.target_point})"

--- a/rj_gameplay/rj_gameplay/tactic/pass_tactic.py
+++ b/rj_gameplay/rj_gameplay/tactic/pass_tactic.py
@@ -10,13 +10,30 @@ import stp.global_parameters as global_parameters
 from rj_msgs.msg import RobotIntent
 
 
+from enum import Enum, auto
+
+
+class State(Enum):
+    INIT = auto()
+    ACTIVE = auto()
+    INIT_PASSER_CAPTURE = auto()
+    PASSER_CAPTURE = auto()
+    GET_RECEIVER = auto()
+    INIT_EXECUTE_PASS = auto()
+    EXECUTE_PASS = auto()
+    AWAIT_PASSER_KICK = auto()
+    PASS_IN_TRANSIT = auto()
+    INIT_AWAIT_RECEIVE = auto()
+    EXECUTE_RECEIVE = auto()
+    AWAIT_RECEIVE = auto()
+    DONE = auto()
+
+
 class PassTactic(stp.tactic.Tactic):
     def __init__(self, world_state: stp.rc.WorldState):
         super().__init__(world_state)
 
-        # TODO: make FSM class (or at least use enum instead of str literals)
-        #       - allow FSM class to print state as debug tool
-        self._state = "init"
+        self._state = State.INIT
 
     def init_roles(self, world_state: stp.rc.WorldState) -> None:
         self.assigned_roles = []
@@ -42,7 +59,7 @@ class PassTactic(stp.tactic.Tactic):
 
         role_intents = []
 
-        if self._state == "init":
+        if self._state == State.INIT:
             # TODO: allow Plays to pass in this (and further below) cost fns,
             #       otherwise behavior is not easy to manipulate
             self._role_requests = [
@@ -53,14 +70,14 @@ class PassTactic(stp.tactic.Tactic):
             ]
             self._needs_assign = True
 
-            self._state = "init_passer_capture"
+            self._state = State.INIT_PASSER_CAPTURE
 
-        elif self._state == "init_passer_capture":
+        elif self._state == State.INIT_PASSER_CAPTURE:
             # assumes play has given new role_requests
             self.init_roles(world_state)
-            self._state = "passer_capture"
+            self._state = State.PASSER_CAPTURE
 
-        elif self._state == "passer_capture":
+        elif self._state == State.PASSER_CAPTURE:
             # TODO: these lines are a little ugly, any fix?
             passer_role = self.assigned_roles[0]
             assert isinstance(passer_role, passer.PasserRole)
@@ -69,9 +86,9 @@ class PassTactic(stp.tactic.Tactic):
             role_intents = [(passer_role.robot.id, intent)]
 
             if passer_role.pass_ready:
-                self._state = "get_receiver"
+                self._state = State.GET_RECEIVER
 
-        elif self._state == "get_receiver":
+        elif self._state == State.GET_RECEIVER:
             self._role_requests = [
                 (
                     stp.role.cost.PickClosestToPoint(world_state.ball.pos),
@@ -84,15 +101,15 @@ class PassTactic(stp.tactic.Tactic):
             ]
             self._needs_assign = True
 
-            self._state = "init_execute_pass"
+            self._state = State.INIT_EXECUTE_PASS
             # decided to get receiver early to allow more coordination in theory, currently not written in
             # TODO: evaluate whether this is a dumb idea or not
 
-        elif self._state == "init_execute_pass":
+        elif self._state == State.INIT_EXECUTE_PASS:
             # one tick delay for play role assignment
-            self._state = "execute_pass"
+            self._state = State.EXECUTE_PASS
 
-        elif self._state == "execute_pass":
+        elif self._state == State.EXECUTE_PASS:
             # assumes play has given new role_requests
             self.init_roles(world_state)
 
@@ -112,9 +129,9 @@ class PassTactic(stp.tactic.Tactic):
                 (receiver_role.robot.id, receiver_role.tick(world_state)),
             ]
 
-            self._state = "await_pass"
+            self._state = State.AWAIT_PASSER_KICK
 
-        elif self._state == "await_pass":
+        elif self._state == State.AWAIT_PASSER_KICK:
             # TODO: these lines are a little ugly, any fix?
             passer_role = self.assigned_roles[0]
             assert isinstance(passer_role, passer.PasserRole)
@@ -127,9 +144,9 @@ class PassTactic(stp.tactic.Tactic):
             ]
 
             if passer_role.is_done(world_state):
-                self._state = "pass_incoming"
+                self._state = State.PASS_IN_TRANSIT
 
-        elif self._state == "pass_incoming":
+        elif self._state == State.PASS_IN_TRANSIT:
             receiver_role = self.assigned_roles[1]
             assert isinstance(receiver_role, receiver.ReceiverRole)
 
@@ -141,13 +158,13 @@ class PassTactic(stp.tactic.Tactic):
             ]
             self._needs_assign = True
 
-            self._state = "init_await_receive"
+            self._state = State.INIT_AWAIT_RECEIVE
 
-        elif self._state == "init_await_receive":
+        elif self._state == State.INIT_AWAIT_RECEIVE:
             # one tick delay for play role assignment
-            self._state = "execute_receive"
+            self._state = State.EXECUTE_RECEIVE
 
-        elif self._state == "execute_receive":
+        elif self._state == State.EXECUTE_RECEIVE:
             # assumes play has given new role_requests
             self.init_roles(world_state)
 
@@ -158,16 +175,16 @@ class PassTactic(stp.tactic.Tactic):
 
             role_intents = [(receiver_role.robot.id, receiver_role.tick(world_state))]
 
-            self._state = "await_receive"
+            self._state = State.AWAIT_RECEIVE
 
-        elif self._state == "await_receive":
+        elif self._state == State.AWAIT_RECEIVE:
             receiver_role = self.assigned_roles[0]
             assert isinstance(receiver_role, receiver.ReceiverRole)
 
             role_intents = [(receiver_role.robot.id, receiver_role.tick(world_state))]
 
             if receiver_role.is_done(world_state):
-                self._state = "done"
+                self._state = State.DONE
                 # end FSM
 
         return role_intents
@@ -180,4 +197,4 @@ class PassTactic(stp.tactic.Tactic):
         return ret
 
     def is_done(self, world_state: stp.rc.WorldState) -> bool:
-        return self._state == "done"
+        return self._state == State.DONE


### PR DESCRIPTION
## Description
Title. This was done as opposed to doing string comparisons, which are slow (and ugly). The State Enums allow one to glance at the top of the file and know what the FSM will tick through.

## Steps to test
Run sim with 3 plays: `BasicDefense, LineUp, and Keepaway . 

Expected result: Behavior should match #1811 .
