### PR TITLE
Basic Offense Play

### DIFF
--- a/rj_gameplay/rj_gameplay/gameplay_node.py
+++ b/rj_gameplay/rj_gameplay/gameplay_node.py
@@ -30,7 +30,7 @@ import numpy as np
 from rj_gameplay.action.move import Move
 
 # ignore "unused import" error
-from rj_gameplay.play import line_up, basic_defense, keepaway  # noqa: F401
+from rj_gameplay.play import line_up, basic_defense, keepaway, basic122  # noqa: F401
 import rj_gameplay.basic_play_selector as basic_play_selector
 
 NUM_ROBOTS = 16
@@ -458,7 +458,7 @@ def main():
     play_selector = basic_play_selector.BasicPlaySelector()
 
     # change this line to test different plays (set to None if no desired test play)
-    test_play = keepaway.Keepaway()
+    test_play = basic122.Basic122()
 
     gameplay = GameplayNode(play_selector, test_play)
     rclpy.spin(gameplay)

--- a/rj_gameplay/rj_gameplay/play/basic122.py
+++ b/rj_gameplay/rj_gameplay/play/basic122.py
@@ -1,116 +1,37 @@
-import stp.play as play
-import stp.tactic as tactic
+from typing import List
 
-from rj_gameplay.tactic import (
-    striker_tactic,
-    goalie_tactic,
-    pass_seek,
-    wall_tactic,
-)
-import stp.skill as skill
-import stp.role as role
-from stp.role.assignment.naive import NaiveRoleAssignment
-import stp.rc as rc
-from typing import (
-    Dict,
-    List,
-    Tuple,
-    Type,
-)
-import numpy as np
-from rj_gameplay.calculations import wall_calculations
+import stp
+
+from rj_gameplay.tactic import pass_tactic
+
+from rj_msgs.msg import RobotIntent
+
+from enum import Enum, auto
 
 
-class Basic122(play.IPlay):
-    """A basic offensive play. One robot is a striker and shoots as soon it gets the ball.
-    other two seek to specific spots (BAD HARDCODING)
+class State(Enum):
+    INIT = auto()
+    ACTIVE = auto()
+    ASSIGN_ROLES = auto()
+
+
+class Basic122(stp.play.Play):
+    """Basic play to score goals. Set up two flank and one center handler. Pass ball as needed.
+    See tick() for more details.
     """
 
     def __init__(self):
-        self.target_point: np.ndarray = np.array([0.0, 9.0])
-        self.striker_tactic = striker_tactic.LineKickStrikerTactic(
-            target_point=self.target_point
-        )
-        self.goalie_tactic = goalie_tactic.GoalieTactic()
-        self.wall_tactic_1 = wall_tactic.WallTactic(role.Priority.LOW, cost_scale=0.1)
-        self.wall_tactic_2 = wall_tactic.WallTactic(role.Priority.LOW, cost_scale=0.1)
+        super().__init__()
 
-        self.num_wallers = 2
-
-        left_pt = np.array([1.5, 7.5])
-        self.seek_left = pass_seek.Seek(
-            left_pt,
-            pass_seek.build_seek_function(left_pt),
-            pass_seek.SeekCost(left_pt),
-        )
-
-        right_pt = np.array([-1.5, 7.5])
-        self.seek_right = pass_seek.Seek(
-            right_pt,
-            pass_seek.build_seek_function(right_pt),
-            pass_seek.SeekCost(right_pt),
-        )
-
-        self.role_assigner = NaiveRoleAssignment()
-
-    def compute_props(self, prev_props):
-        pass
+        self._state = State.INIT
 
     def tick(
         self,
-        world_state: rc.WorldState,
-        prev_results: role.assignment.FlatRoleResults,
-        props,
-    ) -> Tuple[
-        Dict[Type[tactic.SkillEntry], List[role.RoleRequest]],
-        List[tactic.SkillEntry],
-    ]:
-        # TODO: create NamedTuple for this type
-        # pre-calculate wall points and store in numpy array
-        wall_pts = wall_calculations.find_wall_pts(self.num_wallers, world_state)
+        world_state: stp.rc.WorldState,
+    ) -> List[RobotIntent]:
+        """
+        init: 1 ball handler, 2 seekers, 2 markers, 1 goalie
+        when ready: ball handler shoots or passes with 1/3rd probability
+        if ball handler passes: passer shoots immediately
 
-        # Get role requests from all tactics and put them into a dictionary
-
-        role_requests: play.RoleRequests = {
-            self.striker_tactic: self.striker_tactic.get_requests(world_state, None),
-            # self.two_mark: self.two_mark.get_requests(world_state, None),
-            self.seek_left: self.seek_left.get_requests(world_state, None),
-            self.seek_right: self.seek_right.get_requests(world_state, None),
-            self.goalie_tactic: self.goalie_tactic.get_requests(world_state, None),
-            self.wall_tactic_1: self.wall_tactic_1.get_requests(
-                world_state, wall_pts[0], None
-            ),
-            self.wall_tactic_2: self.wall_tactic_2.get_requests(
-                world_state, wall_pts[1], None
-            ),
-        }
-
-        # Flatten requests and use role assigner on them
-        flat_requests = play.flatten_requests(role_requests)
-        flat_results = self.role_assigner.assign_roles(
-            flat_requests, world_state, prev_results
-        )
-        role_results = play.unflatten_results(flat_results)
-
-        # Get list of all skills with assigned roles from tactics
-
-        skills = self.striker_tactic.tick(
-            world_state, role_results[self.striker_tactic]
-        )
-        skills += self.seek_left.tick(world_state, role_results[self.seek_left])
-        skills += self.seek_right.tick(world_state, role_results[self.seek_right])
-        skills += self.goalie_tactic.tick(world_state, role_results[self.goalie_tactic])
-        skills += self.wall_tactic_1.tick(world_state, role_results[self.wall_tactic_1])
-        skills += self.wall_tactic_2.tick(world_state, role_results[self.wall_tactic_2])
-
-        skill_dict = {}
-        skill_dict.update(role_results[self.striker_tactic])
-        skill_dict.update(role_results[self.seek_left])
-        skill_dict.update(role_results[self.seek_right])
-        skill_dict.update(role_results[self.goalie_tactic])
-        skill_dict.update(role_results[self.wall_tactic_1])
-        skill_dict.update(role_results[self.wall_tactic_2])
-        return skill_dict, skills
-
-    def is_done(self, world_state):
-        return self.striker_tactic.is_done(world_state)
+        """

--- a/rj_gameplay/rj_gameplay/play/basic122.py
+++ b/rj_gameplay/rj_gameplay/play/basic122.py
@@ -122,7 +122,6 @@ class Basic122(stp.play.Play):
             return self.get_robot_intents(world_state)
 
         elif self._state == State.INIT_SHOOT:
-            init_striker_cost = stp.role.cost.PickClosestToPoint(world_state.ball.pos)
             self.prioritized_tactics = [
                 goalie_tactic.GoalieTactic(world_state, 0),
                 striker_tactic.StrikerTactic(world_state),

--- a/rj_gameplay/rj_gameplay/play/basic122.py
+++ b/rj_gameplay/rj_gameplay/play/basic122.py
@@ -52,7 +52,6 @@ class Basic122(stp.play.Play):
         DONE: shot taken
         """
 
-        print(f"basic122 state: {self._state}")
         if self._state == State.INIT:
             self.prioritized_tactics = [
                 goalie_tactic.GoalieTactic(world_state, 0),

--- a/rj_gameplay/rj_gameplay/play/basic122.py
+++ b/rj_gameplay/rj_gameplay/play/basic122.py
@@ -52,6 +52,7 @@ class Basic122(stp.play.Play):
         DONE: shot taken
         """
 
+        # TODO: when seeker formation behavior added in, add it in for other 3 robots
         if self._state == State.INIT:
             self.prioritized_tactics = [
                 goalie_tactic.GoalieTactic(world_state, 0),

--- a/rj_gameplay/rj_gameplay/play/basic122.py
+++ b/rj_gameplay/rj_gameplay/play/basic122.py
@@ -2,7 +2,7 @@ from typing import List
 
 import stp
 
-from rj_gameplay.tactic import pass_tactic, basic_seek, goalie_tactic
+from rj_gameplay.tactic import pass_tactic, basic_seek, goalie_tactic, striker_tactic
 
 from rj_msgs.msg import RobotIntent
 
@@ -18,6 +18,8 @@ class State(Enum):
     PASSING = auto()
     PASSING_ASSIGN_ROLES = auto()
     INIT_SHOOT = auto()
+    SHOOTING = auto()
+    DONE = auto()
 
 
 class Basic122(stp.play.Play):
@@ -40,11 +42,17 @@ class Basic122(stp.play.Play):
         world_state: stp.rc.WorldState,
     ) -> List[RobotIntent]:
         """
-        init: 1 ball handler, 2 seekers, 1 goalie
-        when seekers make it to hardcoded pt: ball handler passes to seeker
-        when pass to seeker made: seeker shoots
+        INIT: assign goalie, 2 seekers
+        WAIT_TO_PASS: loop until seekers reach pt
+        INIT_PASS: assign goalie, pass tac
+        PASSING: pass to one of two seekers, when pass done, shoot
+        PASSING_ASSIGN_ROLES: when pass tactic needs role assignment while psasing, assign roles for it, then go back to PASSING
+        INIT_SHOOT: assign goalie, striker, seeker
+        SHOOTING: striker shoots
+        DONE: shot taken
         """
 
+        print(f"basic122 state: {self._state}")
         if self._state == State.INIT:
             self.prioritized_tactics = [
                 goalie_tactic.GoalieTactic(world_state, 0),
@@ -114,5 +122,19 @@ class Basic122(stp.play.Play):
             return self.get_robot_intents(world_state)
 
         elif self._state == State.INIT_SHOOT:
-            print("INIT shoot")
-            pass
+            init_striker_cost = stp.role.cost.PickClosestToPoint(world_state.ball.pos)
+            self.prioritized_tactics = [
+                goalie_tactic.GoalieTactic(world_state, 0),
+                striker_tactic.StrikerTactic(world_state),
+            ]
+
+            self.assign_roles(world_state)
+            self._state = State.SHOOTING
+            return self.get_robot_intents(world_state)
+
+        elif self._state == State.SHOOTING:
+            tactic = self.prioritized_tactics[1]
+            if tactic.is_done(world_state):
+                self._state = State.DONE
+
+            return self.get_robot_intents(world_state)

--- a/rj_gameplay/rj_gameplay/play/basic122.py
+++ b/rj_gameplay/rj_gameplay/play/basic122.py
@@ -13,10 +13,11 @@ import numpy as np
 
 class State(Enum):
     INIT = auto()
-    SETUP = auto()
-    READY_TO_PASS = auto()
-    SEEKER_SHOOT = auto()
-    ASSIGN_ROLES = auto()
+    WAIT_TO_PASS = auto()
+    INIT_PASS = auto()
+    PASSING = auto()
+    PASSING_ASSIGN_ROLES = auto()
+    INIT_SHOOT = auto()
 
 
 class Basic122(stp.play.Play):
@@ -52,29 +53,22 @@ class Basic122(stp.play.Play):
             ]
 
             self.assign_roles(world_state)
-            self._state = State.SETUP
+
+            self._state = State.WAIT_TO_PASS
             return self.get_robot_intents(world_state)
 
-        elif self._state == State.SETUP:
-            # TODO: this loop's logic is fairly crucial in role assignment
-            #
-            # is there a way I can force this to happen as a precondition to assign_roles?
-            # maybe call assign_roles() every tick but check tactic for needs_assign before assigning it
-            # (this works as the method is in Play superclass)
-            for tactic in self.prioritized_tactics:
-                # TODO: goalie tactic (and all tactics?) need a needs_assign
-                #       build in the logic for needs_assign of pass tactic into superclass
-                if tactic.needs_assign:
-                    self._state = State.ASSIGN_ROLES
+        elif self._state == State.WAIT_TO_PASS:
 
-            seek_1 = self.prioritized_tactics[0]
-            seek_2 = self.prioritized_tactics[1]
+            seek_1 = self.prioritized_tactics[1]
+            seek_2 = self.prioritized_tactics[2]
+
+            # TODO: is one tick delay issue?
             if seek_1.is_done(world_state) and seek_2.is_done(world_state):
-                self._state = State.READY_TO_PASS
+                self._state = State.INIT_PASS
 
             return self.get_robot_intents(world_state)
 
-        elif self._state == State.READY_TO_PASS:
+        elif self._state == State.INIT_PASS:
             init_passer_cost = stp.role.cost.PickClosestToPoint(world_state.ball.pos)
             init_receiver_cost = stp.role.cost.PickClosestToPoint(self._seek_pts[0])
             self.prioritized_tactics = [
@@ -85,15 +79,40 @@ class Basic122(stp.play.Play):
             ]
 
             self.assign_roles(world_state)
-            # self._state = State.SEEKER_SHOOT
+            self._state = State.PASSING
             return self.get_robot_intents(world_state)
 
-        elif self._state == State.SEEKER_SHOOT:
-            # TODO: write dummy shoot tactic? or role?
-            pass
+        elif self._state == State.PASSING:
+            # TODO: this logic is fairly crucial in role assignment
+            #
+            # is there a way I can force this to happen as a precondition to assign_roles?
+            # maybe call assign_roles() every tick but check tactic for needs_assign before assigning it
+            # (this works as the method is in Play superclass)
 
-        elif self._state == State.ASSIGN_ROLES:
+            # pass tactic dynamically needs assign, handle here
+            # (think of as an interrupt)
+            for tactic in self.prioritized_tactics:
+                # TODO: goalie tactic (and all tactics?) need a needs_assign
+                #       build in the logic for needs_assign of pass tactic into superclass
+                if tactic.needs_assign:
+                    print(f"{tactic} needs assign, says basic122")
+                    self._state = State.PASSING_ASSIGN_ROLES
+
+            # when pass is complete, go shoot
+            pass_tac = self.prioritized_tactics[1]
+            if pass_tac.is_done(world_state):
+                self._state = State.INIT_SHOOT
+
+            return self.get_robot_intents(world_state)
+
+        elif self._state == State.PASSING_ASSIGN_ROLES:
             # duplicate role assign from init, merge states?
+            # can't bc need to know the state that it came from
+            # TODO: write interrupt-handler style state in play superclass for this behavior, where self._state returns to old state
             self.assign_roles(world_state)
-            # self._state = State.ACTIVE
+            self._state = State.PASSING
             return self.get_robot_intents(world_state)
+
+        elif self._state == State.INIT_SHOOT:
+            print("INIT shoot")
+            pass

--- a/rj_gameplay/rj_gameplay/play/basic122.py
+++ b/rj_gameplay/rj_gameplay/play/basic122.py
@@ -2,16 +2,20 @@ from typing import List
 
 import stp
 
-from rj_gameplay.tactic import pass_tactic
+from rj_gameplay.tactic import pass_tactic, basic_seek, goalie_tactic
 
 from rj_msgs.msg import RobotIntent
 
 from enum import Enum, auto
 
+import numpy as np
+
 
 class State(Enum):
     INIT = auto()
-    ACTIVE = auto()
+    SETUP = auto()
+    READY_TO_PASS = auto()
+    SEEKER_SHOOT = auto()
     ASSIGN_ROLES = auto()
 
 
@@ -25,13 +29,71 @@ class Basic122(stp.play.Play):
 
         self._state = State.INIT
 
+        self._seek_pts = [
+            np.array((2.0, 7.0)),
+            np.array((-2.0, 7.0)),
+        ]
+
     def tick(
         self,
         world_state: stp.rc.WorldState,
     ) -> List[RobotIntent]:
         """
-        init: 1 ball handler, 2 seekers, 2 markers, 1 goalie
-        when ready: ball handler shoots or passes with 1/3rd probability
-        if ball handler passes: passer shoots immediately
-
+        init: 1 ball handler, 2 seekers, 1 goalie
+        when seekers make it to hardcoded pt: ball handler passes to seeker
+        when pass to seeker made: seeker shoots
         """
+
+        if self._state == State.INIT:
+            self.prioritized_tactics = [
+                goalie_tactic.GoalieTactic(world_state, 0),
+                basic_seek.BasicSeek(self._seek_pts[0], world_state),
+                basic_seek.BasicSeek(self._seek_pts[1], world_state),
+            ]
+
+            self.assign_roles(world_state)
+            self._state = State.SETUP
+            return self.get_robot_intents(world_state)
+
+        elif self._state == State.SETUP:
+            # TODO: this loop's logic is fairly crucial in role assignment
+            #
+            # is there a way I can force this to happen as a precondition to assign_roles?
+            # maybe call assign_roles() every tick but check tactic for needs_assign before assigning it
+            # (this works as the method is in Play superclass)
+            for tactic in self.prioritized_tactics:
+                # TODO: goalie tactic (and all tactics?) need a needs_assign
+                #       build in the logic for needs_assign of pass tactic into superclass
+                if tactic.needs_assign:
+                    self._state = State.ASSIGN_ROLES
+
+            seek_1 = self.prioritized_tactics[0]
+            seek_2 = self.prioritized_tactics[1]
+            if seek_1.is_done(world_state) and seek_2.is_done(world_state):
+                self._state = State.READY_TO_PASS
+
+            return self.get_robot_intents(world_state)
+
+        elif self._state == State.READY_TO_PASS:
+            init_passer_cost = stp.role.cost.PickClosestToPoint(world_state.ball.pos)
+            init_receiver_cost = stp.role.cost.PickClosestToPoint(self._seek_pts[0])
+            self.prioritized_tactics = [
+                goalie_tactic.GoalieTactic(world_state, 0),
+                pass_tactic.PassTactic(
+                    world_state, init_passer_cost, init_receiver_cost
+                ),
+            ]
+
+            self.assign_roles(world_state)
+            # self._state = State.SEEKER_SHOOT
+            return self.get_robot_intents(world_state)
+
+        elif self._state == State.SEEKER_SHOOT:
+            # TODO: write dummy shoot tactic? or role?
+            pass
+
+        elif self._state == State.ASSIGN_ROLES:
+            # duplicate role assign from init, merge states?
+            self.assign_roles(world_state)
+            # self._state = State.ACTIVE
+            return self.get_robot_intents(world_state)

--- a/rj_gameplay/rj_gameplay/play/keepaway.py
+++ b/rj_gameplay/rj_gameplay/play/keepaway.py
@@ -38,7 +38,16 @@ class Keepaway(stp.play.Play):
         """
 
         if self._state == State.INIT:
-            self.prioritized_tactics = [pass_tactic.PassTactic(world_state)]
+            init_passer_cost = stp.role.cost.PickClosestToPoint(world_state.ball.pos)
+            # init_receiver_cost = stp.role.cost.PickClosestToPoint(world_state.field.their_goal_loc)
+            init_receiver_cost = stp.role.cost.PickFarthestFromPoint(
+                world_state.ball.pos
+            )
+            self.prioritized_tactics = [
+                pass_tactic.PassTactic(
+                    world_state, init_passer_cost, init_receiver_cost
+                )
+            ]
             # TODO: either add seek tactic(s) or unassigned behavior
 
             self.assign_roles(world_state)

--- a/rj_gameplay/rj_gameplay/role/passer.py
+++ b/rj_gameplay/rj_gameplay/role/passer.py
@@ -63,7 +63,7 @@ class PasserRole(stp.role.Role):
                 robot=self.robot,
                 target_point=self._target_point,
                 chip=False,
-                kick_speed=4.0,  # TODO: adjust based on dist from target_point
+                kick_speed=3.0,  # TODO: adjust based on dist from target_point
             )
             self._state = State.EXECUTE_PASS
         elif self._state == State.EXECUTE_PASS:

--- a/rj_gameplay/rj_gameplay/role/striker.py
+++ b/rj_gameplay/rj_gameplay/role/striker.py
@@ -86,7 +86,8 @@ class StrikerRole(stp.role.Role):
         kick_vector = kick_target - kick_origin
         kick_dist = np.linalg.norm(kick_vector)
         kick_vector /= kick_dist
-        kick_perp = np.array([kick_vector[1], -kick_vector[0]])
+        # unused ??
+        # kick_perp = np.array([kick_vector[1], -kick_vector[0]])
 
         blocker_position = blocker.pose[0:2]
 

--- a/rj_gameplay/rj_gameplay/role/striker.py
+++ b/rj_gameplay/rj_gameplay/role/striker.py
@@ -1,0 +1,163 @@
+import stp.role
+import stp.rc
+
+from rj_gameplay.skill import receive, pivot_kick
+
+from rj_msgs.msg import RobotIntent
+
+from enum import Enum, auto
+
+import numpy as np
+
+
+class State(Enum):
+    INIT = auto()
+    CAPTURING = auto()
+    INIT_SHOOT = auto()
+    SHOOTING = auto()
+    KICK_DONE = auto()
+
+
+# TODO: move params to file
+OPPONENT_SPEED = 1.5
+KICK_SPEED = 4.5
+EFF_BLOCK_WIDTH = 0.7
+
+
+class StrikerRole(stp.role.Role):
+    """Grabs ball and shoots on goal. Should eventually be merged with some hybrid PassOrShoot role."""
+
+    def __init__(self, robot: stp.rc.Robot) -> None:
+        super().__init__(robot)
+
+        self.receive_skill = None
+        self.pivot_kick_skill = None
+
+        self._state = State.INIT
+
+    def tick(self, world_state: stp.rc.WorldState) -> RobotIntent:
+        intent = None
+        if self._state == State.INIT:
+            # taken from role/passer.py
+            self.receive_skill = receive.Receive(robot=self.robot)
+            intent = self.receive_skill.tick(world_state)
+            self._state = State.CAPTURING
+        elif self._state == State.CAPTURING:
+            intent = self.receive_skill.tick(world_state)
+            if self.receive_skill.is_done(world_state):
+                self._state = State.INIT_SHOOT
+        elif self._state == State.INIT_SHOOT:
+            # TODO: make these params configurable
+            shot_kick_speed = 4.0  # TODO: adjust based on dist from target_point
+            best_shot_target_point = self.find_target_point(
+                world_state, shot_kick_speed
+            )
+
+            self.pivot_kick_skill = pivot_kick.PivotKick(
+                robot=self.robot,
+                target_point=best_shot_target_point,
+                chip=False,
+                kick_speed=shot_kick_speed,
+            )
+            self._state = State.SHOOTING
+        elif self._state == State.SHOOTING:
+            # taken from role/passer.py
+            intent = self.pivot_kick_skill.tick(world_state)
+
+            if self.pivot_kick_skill.is_done(world_state):
+                self._state = State.KICK_DONE
+                # end FSM
+
+        return intent
+
+    def is_done(self, world_state: stp.rc.WorldState) -> bool:
+        return self._state == State.KICK_DONE
+
+    def _blocker_margin(
+        self,
+        kick_origin: np.array,
+        kick_target: np.array,
+        kick_speed: float,
+        blocker: stp.rc.Robot,
+    ):
+        if not blocker.visible:
+            return np.inf
+
+        kick_vector = kick_target - kick_origin
+        kick_dist = np.linalg.norm(kick_vector)
+        kick_vector /= kick_dist
+        kick_perp = np.array([kick_vector[1], -kick_vector[0]])
+
+        blocker_position = blocker.pose[0:2]
+
+        # Calculate blocker intercept
+        blocker_intercept_dist_along_kick = np.dot(
+            blocker_position - kick_origin, kick_vector
+        )
+        blocker_intercept_dist_along_kick = np.clip(
+            blocker_intercept_dist_along_kick, a_min=0, a_max=kick_dist
+        )
+        blocker_intercept = (
+            kick_origin + kick_vector * blocker_intercept_dist_along_kick
+        )
+
+        blocker_distance = np.clip(
+            np.linalg.norm(blocker_intercept - blocker_position) - EFF_BLOCK_WIDTH,
+            a_min=0.0,
+            a_max=np.inf,
+        )
+
+        blocker_time = np.abs(blocker_distance) / OPPONENT_SPEED
+
+        # Doesn't include friction...oops?
+        ball_time = np.linalg.norm(blocker_intercept - kick_origin) / kick_speed
+
+        return blocker_time - ball_time
+
+    def _kick_cost(
+        self,
+        point: np.array,
+        kick_speed: float,
+        kick_origin: np.array,
+        world_state: stp.rc.WorldState,
+    ):
+        margins = [
+            self._blocker_margin(kick_origin, point, kick_speed, blocker)
+            for blocker in world_state.their_robots
+        ]
+        return -min(margins)
+
+    def find_target_point(
+        self, world_state: stp.rc.WorldState, kick_speed: float
+    ) -> np.ndarray:
+        goal_y = world_state.field.length_m
+        cost = 0
+
+        ball_pos = world_state.ball.pos
+
+        # Heuristic: limit where we kick if we're very wide
+        xmin = -0.43
+        xmax = 0.43
+        if abs(ball_pos[0]) > 1:
+            kick_extent = -1 / ball_pos[0]
+            if kick_extent < 0:
+                xmin = np.clip(kick_extent, a_min=xmin, a_max=0)
+            elif kick_extent > 0:
+                xmax = np.clip(kick_extent, a_min=0, a_max=xmax)
+
+        try_points = [np.array([x, goal_y]) for x in np.arange(xmin, xmax, step=0.05)]
+
+        cost, point = min(
+            [
+                (
+                    self._kick_cost(
+                        point, kick_speed, world_state.ball.pos, world_state
+                    ),
+                    point,
+                )
+                for point in try_points
+            ],
+            key=lambda x: x[0],
+        )
+
+        return point

--- a/rj_gameplay/rj_gameplay/role/striker.py
+++ b/rj_gameplay/rj_gameplay/role/striker.py
@@ -49,7 +49,7 @@ class StrikerRole(stp.role.Role):
         elif self._state == State.INIT_SHOOT:
             # TODO: make these params configurable
             shot_kick_speed = 4.0  # TODO: adjust based on dist from target_point
-            best_shot_target_point = self.find_target_point(
+            best_shot_target_point = self._find_target_point(
                 world_state, shot_kick_speed
             )
 
@@ -127,7 +127,7 @@ class StrikerRole(stp.role.Role):
         ]
         return -min(margins)
 
-    def find_target_point(
+    def _find_target_point(
         self, world_state: stp.rc.WorldState, kick_speed: float
     ) -> np.ndarray:
         goal_y = world_state.field.length_m

--- a/rj_gameplay/rj_gameplay/tactic/basic_seek.py
+++ b/rj_gameplay/rj_gameplay/tactic/basic_seek.py
@@ -1,0 +1,51 @@
+import stp
+from rj_gameplay.role import dumb_move
+from typing import List, Tuple
+import numpy as np
+
+from rj_msgs.msg import RobotIntent
+
+
+class BasicSeek(stp.tactic.Tactic):
+    """Seeks to a single point, passed in on init."""
+
+    def __init__(self, seek_pt: np.ndarray, world_state: stp.rc.WorldState):
+        super().__init__(world_state)
+
+        self._seek_pt = seek_pt
+
+        self._role_requests.append(
+            (stp.role.cost.PickClosestToPoint(seek_pt), dumb_move.DumbMove)
+        )
+
+    def tick(
+        self,
+        world_state: stp.rc.WorldState,
+    ) -> List[Tuple[int, RobotIntent]]:
+        # returns list of (robot_id, robot_intent)
+
+        # assumes all roles requested are filled, because tactic is one unit
+        if len(self.assigned_roles) != len(self._role_requests):
+            self.init_roles(world_state)
+
+        return [(role.robot.id, role.tick(world_state)) for role in self.assigned_roles]
+
+    def is_done(
+        self,
+        world_state: stp.rc.WorldState,
+    ) -> bool:
+        return all([role.is_done(world_state) for role in self.assigned_roles])
+
+    def init_roles(
+        self,
+        world_state: stp.rc.WorldState,
+    ):
+        robot = self.assigned_robots[0]
+        role = self._role_requests[0][1]
+        if role is dumb_move.DumbMove:
+            self.assigned_roles.append(role(robot, self._seek_pt, world_state.ball.pos))
+
+    def needs_assign(self):
+        # never needs assign after init
+        # TODO: make this + pass tac part of the superclass
+        return False

--- a/rj_gameplay/rj_gameplay/tactic/goalie_tactic.py
+++ b/rj_gameplay/rj_gameplay/tactic/goalie_tactic.py
@@ -42,6 +42,7 @@ class GoalieTactic(stp.tactic.Tactic):
             robot_intents.append((role.robot.id, role.tick(world_state)))
         return robot_intents
 
+    @property
     def needs_assign(self):
         # never needs assign after init
         # TODO: make this + pass tac part of the superclass

--- a/rj_gameplay/rj_gameplay/tactic/goalie_tactic.py
+++ b/rj_gameplay/rj_gameplay/tactic/goalie_tactic.py
@@ -42,6 +42,11 @@ class GoalieTactic(stp.tactic.Tactic):
             robot_intents.append((role.robot.id, role.tick(world_state)))
         return robot_intents
 
+    def needs_assign(self):
+        # never needs assign after init
+        # TODO: make this + pass tac part of the superclass
+        return False
+
     def is_done(self, world_state: stp.rc.WorldState) -> bool:
         # special case: we know the only role is Goalie, so we borrow that is_done()
         return self.assigned_roles[0].is_done(world_state)

--- a/rj_gameplay/rj_gameplay/tactic/striker_tactic.py
+++ b/rj_gameplay/rj_gameplay/tactic/striker_tactic.py
@@ -8,65 +8,6 @@ import stp.skill as skill
 import numpy as np
 from math import atan2
 
-# TODO: move all of this logic to StrikerRole
-OPPONENT_SPEED = 1.5
-KICK_SPEED = 4.5
-EFF_BLOCK_WIDTH = 0.7
-
-
-def blocker_margin(
-    kick_origin: np.array,
-    kick_target: np.array,
-    kick_speed: float,
-    blocker: rc.Robot,
-):
-    if not blocker.visible:
-        return np.inf
-
-    kick_vector = kick_target - kick_origin
-    kick_dist = np.linalg.norm(kick_vector)
-    kick_vector /= kick_dist
-    kick_perp = np.array([kick_vector[1], -kick_vector[0]])
-
-    blocker_position = blocker.pose[0:2]
-
-    # Calculate blocker intercept
-    blocker_intercept_dist_along_kick = np.dot(
-        blocker_position - kick_origin, kick_vector
-    )
-    blocker_intercept_dist_along_kick = np.clip(
-        blocker_intercept_dist_along_kick, a_min=0, a_max=kick_dist
-    )
-    blocker_intercept = kick_origin + kick_vector * blocker_intercept_dist_along_kick
-
-    blocker_distance = np.clip(
-        np.linalg.norm(blocker_intercept - blocker_position) - EFF_BLOCK_WIDTH,
-        a_min=0.0,
-        a_max=np.inf,
-    )
-
-    blocker_time = np.abs(blocker_distance) / OPPONENT_SPEED
-
-    # Doesn't include friction...oops?
-    ball_time = np.linalg.norm(blocker_intercept - kick_origin) / kick_speed
-
-    return blocker_time - ball_time
-
-
-def kick_cost(
-    point: np.array,
-    kick_speed: float,
-    kick_origin: np.array,
-    world_state: rc.WorldState,
-):
-    margins = [
-        blocker_margin(kick_origin, point, kick_speed, blocker)
-        for blocker in world_state.their_robots
-    ]
-    return -min(margins)
-
-
-# TODO: move imports to top once this file fixed
 from rj_gameplay.role import striker
 import stp
 

--- a/rj_gameplay/rj_gameplay/tactic/striker_tactic.py
+++ b/rj_gameplay/rj_gameplay/tactic/striker_tactic.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Tuple
 import stp.rc as rc
 import stp.tactic as tactic
 import stp.role as role
@@ -8,6 +8,7 @@ import stp.skill as skill
 import numpy as np
 from math import atan2
 
+# TODO: move all of this logic to StrikerRole
 OPPONENT_SPEED = 1.5
 KICK_SPEED = 4.5
 EFF_BLOCK_WIDTH = 0.7
@@ -65,156 +66,60 @@ def kick_cost(
     return -min(margins)
 
 
-def find_target_point(world_state: rc.WorldState, kick_speed) -> np.ndarray:
-    goal_y = world_state.field.length_m
-    cost = 0
+# TODO: move imports to top once this file fixed
+from rj_gameplay.role import striker
+import stp
 
-    ball_pos = world_state.ball.pos
+from rj_msgs.msg import RobotIntent
 
-    # Heuristic: limit where we kick if we're very wide
-    xmin = -0.43
-    xmax = 0.43
-    if abs(ball_pos[0]) > 1:
-        kick_extent = -1 / ball_pos[0]
-        if kick_extent < 0:
-            xmin = np.clip(kick_extent, a_min=xmin, a_max=0)
-        elif kick_extent > 0:
-            xmax = np.clip(kick_extent, a_min=0, a_max=xmax)
 
-    try_points = [np.array([x, goal_y]) for x in np.arange(xmin, xmax, step=0.05)]
+class StrikerTactic(stp.tactic.Tactic):
+    """
+    Captures ball and shoots. This Tactic merely holds the StrikerRole and handles its assignment for the Play level.
+    """
 
-    cost, point = min(
-        [
+    def __init__(self, world_state: stp.rc.WorldState):
+        super().__init__(world_state)
+
+        self._role_requests.append(
             (
-                kick_cost(point, kick_speed, world_state.ball.pos, world_state),
-                point,
-            )
-            for point in try_points
-        ],
-        key=lambda x: x[0],
-    )
-
-    return point
-
-
-class CaptureCost(role.CostFn):
-    """
-    A cost function for how to choose a robot that will pass
-    """
-
-    def __call__(
-        self,
-        robot: rc.Robot,
-        prev_result: Optional[role.RoleResult],
-        world_state: rc.WorldState,
-    ) -> float:
-        if robot.has_ball_sense:
-            return 0
-        else:
-            robot_pos = robot.pose[0:2]
-            ball_pos = world_state.ball.pos[0:2]
-
-            goal_y = world_state.field.length_m
-            goal_pos = np.array([0.0, goal_y])
-            robot_to_ball = ball_pos - robot_pos
-            # robot_to_ball /= np.linalg.norm(robot_to_ball) + 1e-6
-            ball_to_goal = goal_pos - ball_pos
-            ball_to_goal /= np.linalg.norm(ball_to_goal) + 1e-6
-
-            LINE_KICK_APPROACH_DISTANCE = 0.2
-            target_pos = ball_pos - ball_to_goal * LINE_KICK_APPROACH_DISTANCE
-            dist_to_ball = np.linalg.norm(target_pos - robot_pos)
-
-            switch_cost = 0.0
-            if prev_result is not None and prev_result.is_filled():
-                switch_cost += 1.0 * (prev_result.role.robot.id != robot.id)
-
-            return 10 * dist_to_ball + 0.5 * switch_cost
-
-    def unassigned_cost_fn(
-        self,
-        prev_result: Optional[role.RoleResult],
-        world_state: rc.WorldState,
-    ) -> float:
-
-        # TODO: Implement real unassigned cost function
-        return role.BIG_STUPID_NUMBER_CONST_FOR_UNASSIGNED_COST_PLS_CHANGE
-
-
-class StrikerTactic(tactic.ITactic):
-    """
-    A striker tactic which receives then shoots the ball
-    """
-
-    def __init__(self, target_point: np.ndarray, cost: role.CostFn = None):
-        self.cost = cost  # unused
-        self.target_point = target_point
-        self.capture = tactic.SkillEntry(capture.Capture())
-        self.capture_cost = CaptureCost()
-        self.shoot = tactic.SkillEntry(
-            pivot_kick.PivotKick(
-                robot=None,
-                chip=False,
-                kick_speed=KICK_SPEED,
-                target_point=target_point,
-                threshold=0.05,
+                stp.role.cost.PickClosestToPoint(world_state.ball.pos),
+                striker.StrikerRole,
             )
         )
-
-    def compute_props(self):
-        pass
-
-    def create_request(self, **kwargs) -> role.RoleRequest:
-        """
-        Creates a sane default RoleRequest.
-        :return: A list of size 1 of a sane default RoleRequest.
-        """
-        pass
-
-    def get_requests(
-        self, world_state: rc.WorldState, props
-    ) -> List[tactic.RoleRequests]:
-
-        striker_request = role.RoleRequest(
-            role.Priority.MEDIUM, True, self.capture_cost
-        )
-        role_requests: tactic.RoleRequests = {}
-
-        striker = [robot for robot in world_state.our_robots if robot.has_ball_sense]
-
-        if striker:
-            role_requests[self.capture] = []
-            role_requests[self.shoot] = [striker_request]
-        else:
-            role_requests[self.capture] = [striker_request]
-            role_requests[self.shoot] = []
-
-        return role_requests
 
     def tick(
         self,
-        world_state: rc.WorldState,
-        role_results: tactic.RoleResults,
-    ) -> List[tactic.SkillEntry]:
-        """
-        :return: list of skills
-        """
+        world_state: stp.rc.WorldState,
+    ) -> List[Tuple[int, RobotIntent]]:
+        # returns list of (robot_id, robot_intent)
 
-        capture_result = role_results[self.capture]
-        shoot_result = role_results[self.shoot]
+        # assumes all roles requested are filled, because tactic is one unit
+        if len(self.assigned_roles) != len(self._role_requests):
+            self.init_roles(world_state)
 
-        if capture_result and capture_result[0].is_filled():
-            return [self.capture]
-        if shoot_result and shoot_result[0].is_filled():
-            self.shoot.skill.target_point = find_target_point(
-                world_state, kick_speed=KICK_SPEED
-            )
-            return [self.shoot]
+        return [(role.robot.id, role.tick(world_state)) for role in self.assigned_roles]
 
-        return []
+    def is_done(
+        self,
+        world_state: stp.rc.WorldState,
+    ) -> bool:
+        return all([role.is_done(world_state) for role in self.assigned_roles])
 
-    def is_done(self, world_state) -> bool:
-        return self.shoot.skill.is_done(world_state)
+    def init_roles(
+        self,
+        world_state: stp.rc.WorldState,
+    ):
+        robot = self.assigned_robots[0]
+        role = self._role_requests[0][1]
+        if role is striker.StrikerRole:
+            self.assigned_roles.append(role(robot))
+
+    @property
+    def needs_assign(self):
+        # never needs assign after init
+        # TODO: make this + pass tac part of the superclass
+        return False
 
 
 class LineKickStrikerTactic(tactic.ITactic):

--- a/rj_gameplay/rj_gameplay/tactic/striker_tactic.py
+++ b/rj_gameplay/rj_gameplay/tactic/striker_tactic.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 import stp.rc as rc
 import stp.tactic as tactic
 import stp.role as role

--- a/rj_gameplay/rj_gameplay/tactic/striker_tactic.py
+++ b/rj_gameplay/rj_gameplay/tactic/striker_tactic.py
@@ -39,6 +39,7 @@ class StrikerTactic(stp.tactic.Tactic):
         if len(self.assigned_roles) != len(self._role_requests):
             self.init_roles(world_state)
 
+        # if low performance, make this not a for loop since it's only one tactic
         return [(role.robot.id, role.tick(world_state)) for role in self.assigned_roles]
 
     def is_done(

--- a/rj_gameplay/stp/play/__init__.py
+++ b/rj_gameplay/stp/play/__init__.py
@@ -38,6 +38,10 @@ class IPlay(ABC):
     pass
 
 
+class RoleAssignFailure(Exception):
+    pass
+
+
 class Play(ABC):
     """Coordinate full-team behaviors via Tactics. Assumes number of Roles matches number of robots on the field.
     Ends when SituationAnalysis switches the Play, so no is_done() necessary.
@@ -77,7 +81,7 @@ class Play(ABC):
         self,
         world_state: stp.rc.WorldState,
     ) -> None:
-        """Given that all Roles are in sorted order of priority, greedily assign the highest-priority Role to the lowest-cost robot for that Role. Instantiate Tactics with the correct robots post-assignment. (Note that this behavior is largely handled by the init_roles of each Tactic.)
+        """Given that all Roles are in sorted order of priority, greedily assign the highest-priority Role to the lowest-cost robot for that Role. Instantiate Tactics with the correct robots post-assignment. (Note that this behavior is largely handled by the init_roles() of each Tactic.)
         Satisfy constraint that all Roles of a Tactic must all be assigned at once. If a Tactic's Roles cannot all be filled, do not fill any of its Roles.
         """
 
@@ -99,8 +103,10 @@ class Play(ABC):
                         cheapest_robot = robot
 
                 if cheapest_robot is None:
-                    # TODO: properly error handle if cheapest_robot is None
-                    print(f"RoleRequest ({role}, {cost_fn}) was not assigned")
+                    # TODO: consider looping until success?
+                    raise RoleAssignFailure(
+                        f"RoleRequest ({role}, {cost_fn}) was not assigned"
+                    )
 
                 used_robots.add(cheapest_robot)
                 robots_for_tactic.append(cheapest_robot)

--- a/rj_gameplay/stp/play/__init__.py
+++ b/rj_gameplay/stp/play/__init__.py
@@ -94,6 +94,7 @@ class Play(ABC):
             for cost_fn, role in tactic.role_requests:
                 min_cost = 1e9
                 cheapest_robot = None
+
                 for robot in world_state.our_robots:
                     if robot in used_robots or not robot.visible:
                         continue

--- a/rj_gameplay/stp/role/cost.py
+++ b/rj_gameplay/stp/role/cost.py
@@ -59,4 +59,26 @@ class PickClosestToPoint(stp.role.CostFn):
         return 1e9
 
     def __repr__(self):
-        return f"PickClosestRobot(target_point={self._target_point})"
+        return f"PickClosestToPoint(target_point={self._target_point})"
+
+
+class PickFarthestFromPoint(stp.role.CostFn):
+    """Always select farthest robot to some target_point (passed on init).
+    Can get farthest from ball by passing in `world_state.ball.pos`.
+    """
+
+    def __init__(self, target_point):
+        self.closest_picker = PickClosestToPoint(target_point)
+
+    def __call__(
+        self,
+        robot: stp.rc.Robot,
+        world_state: stp.rc.WorldState,
+    ) -> float:
+        closest_cost = self.closest_picker(robot, world_state)
+        if closest_cost >= 1e9:
+            return 1e9
+        return -closest_cost
+
+    def __repr__(self):
+        return f"PickFarthestFromPoint(target_point={self._target_point})"


### PR DESCRIPTION
## Description

Fills in basic122 with a sensible default offense play: move two robots to the wings, have a third robot pass to one of those two, and shoot once the wings have received a pass.

Costs are now passed into the pass tactic, to allow different plays to choose how they want to pass differently.

Currently the passing is buggy because kick speed is wrong and capture planner is weak, need to fix in separate PRs.

## Steps to test
Run sim.

Expected result: Description of sensible default offense play matches observed behavior.
