### PR TITLE
add isort and make pretty-lines to pre-commit hook, autoupdate pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
   hooks:
   - id: isort
     name: isort (python)
-    args: [--profile=black]
+    args: ["--profile","black"]
 - repo: https://github.com/psf/black
-    rev: 22.1.0
-    hooks:
-    -   id: black
+  rev: 22.1.0
+  hooks:
+  -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,10 @@ repos:
   rev: 22.1.0
   hooks:
   -   id: black
+- repo: local
+  hooks:
+  -   id: pretty-lines
+      name: pretty-lines
+      entry: make pretty-lines #root makefile pretty-lines
+      language: system
+      types: [c++]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
-#Run pre-commit autoupdate periodically to make sure version (rev) is correct
 repos:
--   repo: https://github.com/psf/black
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+  - id: isort
+    name: isort (python)
+    args: [--profile=black]
+- repo: https://github.com/psf/black
     rev: 22.1.0
     hooks:
     -   id: black

--- a/util/requirements3.txt
+++ b/util/requirements3.txt
@@ -13,10 +13,11 @@ pylint # static checker for python
 mypy == 0.770 # static arugment checker. Pinned to 0.770 because something is broken with 0.780
 
 yapf # python checker
-black #python checker
+black # python style autoformatter
+isort # python import sorted
 typing-extensions # For TypedDict
 cmake_format
-pre-commit #hook support
+pre-commit # hook support
 
 sphinx
 sphinx_rtd_theme

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -167,9 +167,11 @@ apt-get install $ARGS $PACKAGES
 python3 -m pip install pip==20.2.4
 pip3 install -r $BASE/util/requirements3.txt
 
-# install pre-commit hook for Black formatter
+# install pre-commit hooks
 echo "-- Installing pre-commit hook"
 pre-commit install
+# runs pre-commit autoupdate periodically to make sure version (rev) is correct
+pre-commit autoupdate
 
 echo "-- Installing grSim default configuration"
 GRSIM_XML_INSTALL_LOCATION="$HOME/.grsim.xml"


### PR DESCRIPTION
## Description
Adding isort to the pre-commit hook, fixing formatting issues in the .yaml file, and auto-updating pre-commit hooks in ubuntu setup

## Associated Issue
Issue #???

## Design Documents
[Link](link-to-design-doc)

## Steps to test
### Test Case 1
1. Step 1
Modify some python file, so that it has a style issue, such as adding unnecessary spaces to the end of line (black formatter), or unnecessary spaces in the imports line (isort).
2. Step 2
Modify some c++ file, so that it has a style issue, like unnecessary spaces (pretty-lines).
3. Step 3
Add the file(s) to be staged, and try to commit the branch. On the first try it should initialize the environment with isort, black, and pretty-lines, and then reformat the original file. (Make sure it corrected whatever result you had).

Expected result: 

Something along the following lines:

reformatted rj_gameplay/rj_gameplay/tactic/goalie_tactic.py

All done! ✨ 🍰 ✨
1 file reformatted.
