### PR TITLE
Ball gets to target in amount of time specified

### DIFF
--- a/rj_gameplay/rj_gameplay/role/passer.py
+++ b/rj_gameplay/rj_gameplay/role/passer.py
@@ -1,4 +1,3 @@
-from mimetypes import init
 import stp.role
 import stp.rc
 
@@ -71,8 +70,6 @@ class PasserRole(stp.role.Role):
             # kick_speed is modeled off of the ETDP of ZJUNlict, which can be found in section 5 of https://ssl.robocup.org/wp-content/uploads/2020/03/2020_ETDP_ZJUNlict.pdf
             distance = np.linalg.norm(self._target_point - self.robot.pose[0:2])
             initial_velocity = np.sqrt((FINAL_VELOCITY ** 2) - (2 * BALL_DECELERATION * distance))
-            print(distance)
-            print(initial_velocity)
             self.pivot_kick_skill = pivot_kick.PivotKick(
                 robot=self.robot,
                 target_point=self._target_point,

--- a/rj_gameplay/rj_gameplay/role/passer.py
+++ b/rj_gameplay/rj_gameplay/role/passer.py
@@ -9,10 +9,10 @@ from enum import Enum, auto
 
 import numpy as np
 
-# Time for the ball to the get to the target location (seems constant according to ZJUNlict)
-TIME_TO_TARGET = 0.75
+# The final velocity of the ball when it reaches our teammate
+FINAL_VELOCITY = 1
 # Rolling deceleration of the ball after it has been kicked
-BALL_DECELERATION = -0.3
+BALL_DECELERATION = -0.4
 
 
 class State(Enum):
@@ -73,7 +73,7 @@ class PasserRole(stp.role.Role):
                 robot=self.robot,
                 target_point=self._target_point,
                 chip=False,
-                kick_speed=(1.4*(distance + 0.5 * BALL_DECELERATION * (TIME_TO_TARGET ** 2)) / TIME_TO_TARGET),
+                kick_speed=(1.4 * np.sqrt((FINAL_VELOCITY ** 2) - (2 * BALL_DECELERATION * distance))),
             )
             self._state = State.EXECUTE_PASS
         elif self._state == State.EXECUTE_PASS:

--- a/rj_gameplay/rj_gameplay/role/passer.py
+++ b/rj_gameplay/rj_gameplay/role/passer.py
@@ -1,3 +1,4 @@
+from mimetypes import init
 import stp.role
 import stp.rc
 
@@ -10,7 +11,7 @@ from enum import Enum, auto
 import numpy as np
 
 # The final velocity of the ball when it reaches our teammate
-FINAL_VELOCITY = 1
+FINAL_VELOCITY = 4
 # Rolling deceleration of the ball after it has been kicked
 BALL_DECELERATION = -0.4
 
@@ -69,11 +70,14 @@ class PasserRole(stp.role.Role):
             # TODO: make these params configurable
             # kick_speed is modeled off of the ETDP of ZJUNlict, which can be found in section 5 of https://ssl.robocup.org/wp-content/uploads/2020/03/2020_ETDP_ZJUNlict.pdf
             distance = np.linalg.norm(self._target_point - self.robot.pose[0:2])
+            initial_velocity = np.sqrt((FINAL_VELOCITY ** 2) - (2 * BALL_DECELERATION * distance))
+            print(distance)
+            print(initial_velocity)
             self.pivot_kick_skill = pivot_kick.PivotKick(
                 robot=self.robot,
                 target_point=self._target_point,
                 chip=False,
-                kick_speed=(1.4 * np.sqrt((FINAL_VELOCITY ** 2) - (2 * BALL_DECELERATION * distance))),
+                kick_speed=initial_velocity,
             )
             self._state = State.EXECUTE_PASS
         elif self._state == State.EXECUTE_PASS:


### PR DESCRIPTION
## Description
Basically I used a quick linear approximation from [ZJUNlict's 2020 TDP](https://ssl.robocup.org/wp-content/uploads/2020/03/2020_ETDP_ZJUNlict.pdf) to allow the ball to end at the other opponent at a specified "velocity."  I'm not sure the units or dimensionality of this "velocity," but it works proportionally.  

The approximation seems to work pretty accurately, however it seems that the robot will not always pass the ball directly to the other robot.  This is because the threshold for pivoting is high and the other robot does not actually move to get the ball.  In the future if we wanted to increase the efficacy of our passes we could either lower the threshold of pivoting (this would make the robots take longer before passing) or increasing the effectiveness of our receiving robot receiving the ball.

## Steps to test
### Test Case 1
1. Run keepaway play
2. Watch robots pass
3. profit

Expected result: Robots should make passes that reach their opponents in the amount of time specified in passer.py (by default this is 0.75 seconds)
