### PR TITLE
make only 6 robots present

### DIFF
--- a/soccer/src/soccer/radio/sim_radio.cpp
+++ b/soccer/src/soccer/radio/sim_radio.cpp
@@ -63,7 +63,7 @@ static SimulatorCommand convert_placement_to_proto(
         //
         // to see this in effect, click and drag the robots expected to be not
         // present and they should disappear
-        if (robot.robot_id <= 6) {
+        if (robot.robot_id <= 5) {
             robot_proto->set_present(true);
         } else {
             robot_proto->set_present(false);

--- a/soccer/src/soccer/radio/sim_radio.cpp
+++ b/soccer/src/soccer/radio/sim_radio.cpp
@@ -50,12 +50,24 @@ static SimulatorCommand convert_placement_to_proto(
         robot_proto->set_x(static_cast<float>(robot.pose.position.x));
         robot_proto->set_y(static_cast<float>(robot.pose.position.y));
         robot_proto->set_orientation(static_cast<float>(robot.pose.heading));
+
         robot_proto->set_v_x(0);
         robot_proto->set_v_y(0);
         robot_proto->set_v_angular(0);
         robot_proto->mutable_id()->set_id(robot.robot_id);
         robot_proto->mutable_id()->set_team(robot.is_blue_team ? Team::BLUE : Team::YELLOW);
-        robot_proto->set_present(true);
+
+        // this line sets robots with an ID above 6 to "not present", meaning
+        // they will be removed on their next sim command
+        // see "rj_protos/proto/ssl_simulation_control.proto"
+        //
+        // to see this in effect, click and drag the robots expected to be not
+        // present and they should disappear
+        if (robot.robot_id <= 6) {
+            robot_proto->set_present(true);
+        } else {
+            robot_proto->set_present(false);
+        }
     }
     return packet;
 }


### PR DESCRIPTION
## Description
Pretty self-explanatory. Argument to be made that the number 6 should be put into a yaml or config or something. I have a feeling that that would be a much bigger PR, though (for instance our gameplay thinks NUM_ROBOTS=16, our topic generation follows that 16 as well, but the two variables are not set in the same place), so I left it at this for now.

## Steps to Test

1. build
2. launch sim
3. launch er-force (with `-g 2020B`)
4. click and drag every robot with id >= 6 to see them fly away!

Expected result: only 6v6 soccer by the end

@p-nayak11 if you want to add a card in the long-term that does this automatically instead of forcing us to click and drag every robot that'd be great