### PR TITLE
Penalty line tactic

### DIFF
--- a/rj_gameplay/rj_gameplay/play/penalty_defense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_defense.py
@@ -15,12 +15,10 @@ class State(Enum):
     INIT = auto()
     ACTIVE = auto()
 
-
 class PenaltyDefense(stp.play.Play):
-    """This is a play that represents the lineup procedure in the event that an opposing team has been awarded a penalty kick. 
+    """This is a play that represents the lineup procedure in the event that an opposing team has been awarded a penalty kick.
        Per rule 3 in Section 5.3.5 of the RoboCup SSL Playbook (https://robocup-ssl.github.io/ssl-rules/sslrules.html#_penalty_kick),
-       "Throughout the penalty kick procedure, all other robots have to be 1m behind the ball such that they do not interfere the penalty kick procedure".
-       As such, this play assigns one goalkeeper robot and lines up the remaining robots at least 1m behind the ball to prepare for the penalty. 
+       this play assigns one goalkeeper and lines up the other bots at least 1m behind the ball.
 
     :param state: An enum value that represents the current state of the play.
     :type state: class:`State`

--- a/rj_gameplay/rj_gameplay/play/penalty_defense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_defense.py
@@ -20,6 +20,7 @@ class PenaltyDefense(stp.play.Play):
     """This is a play that represents the lineup procedure in the event that an opposing team has been awarded a penalty kick. 
        Per rule 3 in Section 5.3.5 of the RoboCup SSL Playbook (https://robocup-ssl.github.io/ssl-rules/sslrules.html#_penalty_kick),
        "Throughout the penalty kick procedure, all other robots have to be 1m behind the ball such that they do not interfere the penalty kick procedure".
+       As such, this play assigns one goalkeeper robot and lines up the remaining robots at least 1m behind the ball to prepare for the penalty. 
 
     :param state: An enum value that represents the current state of the play.
     :type state: class:`State`
@@ -39,8 +40,8 @@ class PenaltyDefense(stp.play.Play):
             self.prioritized_tactics.append(goalie_tactic.GoalieTactic(world_state, 0))
             num_liners = len(world_state.our_visible_robots) - 1
             # 7.5 meters to our goal (designed so that 5 robots can be at least 1 meter behind the penalty line before the penalty is taken)
-            start_pt = np.array([-1.8, 7.5])
-            end_pt = np.array([1.8, 7.5])
+            start_pt = np.array([-2.1, 7.25])
+            end_pt = np.array([2.1, 7.25])
             self.prioritized_tactics.append(
                 line_tactic.LineTactic(world_state, num_liners, start_pt, end_pt)
             )

--- a/rj_gameplay/rj_gameplay/play/penalty_defense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_defense.py
@@ -29,8 +29,8 @@ class PenaltyDefense(stp.play.Play):
         if self._state == State.INIT:
             self.prioritized_tactics.append(goalie_tactic.GoalieTactic(world_state, 0))
             num_liners = len(world_state.our_visible_robots) - 1
-            start_pt = np.array([-3.0, 0.5])
-            end_pt = np.array([-3.0, 5.5])
+            start_pt = np.array([-1.8, 1.5])
+            end_pt = np.array([1.8, 1.5])
             self.prioritized_tactics.append(
                 line_tactic.LineTactic(world_state, num_liners, start_pt, end_pt)
             )

--- a/rj_gameplay/rj_gameplay/play/penalty_defense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_defense.py
@@ -29,9 +29,9 @@ class PenaltyDefense(stp.play.Play):
         if self._state == State.INIT:
             self.prioritized_tactics.append(goalie_tactic.GoalieTactic(world_state, 0))
             num_liners = len(world_state.our_visible_robots) - 1
-            # 7.5 metres to the opponent goal (esigned so that 5 robots can be on the line before the penalty is taken)
-            start_pt = np.array([-1.8, 1.5])
-            end_pt = np.array([1.8, 1.5])
+            # 7.5 metres to our goal (esigned so that 5 robots can be at least 1 metre behind the penalty line before the penalty is taken)
+            start_pt = np.array([-1.8, 7.5])
+            end_pt = np.array([1.8, 7.5])
             self.prioritized_tactics.append(
                 line_tactic.LineTactic(world_state, num_liners, start_pt, end_pt)
             )

--- a/rj_gameplay/rj_gameplay/play/penalty_defense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_defense.py
@@ -29,6 +29,7 @@ class PenaltyDefense(stp.play.Play):
         if self._state == State.INIT:
             self.prioritized_tactics.append(goalie_tactic.GoalieTactic(world_state, 0))
             num_liners = len(world_state.our_visible_robots) - 1
+            # 7.5 metres to the opponent goal (esigned so that 5 robots can be on the line before the penalty is taken)
             start_pt = np.array([-1.8, 1.5])
             end_pt = np.array([1.8, 1.5])
             self.prioritized_tactics.append(

--- a/rj_gameplay/rj_gameplay/play/penalty_defense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_defense.py
@@ -10,13 +10,22 @@ from rj_msgs.msg import RobotIntent
 
 from rj_gameplay.tactic import goalie_tactic, line_tactic
 
-
 class State(Enum):
+    """This class represents the state of the PenaltyDefense play."""
     INIT = auto()
     ACTIVE = auto()
 
 
 class PenaltyDefense(stp.play.Play):
+    """This is a play that represents the lineup procedure in the event that an opposing team has been awarded a penalty kick. 
+       Per rule 3 in Section 5.3.5 of the RoboCup SSL Playbook (https://robocup-ssl.github.io/ssl-rules/sslrules.html#_penalty_kick),
+       "Throughout the penalty kick procedure, all other robots have to be 1m behind the ball such that they do not interfere the penalty kick procedure".
+
+    :param state: An enum value that represents the current state of the play.
+    :type state: class:`State`
+    :param world_state: Contains the states of all aspects of the match.
+    :type world_state: class:`stp.rc.WorldState`
+    """
     def __init__(self):
         super().__init__()
         self._state = State.INIT

--- a/rj_gameplay/rj_gameplay/play/penalty_defense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_defense.py
@@ -29,7 +29,7 @@ class PenaltyDefense(stp.play.Play):
         if self._state == State.INIT:
             self.prioritized_tactics.append(goalie_tactic.GoalieTactic(world_state, 0))
             num_liners = len(world_state.our_visible_robots) - 1
-            # 7.5 metres to our goal (esigned so that 5 robots can be at least 1 metre behind the penalty line before the penalty is taken)
+            # 7.5 meters to our goal (designed so that 5 robots can be at least 1 meter behind the penalty line before the penalty is taken)
             start_pt = np.array([-1.8, 7.5])
             end_pt = np.array([1.8, 7.5])
             self.prioritized_tactics.append(

--- a/rj_gameplay/rj_gameplay/play/penalty_offense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_offense.py
@@ -62,7 +62,7 @@ class PrepPenaltyOff(stp.play.Play):
         if self._state == State.INIT:
             self.prioritized_tactics.append(prep_move.PrepMove(world_state))
             num_liners = len(world_state.our_visible_robots) - 1
-            # 7.5 metres to opponent's goal (6 metres to penalty line, 1 metre behind line, then spare distance to be safe)
+            # 7.5 meters to opponent's goal (6 meters to penalty line, 1 meter behind line, then spare distance to be safe)
             start_pt = np.array([-2.4, 1.5])
             end_pt = np.array([2.4, 1.5])
             self.prioritized_tactics.append(

--- a/rj_gameplay/rj_gameplay/play/penalty_offense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_offense.py
@@ -80,8 +80,8 @@ class PrepPenaltyOff(stp.play.Play):
             self.prioritized_tactics.append(prep_move.PrepMove(world_state))
             num_liners = len(world_state.our_visible_robots) - 1
             # 7.5 meters to opponent's goal (6 meters to penalty line, 1 meter behind line, then spare distance to be safe)
-            start_pt = np.array([-2.4, 1.5])
-            end_pt = np.array([2.4, 1.5])
+            start_pt = np.array([-2.4, 1.75])
+            end_pt = np.array([2.4, 1.75])
             self.prioritized_tactics.append(
                 line_tactic.LineTactic(world_state, num_liners, start_pt, end_pt)
             )

--- a/rj_gameplay/rj_gameplay/play/penalty_offense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_offense.py
@@ -19,10 +19,9 @@ class State(Enum):
 
 # TODO: add a shared state between these two classes somehow
 class PenaltyOffense(stp.play.Play):
-    """This is a play that represents the lineup procedure in the event that our team has been awarded a penalty kick. 
+    """This is a play that represents the lineup procedure in the event that an opposing team has been awarded a penalty kick.
        Per rule 3 in Section 5.3.5 of the RoboCup SSL Playbook (https://robocup-ssl.github.io/ssl-rules/sslrules.html#_penalty_kick),
-       "Throughout the penalty kick procedure, all other robots have to be 1m behind the ball such that they do not interfere the penalty kick procedure".
-       As such, this play lines up 5 offensive robots such that they are at least 1m behind the ball and assigns a striker to take the penalty.
+       this play assigns one goalkeeper and lines up the other bots at least 1m behind the ball.
 
     :param state: An enum value that represents the current state of the play.
     :type state: class:`State`

--- a/rj_gameplay/rj_gameplay/play/penalty_offense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_offense.py
@@ -33,8 +33,8 @@ class PenaltyOffense(stp.play.Play):
         if self._state == State.INIT:
             self.prioritized_tactics.append(striker_tactic.StrikerTactic(world_state))
             num_liners = len(world_state.our_visible_robots) - 1
-            start_pt = np.array([-2.0, 1.5])
-            end_pt = np.array([2.0, 1.5])
+            start_pt = np.array([-2.4, 1.5])
+            end_pt = np.array([2.4, 1.5])
             self.prioritized_tactics.append(
                 line_tactic.LineTactic(world_state, num_liners, start_pt, end_pt)
             )

--- a/rj_gameplay/rj_gameplay/play/penalty_offense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_offense.py
@@ -62,8 +62,9 @@ class PrepPenaltyOff(stp.play.Play):
         if self._state == State.INIT:
             self.prioritized_tactics.append(prep_move.PrepMove(world_state))
             num_liners = len(world_state.our_visible_robots) - 1
-            start_pt = np.array([-2.0, 1.5])
-            end_pt = np.array([2.0, 1.5])
+            # 7.5 metres to opponent's goal (6 metres to penalty line, 1 metre behind line, then spare distance to be safe)
+            start_pt = np.array([-2.4, 1.5])
+            end_pt = np.array([2.4, 1.5])
             self.prioritized_tactics.append(
                 line_tactic.LineTactic(world_state, num_liners, start_pt, end_pt)
             )

--- a/rj_gameplay/rj_gameplay/play/penalty_offense.py
+++ b/rj_gameplay/rj_gameplay/play/penalty_offense.py
@@ -12,13 +12,23 @@ from rj_gameplay.tactic import line_tactic, prep_move, striker_tactic
 
 
 class State(Enum):
+    """This is a class that represents the status of the PenaltyOffense play."""
     INIT = auto()
     ACTIVE = auto()
 
 
 # TODO: add a shared state between these two classes somehow
 class PenaltyOffense(stp.play.Play):
-    """striker + line up rest of robots"""
+    """This is a play that represents the lineup procedure in the event that our team has been awarded a penalty kick. 
+       Per rule 3 in Section 5.3.5 of the RoboCup SSL Playbook (https://robocup-ssl.github.io/ssl-rules/sslrules.html#_penalty_kick),
+       "Throughout the penalty kick procedure, all other robots have to be 1m behind the ball such that they do not interfere the penalty kick procedure".
+       As such, this play lines up 5 offensive robots such that they are at least 1m behind the ball and assigns a striker to take the penalty.
+
+    :param state: An enum value that represents the current state of the play.
+    :type state: class:`State`
+    :param world_state: Contains the states of all aspects of the match.
+    :type world_state: class:`stp.rc.WorldState`
+    """
 
     def __init__(self):
         super().__init__()
@@ -47,7 +57,14 @@ class PenaltyOffense(stp.play.Play):
 
 
 class PrepPenaltyOff(stp.play.Play):
-    """prepare striker + line up all robots"""
+    """This class, when called, prepares the PenaltyOffense play by lining up 5 offensive robots such that they are at least 1m behind the ball 
+    and assigns a striker to take the penalty.
+
+    :param state: An enum value that represents the current state of the play.
+    :type state: class:`State`
+    :param world_state: Contains the states of all aspects of the match.
+    :type world_state: class:`stp.rc.WorldState`
+    """
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
## Description
Updating the line tactic end points in the Penalty_Offense and Penalty_Defense tactics

## Associated Issue
**update line tactic start points for penalty situations according to rules** on ClickUp

## Steps to test and expected result
1. On penalty offense running, make sure 5 robots line up 7.5 metres away from the opponent's goal
2. On penalty defense running, make sure 4 robots line up 7.5 metres from our goal. 

7.5 metres is calculated per regulations (penalty line is 6 metres away, and all robots must be 1 metre behind the penalty line before the ball is kicked. 

