### PR TITLE
fix launch bug by sending NOP when no game info

### DIFF
--- a/rj_gameplay/rj_gameplay/gameplay_node.py
+++ b/rj_gameplay/rj_gameplay/gameplay_node.py
@@ -276,15 +276,23 @@ class GameplayNode(Node):
                 self._test_play = eval(play_str)
 
         if self.world_state is not None:
+            # if we don't have a test play, use play_selector
             if self._test_play is None:
-                new_situation, new_play = self.play_selector.select(self.world_state)
+                # sometimes game_info is None while world_state is not None
+                # don't do anything if we don't know what the game state is
+                if self.world_state.game_info is None:
+                    return
 
-                # if play/situation hasn't changed, keep old play
+                # if play selector wants to keep the same play, don't
+                # re-instantiate the Play object
+                new_situation, new_play = self.play_selector.select(self.world_state)
                 if type(self._curr_play) is not type(new_play) or type(
                     self._curr_situation
                 ) != type(new_situation):
                     self._curr_play = new_play
                     self._curr_situation = new_situation
+
+            # else, use the test play
             else:
                 self._curr_play = self._test_play
 


### PR DESCRIPTION
## Description
Fixes this annoying error msg:
```
[gameplay_node-10]   File "/home/kfu/coding/robocup-software/rj_gameplay/rj_gameplay/play_selector.py", line 192, in select
[gameplay_node-10]     if game_info.is_kickoff():
[gameplay_node-10] AttributeError: 'NoneType' object has no attribute 'is_kickoff'
```

## Associated / Resolved Issue
Resolves # or [ClickUp card](https://app.clickup.com/t/2mru7y4)

## Steps to test
### Test Case 1
1. Run `make run-sim` about 20 times. 

**Expected result:**  no crashes on launch.

## Key Files to Review
Only one file :)

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack
