### PR TITLE
Added Python venv to ubuntu-setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
         run: "sudo ./util/ubuntu-setup --yes"
 
       - name: Install git pre-commit hooks & update submodules
-        run: "./util/git-setup --yes"
+        run: | 
+          sudo apt-get install python3-venv
+          "./util/git-setup --yes"
 
       - name: Make ${{ github.base_ref }} branch exist
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           echo "::add-matcher::ci/clang.json"
           source /opt/ros/foxy/setup.bash
           source install/setup.bash
+          source rj_env/bin/activate
           make all
           echo "::remove-matcher owner=clang::"
 
@@ -43,6 +44,7 @@ jobs:
           echo "::add-matcher::ci/gtest.json"
           source /opt/ros/foxy/setup.bash
           source install/setup.bash
+          source rj_env/bin/activate
           ./install/lib/rj_robocup/test-soccer
           echo "::remove-matcher owner=gtest::"
 
@@ -51,6 +53,7 @@ jobs:
           echo "::add-matcher::ci/clang-tidy.json"
           source /opt/ros/foxy/setup.bash
           source install/setup.bash
+          source rj_env/bin/activate
           DIFFBASE=${{ github.base_ref }} make checktidy-lines
           echo "::remove-matcher owner=clang-tidy::"
         if: always()
@@ -71,6 +74,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          source rj_env/bin/activate
           sudo python3 -m pip install pylint
           sudo ./util/ubuntu-setup --yes
 
@@ -86,6 +90,7 @@ jobs:
         run: |
           source /opt/ros/foxy/setup.bash
           source install/setup.bash
+          source rj_env/bin/activate
           echo "::add-matcher::ci/mypy.json"
           mypy --ignore-missing-imports rj_gameplay/rj_gameplay rj_gameplay/stp
           echo "::remove-matcher owner=mypy::"
@@ -106,6 +111,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          source rj_env/bin/activate
           sudo python3 -m pip install pylint
           sudo ./util/ubuntu-setup --yes
 
@@ -120,6 +126,7 @@ jobs:
         run: |
           source /opt/ros/foxy/setup.bash
           source install/setup.bash
+          source rj_env/bin/activate
           echo "::add-matcher::ci/pylint.json"
           pylint rj_gameplay/rj_gameplay rj_gameplay/stp
           echo "::remove-matcher owner=pylint-warning::"
@@ -149,6 +156,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update && apt-get -y install clang-format sudo git python3-pip
+          source rj_env/bin/activate
           sudo pip3 install --upgrade flake8-diff flake8 pip
 
       - name: Run clang-format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,12 @@ jobs:
           fetch-depth: 0
 
       - name: Run util/ubuntu-setup as sudo
-        run: "sudo ./util/ubuntu-setup --yes"
+        run: |
+          "sudo apt-get install python3-venv"
+          "sudo ./util/ubuntu-setup --yes"
 
       - name: Install git pre-commit hooks & update submodules
         run: | 
-          sudo apt-get install python3-venv
           "./util/git-setup --yes"
 
       - name: Make ${{ github.base_ref }} branch exist

--- a/util/requirements3.txt
+++ b/util/requirements3.txt
@@ -24,3 +24,5 @@ pre-commit # hook support
 sphinx
 sphinx_rtd_theme
 breathe
+
+python3-venv

--- a/util/requirements3.txt
+++ b/util/requirements3.txt
@@ -24,5 +24,3 @@ pre-commit # hook support
 sphinx
 sphinx_rtd_theme
 breathe
-
-python3-venv

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -159,6 +159,19 @@ PACKAGES="$(sed 's/#.*//;/^$/d' $BASE/util/ubuntu-packages.txt)"
 # install all of the packages listed in required_packages.txt
 apt-get install $ARGS $PACKAGES
 
+#create a python virtual environment if needed
+py_env=rj_env
+if [ ! -e "$BASE/$py_env" ]; then
+    echo "Creating Python3 virtual environment: $py_env"
+	cd ../
+	python3 -m venv rj_env
+else
+    cd ../
+fi
+
+#activate python virtual environment
+source $BASE/$py_env/bin/activate
+
 # install python3 requirements
 python3 -m pip install pip==22.1
 pip3 install -r $BASE/util/requirements3.txt


### PR DESCRIPTION
## Description
The `util/ubuntu-setup` script now creates a Python virtual environment (`rj_env`) and uses it for installing our repo's Python packages

* Helps prevent causing problems in users' global Python installation
* Virtual environment is added to the $PYTHONPATH variable and can be used when calling our build script without additional flags/arguments

## Steps to Test
1. Run ubuntu-setup script
2. Build soccer
3. Run soccer (will need to activate the virtual environment with an additional command first: `source rj_env/bin/activate`)

It might be good for me to add that last one to the existing README in the launch instructions- I'll do that as long as this works for everyone else.

**Expected result:**
Soccer and sim should launch without problems using packages from the virtual environment

## Key Files to Review
* util/ubuntu-setup