### PR TITLE
Fix ER-Force Build Instructions

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -41,7 +41,7 @@ Then, build their code with the following:
 
     mkdir build && cd build
     cmake ..
-    make
+    make simulator-cli
 
 This builds an executable in ``framework/build/bin``. Like any other
 executable, it can be run with ``[filepath-to-executable]``. Since we're

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -39,9 +39,9 @@ Then, build their code with the following:
 
 .. code-block:: sh
 
-    mkdir build
-    cd build cmake 
-    make simulator-cli
+    mkdir build && cd build
+    cmake ..
+    make
 
 This builds an executable in ``framework/build/bin``. Like any other
 executable, it can be run with ``[filepath-to-executable]``. Since we're

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -39,7 +39,9 @@ Then, build their code with the following:
 
 .. code-block:: sh
 
-    mkdir build && cd build cmake .. make simulator-cli
+    mkdir build
+    cd build cmake 
+    make simulator-cli
 
 This builds an executable in ``framework/build/bin``. Like any other
 executable, it can be run with ``[filepath-to-executable]``. Since we're
@@ -67,9 +69,10 @@ Sadly, this program has no output, so when you run it nothing will appear to
 happen. However, it will become obvious after you start our UI whether or not
 you've correctly started the simulator or not.
 
-Now, make sure you're on the most updated version of ``ros2`` branch. This is
-where the latest working version of our codebase exists. (See "Github" doc.
---TODO(Prabhanjan): transfer this to docs--)
+In another terminal, change directories back into ``robocup-software``.
+Make sure you're on the most updated version of ``ros2`` branch. This is
+where the latest working version of our codebase exists. (See Contributing page for
+more information).
 
 .. code-block:: bash
 


### PR DESCRIPTION
## Description
Changed tutorial page wording from user feedback. Make sure the page looks easier to read.

**Expected result:**Tutorial Page makes more sense while going through it.

## Key Files to Review
docs
 * getting_started.rst

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack
