### PR TITLE
one goal at a time (WIP)

### DIFF
--- a/soccer/src/soccer/agent_action_client/position/goalie.cpp
+++ b/soccer/src/soccer/agent_action_client/position/goalie.cpp
@@ -14,37 +14,27 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
     }
 
     rj_msgs::msg::RobotIntent intent;
-    intent.robot_id = 2;
-    auto ptmc = rj_msgs::msg::PathTargetMotionCommand{};
-
-    double x = 2.0;
-    if (move_ct % 2 == 1) {
-        x = 4.0;
-    }
-
-    auto pt = rj_geometry::Point(x, 3.0);
-    ptmc.target.position = rj_convert::convert_to_ros(pt);
-    auto vel = rj_geometry::Point(0.0, 0.0);
-    ptmc.target.velocity = rj_convert::convert_to_ros(vel);
-    auto face_pt = rj_geometry::Point(1.0, 1.0);
-    ptmc.override_face_point = {rj_convert::convert_to_ros(face_pt)};
-
-    intent.motion_command.path_target_command = {ptmc};
-    return intent;
+    intent.robot_id = 0;
 
     // thread-safe getter
-    /* WorldState* world_state = this->world_state(); */
+    WorldState* world_state = this->world_state();
 
-    /* if (world_state == nullptr) { */
-    /*     rj_msgs::msg::RobotIntent intent; */
-    /*     intent.robot_id = 0; */
-    /*     auto empty = rj_msgs::msg::EmptyMotionCommand{}; */
-    /*     intent.motion_command.empty_command = {empty}; */
-    /*     return intent; */
-    /* } */
+    if (world_state == nullptr) {
+         auto empty = rj_msgs::msg::EmptyMotionCommand{};
+         intent.motion_command.empty_command = {empty};
+    } else {
+        auto ptmc = rj_msgs::msg::PathTargetMotionCommand{};
+        auto pt = get_block_pt(world_state);
+        ptmc.target.position = rj_convert::convert_to_ros(pt);
+        auto face_pt = rj_geometry::Point(1.0, 1.0);
+        ptmc.override_face_point = {rj_convert::convert_to_ros(face_pt)};
+        intent.motion_command.path_target_command = {ptmc};
+    }
+
+    return intent;
 }
 
-rj_geometry::Point Goalie::get_block_pt(WorldState* world_state) {
+    rj_geometry::Point Goalie::get_block_pt(WorldState* world_state) {
     // TODO: make intercept planner do what its header file does, so we don't need this
     // also, fix the intercept planner so we don't have to pass in the ball
     // point every tick
@@ -69,6 +59,7 @@ rj_geometry::Point Goalie::get_block_pt(WorldState* world_state) {
     }
 
     rj_geometry::Point block_pt{cross_x, 0.0};
+    SPDLOG_INFO("block pt {}, {}", block_pt.x(), block_pt.y());
     return block_pt;
 }
 

--- a/soccer/src/soccer/agent_action_client/position/goalie.cpp
+++ b/soccer/src/soccer/agent_action_client/position/goalie.cpp
@@ -20,8 +20,8 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
     WorldState* world_state = this->world_state();
 
     if (world_state == nullptr) {
-         auto empty = rj_msgs::msg::EmptyMotionCommand{};
-         intent.motion_command.empty_command = {empty};
+        auto empty = rj_msgs::msg::EmptyMotionCommand{};
+        intent.motion_command.empty_command = {empty};
     } else {
         auto ptmc = rj_msgs::msg::PathTargetMotionCommand{};
         auto pt = get_block_pt(world_state);
@@ -34,7 +34,7 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
     return intent;
 }
 
-    rj_geometry::Point Goalie::get_block_pt(WorldState* world_state) {
+rj_geometry::Point Goalie::get_block_pt(WorldState* world_state) {
     // TODO: make intercept planner do what its header file does, so we don't need this
     // also, fix the intercept planner so we don't have to pass in the ball
     // point every tick

--- a/soccer/src/soccer/agent_action_client/position/goalie.hpp
+++ b/soccer/src/soccer/agent_action_client/position/goalie.hpp
@@ -39,13 +39,13 @@ private:
      * @return Point for Goalie to block a shot. Calls get_idle_pt() if ball is
      * slow or shot will miss the goal.
      */
-    rj_geometry::Point get_block_pt(WorldState* world_state);
+    static rj_geometry::Point get_block_pt(WorldState* world_state);
 
     /*
      * @return Point for Goalie to stand in when no shot is coming. Expects
      * ball to be slow.
      */
-    rj_geometry::Point get_idle_pt(WorldState* world_state);
+    static rj_geometry::Point get_idle_pt(WorldState* world_state);
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -47,12 +47,24 @@ PlannerNode::PlannerNode()
 rclcpp_action::GoalResponse PlannerNode::handle_goal(const rclcpp_action::GoalUUID& uuid,
                                                      std::shared_ptr<const RobotMove::Goal> goal) {
     (void)uuid;
+    auto delay = std::chrono::milliseconds(1000 / 60);
+    rclcpp::Rate loop_rate(delay);
 
     // TODO(p-nayak): REJECT duplicate goal requests so we aren't constantly replanning them
 
     // planning::MotionCommand motion_command_ = goal->robot_intent.motion_command;
 
+    int robot_id = goal->robot_intent.robot_id;
     SPDLOG_ERROR("robot id {} sent goal", goal->robot_intent.robot_id);
+    auto& robot_task = server_task_states_.at(robot_id);
+    std::unique_lock lock{robot_task.mutex};
+    bool& is_executing = robot_task.is_executing;
+    if (is_executing) {
+        robot_task.new_task_waiting_signal = true;
+        robot_task.execute_cleared.wait(lock );
+        robot_task.new_task_waiting_signal = false;
+    }
+    is_executing = true;
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }
 
@@ -84,36 +96,54 @@ void PlannerNode::execute(const std::shared_ptr<GoalHandleRobotMove> goal_handle
     int robot_id = goal->robot_intent.robot_id;
     std::shared_ptr<PlannerForRobot> my_robot_planner = robots_planners_[robot_id];
 
+    auto& robot_task = server_task_states_.at(robot_id);
+
     // loop until goal is done (SUCCEEDED or CANCELED)
     for (;;) {
-        // if the ActionClient is trying to cancel the goal, cancel it & terminate early
-        if (goal_handle->is_canceling()) {
-            result->is_done = false;
-            goal_handle->canceled(result);
-            return;
-        }
+        // check if there is a new goal
+        {
+            std::unique_lock lock{robot_task.mutex};
+            bool& new_task_ready = robot_task.new_task_waiting_signal;
 
-        // pub Trajectory based on the RobotIntent
-        my_robot_planner->execute_trajectory(rj_convert::convert_from_ros(goal->robot_intent));
+            if (new_task_ready) {
+                result->is_done = false;
+                goal_handle->abort(result);
+                new_task_ready = false;
+                lock.release();
+                robot_task.execute_cleared.notify_all();
+                break;
+            }
 
-        // send feedback
-        std::shared_ptr<RobotMove::Feedback> feedback = std::make_shared<RobotMove::Feedback>();
-        if (auto time_left = my_robot_planner->get_time_left()) {
-            feedback->time_left = rj_convert::convert_to_ros(time_left.value());
-            goal_handle->publish_feedback(feedback);
-        }
+            // if the ActionClient is trying to cancel the goal, cancel it & terminate early
+            if (goal_handle->is_canceling()) {
+                result->is_done = false;
+                goal_handle->canceled(result);
+                break;
+            }
 
-        // when done, tell client goal is done, break loop
-        // TODO(p-nayak): when done, publish empty motion command to this robot's trajectory
-        if (my_robot_planner->is_done()) {
-            if (rclcpp::ok()) {
-                result->is_done = true;
-                goal_handle->succeed(result);
-                return;
+            // pub Trajectory based on the RobotIntent
+            my_robot_planner->execute_trajectory(rj_convert::convert_from_ros(goal->robot_intent));
+
+            // send feedback
+            std::shared_ptr<RobotMove::Feedback> feedback = std::make_shared<RobotMove::Feedback>();
+            if (auto time_left = my_robot_planner->get_time_left()) {
+                feedback->time_left = rj_convert::convert_to_ros(time_left.value());
+                goal_handle->publish_feedback(feedback);
+            }
+
+            // when done, tell client goal is done, break loop
+            // TODO(p-nayak): when done, publish empty motion command to this robot's trajectory
+            if (my_robot_planner->is_done()) {
+                if (rclcpp::ok()) {
+                    result->is_done = true;
+                    goal_handle->succeed(result);
+                    break;
+                }
             }
         }
         loop_rate.sleep();
     }
+    robot_task.is_executing = false;
 }
 
 PlannerForRobot::PlannerForRobot(int robot_id, rclcpp::Node* node,

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -59,9 +59,10 @@ rclcpp_action::GoalResponse PlannerNode::handle_goal(const rclcpp_action::GoalUU
     auto& robot_task = server_task_states_.at(robot_id);
     std::unique_lock lock{robot_task.mutex};
     bool& is_executing = robot_task.is_executing;
+    bool& new_task_waiting_signal = robot_task.new_task_waiting_signal;
     if (is_executing) {
         robot_task.new_task_waiting_signal = true;
-        robot_task.execute_cleared.wait(lock, [robot_task.new_task_waiting_signal] {return !robot_task.new_task_waiting_signal;});
+        robot_task.execute_cleared.wait(lock, [new_task_waiting_signal] {return !new_task_waiting_signal;});
     }
     is_executing = true;
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;

--- a/soccer/src/soccer/planning/planner_node.hpp
+++ b/soccer/src/soccer/planning/planner_node.hpp
@@ -254,11 +254,9 @@ private:
         ServerTaskState() = default;
         ~ServerTaskState() = default;
         // make clear that there's no copy constructor
-        ServerTaskState(ServerTaskState const &state) = delete;
-        std::mutex mutex;
-        std::condition_variable execute_cleared;
-        bool is_executing{false};
-        bool new_task_waiting_signal{false};
+        ServerTaskState(ServerTaskState const& state) = delete;
+        std::atomic_bool is_executing{false};
+        std::atomic_bool new_task_waiting_signal{false};
     };
     std::array<ServerTaskState, kNumShells> server_task_states_;
 };

--- a/soccer/src/soccer/planning/planner_node.hpp
+++ b/soccer/src/soccer/planning/planner_node.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
 #include <vector>
-#include <boost/interprocess/sync/interprocess_condition.hpp>
-#include <boost/interprocess/sync/interprocess_mutex.hpp>
-#include <boost/interprocess/sync/scoped_lock.hpp>
 
 #include <rclcpp/rclcpp.hpp>
 // for ROS actions
@@ -254,7 +251,7 @@ private:
     void execute(const std::shared_ptr<GoalHandleRobotMove> goal_handle);
 
     struct ServerTaskState {
-        ServerTaskState() : mutex(), execute_cleared() {}
+        ServerTaskState() = default;
         ~ServerTaskState() = default;
         // make clear that there's no copy constructor
         ServerTaskState(ServerTaskState const &state) = delete;


### PR DESCRIPTION
## Description
Ensures Planning ActionServer only runs one goal per robot, and cancels previously running goals on receiving a new one. This is how SimpleActionServer in ROS 1 behaves. (In ROS2, by default any action server can handle any number of goals at once, which we found to be a bad model for our use case.)

Implemented via a classic "handshake agreement":
https://www.thefreedictionary.com/Handshake+(computing)
