### PR TITLE
Update clang tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,14 @@ jobs:
           ./install/lib/rj_robocup/test-soccer
           echo "::remove-matcher owner=gtest::"
 
-      # - name: Run clang-tidy
-      #   run: |
-      #     echo "::add-matcher::ci/clang-tidy.json"
-      #     source /opt/ros/foxy/setup.bash
-      #     source install/setup.bash
-      #     DIFFBASE=${{ github.base_ref }} make checktidy-lines
-      #     echo "::remove-matcher owner=clang-tidy::"
-      #   if: always()
+      - name: Run clang-tidy
+        run: |
+          echo "::add-matcher::ci/clang-tidy.json"
+          source /opt/ros/foxy/setup.bash
+          source install/setup.bash
+          DIFFBASE=${{ github.base_ref }} make checktidy-lines
+          echo "::remove-matcher owner=clang-tidy::"
+        if: always()
 
   mypy:
     runs-on: ubuntu-latest
@@ -148,7 +148,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update && apt-get -y install clang-format clang-tidy sudo git python3-pip
+          apt-get update && apt-get -y install clang-format sudo git python3-pip
           sudo pip3 install --upgrade flake8-diff flake8 pip
 
       # check formatting style (C++)
@@ -157,13 +157,6 @@ jobs:
           echo "::add-matcher::ci/clang-format.json"
           git diff -U0 --no-color ${{ github.base_ref }} HEAD | python3 util/clang-format-diff.py -binary clang-format -p1 -dry_run
           echo "::remove-matcher owner=clang-format::"
-
-      # check for code smells (C++)
-      - name: Run clang-tidy
-        run: |
-          echo "::add-matcher::ci/clang-tidy.json"
-          git diff -U0 --no-color ${{ github.base_ref }} HEAD | python3 util/clang-tidy-diff.py -clang-tidy-binary clang-tidy -p1
-          echo "::remove-matcher owner=clang-tidy::"
 
       - name: Run flake8
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,14 @@ jobs:
           ./install/lib/rj_robocup/test-soccer
           echo "::remove-matcher owner=gtest::"
 
-      - name: Run clang-tidy
-        run: |
-          echo "::add-matcher::ci/clang-tidy.json"
-          source /opt/ros/foxy/setup.bash
-          source install/setup.bash
-          DIFFBASE=${{ github.base_ref }} make checktidy-lines
-          echo "::remove-matcher owner=clang-tidy::"
-        if: always()
+      # - name: Run clang-tidy
+      #   run: |
+      #     echo "::add-matcher::ci/clang-tidy.json"
+      #     source /opt/ros/foxy/setup.bash
+      #     source install/setup.bash
+      #     DIFFBASE=${{ github.base_ref }} make checktidy-lines
+      #     echo "::remove-matcher owner=clang-tidy::"
+      #   if: always()
 
   mypy:
     runs-on: ubuntu-latest
@@ -148,14 +148,22 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update && apt-get -y install clang-format sudo git python3-pip
+          apt-get update && apt-get -y install clang-format clang-tidy sudo git python3-pip
           sudo pip3 install --upgrade flake8-diff flake8 pip
 
+      # check formatting style (C++)
       - name: Run clang-format
         run: |
           echo "::add-matcher::ci/clang-format.json"
           git diff -U0 --no-color ${{ github.base_ref }} HEAD | python3 util/clang-format-diff.py -binary clang-format -p1 -dry_run
           echo "::remove-matcher owner=clang-format::"
+
+      # check for code smells (C++)
+      - name: Run clang-tidy
+        run: |
+          echo "::add-matcher::ci/clang-tidy.json"
+          git diff -U0 --no-color ${{ github.base_ref }} HEAD | python3 util/clang-tidy-diff.py -clang-tidy-binary clang-tidy -p1
+          echo "::remove-matcher owner=clang-tidy::"
 
       - name: Run flake8
         if: always()

--- a/makefile
+++ b/makefile
@@ -181,8 +181,8 @@ checkstyle:
 	@printf "Run this command to reformat code if needed:\n\ngit apply <(curl -L $${LINK_PREFIX:-file://}clean.patch)\n\n"
 	@stylize.v1 --git_diffbase=$(DIFFBASE) --patch_output "$${CIRCLE_ARTIFACTS:-.}/clean.patch"
 
-CLANG_FORMAT_BINARY=clang-format-10
-CLANG_TIDY_BINARY=clang-tidy-10
+CLANG_FORMAT_BINARY=clang-format-12
+CLANG_TIDY_BINARY=clang-tidy-12
 COMPILE_COMMANDS_DIR=build-debug
 
 # circleci has 2 cores, but advertises 32
@@ -211,8 +211,9 @@ checkstyle-lines:
 	@git diff -U0 --no-color $(DIFFBASE) | python3 util/yapf-diff.py -style .style.yapf -p1 | tee -a /tmp/checkstyle.patch
 	@bash -c '[[ ! "$$(cat /tmp/checkstyle.patch)" ]] || (echo "****************************** Checkstyle errors *******************************" && exit 1)'
 
-# used in GH Actions - build-and-test
+# used in GH Actions - build-and-test/clang-tidy (code linter)
+# google-runtime-references warnings ignored (advice is outdated)
 checktidy-lines:
 	@echo "Removing GCC precompiled headers from compile_commands.json so that clang-tidy will work"
 	@sed -i 's/-include [^ ]*cmake_pch\.hxx//' $(COMPILE_COMMANDS_DIR)/compile_commands.json
-	@git diff -U0 --no-color $(DIFFBASE) | python3 util/clang-tidy-diff.py -clang-tidy-binary $(CLANG_TIDY_BINARY) -p1 -path $(COMPILE_COMMANDS_DIR) -j$(CORES)
+	@git diff -U0 --no-color $(DIFFBASE) | python3 util/clang-tidy-diff.py -clang-tidy-binary $(CLANG_TIDY_BINARY) -p1 -path $(COMPILE_COMMANDS_DIR) -j$(CORES) -checks=-google-runtime-references

--- a/soccer/src/soccer/temp.cpp
+++ b/soccer/src/soccer/temp.cpp
@@ -1,0 +1,1 @@
+void fake_func(int& pass_by_ref) { pass_by_ref = 2; }

--- a/util/ubuntu-packages.txt
+++ b/util/ubuntu-packages.txt
@@ -35,8 +35,8 @@ clang
 g++
 
 # C/C++ (and more) code-formatting tool
-clang-format-10
-clang-tidy-10
+clang-format-12
+clang-tidy-12
 
 # contains a ton of great C++ libraries
 libboost-all-dev


### PR DESCRIPTION
## Description
Suppresses "google-runtime-references" warnings from clang-tidy, which is outdated according to the new Google style guide for C++. (See [here](https://github.com/RoboJackets/robocup-software/pull/1962#discussion_r1019804192).)

## Steps to Test
### Test Case 1
1. Look at files changed.
2. Notice that there is no check warning for a pass-by-reference in temp.cpp.

### Test Case 2
1. Go to the "Actions" tab (right of Pull Requests)
2. Go to the PR checks log for `#1015`
3. Go to build-and-test > run clang-tidy
4. Notice that the warning exists for temp.cpp there (this commit was before the suppression of google-runtime-references).

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack

**TODO**: delete temp.cpp before merge.
