### PR TITLE
Fix planner node

### DIFF
--- a/launch/soccer.launch.py
+++ b/launch/soccer.launch.py
@@ -171,13 +171,13 @@ def generate_launch_description():
                 output="screen",
                 on_exit=Shutdown(),
             ),
-            # Node(
-            #     package="rj_robocup",
-            #     executable="planner_node",
-            #     output="screen",
-            #     parameters=[param_config_filepath],
-            #     on_exit=Shutdown(),
-            # ),
+            Node(
+                package="rj_robocup",
+                executable="planner_node",
+                output="screen",
+                parameters=[param_config_filepath],
+                on_exit=Shutdown(),
+            ),
             # spawn manual node only if use_manual_control is True
             Node(
                 condition=IfCondition(PythonExpression([use_manual_control])),

--- a/launch/soccer.launch.py
+++ b/launch/soccer.launch.py
@@ -171,13 +171,13 @@ def generate_launch_description():
                 output="screen",
                 on_exit=Shutdown(),
             ),
-            Node(
-                package="rj_robocup",
-                executable="planner_node",
-                output="screen",
-                parameters=[param_config_filepath],
-                on_exit=Shutdown(),
-            ),
+            # Node(
+            #     package="rj_robocup",
+            #     executable="planner_node",
+            #     output="screen",
+            #     parameters=[param_config_filepath],
+            #     on_exit=Shutdown(),
+            # ),
             # spawn manual node only if use_manual_control is True
             Node(
                 condition=IfCondition(PythonExpression([use_manual_control])),

--- a/rj_geometry/include/rj_geometry/circle.hpp
+++ b/rj_geometry/include/rj_geometry/circle.hpp
@@ -13,19 +13,20 @@ public:
     using Msg = rj_geometry_msgs::msg::Circle;
 
     Circle() {
-        r_ = -1;
-        rsq_ = -1;
+        r_ = 0;
+        rsq_ = 0;
     }
 
     Circle(Point c, float r) {
         center = c;
         r_ = r;
-        rsq_ = -1;
+        rsq_ = r_ * r_;
     }
 
     Circle(const Circle& other) {
         center = other.center;
         r_ = other.radius();
+        rsq_ = r_ * r_;
     }
 
     Shape* clone() const override;
@@ -36,30 +37,22 @@ public:
 
     // Radius squared
     float radius_sq() const {
-        if (rsq_ < 0 && r_ >= 0) {
-            rsq_ = r_ * r_;
-        }
-
         return rsq_;
     }
 
     void radius_sq(float value) {
         rsq_ = value;
-        r_ = -1;
+        r_ = sqrtf(rsq_);
     }
 
     // Radius
     float radius() const {
-        if (r_ < 0 && rsq_ >= 0) {
-            r_ = sqrtf(rsq_);
-        }
-
         return r_;
     }
 
     void radius(float value) {
         r_ = value;
-        rsq_ = -1;
+        rsq_ = r_ * r_;
     }
 
     bool contains_point(Point pt) const override;
@@ -97,9 +90,9 @@ public:
 
 protected:
     // Radius
-    mutable float r_;
+    float r_;
 
     // Radius squared
-    mutable float rsq_;
+    float rsq_;
 };
 }

--- a/soccer/src/soccer/CMakeLists.txt
+++ b/soccer/src/soccer/CMakeLists.txt
@@ -42,6 +42,7 @@ set(ROBOCUP_LIB_SRC
     planning/planner_node.cpp
     planning/trajectory.cpp
     planning/trajectory_utils.cpp
+    planning/trajectory_collection.cpp
     planning/planning_params.cpp
     processor.cpp
     radio/network_radio.cpp

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -2,13 +2,15 @@
 
 namespace planning {
 
-void fill_robot_obstacle(const RobotState& robot, rj_geometry::Point& obs_center, double& obs_radius) {
+void fill_robot_obstacle(const RobotState& robot, rj_geometry::Point& obs_center,
+                         double& obs_radius) {
     // params for obstacle shift
     double obs_center_shift = 0.5;
     double obs_radius_inflation = 1.0;
 
     // shift obs center off robot
-    obs_center = robot.pose.position() + (robot.velocity.linear() * kRobotRadius * obs_center_shift);
+    obs_center =
+        robot.pose.position() + (robot.velocity.linear() * kRobotRadius * obs_center_shift);
 
     // inflate obs radius if needed
     double vel_mag = robot.velocity.linear().mag();

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -2,20 +2,18 @@
 
 namespace planning {
 
-std::shared_ptr<rj_geometry::Circle> calc_static_robot_obs(const RobotState& robot) {
+void fill_robot_obstacle(const RobotState& robot, rj_geometry::Point& obs_center, double& obs_radius) {
     // params for obstacle shift
     double obs_center_shift = 0.5;
     double obs_radius_inflation = 1.0;
 
     // shift obs center off robot
-    rj_geometry::Point obs_center =
-        robot.pose.position() + (robot.velocity.linear() * kRobotRadius * obs_center_shift);
+    obs_center = robot.pose.position() + (robot.velocity.linear() * kRobotRadius * obs_center_shift);
 
     // inflate obs radius if needed
     double vel_mag = robot.velocity.linear().mag();
     double safety_margin = vel_mag * obs_radius_inflation;
-    double obs_radius = kRobotRadius + (kRobotRadius * safety_margin);
-    return std::make_shared<rj_geometry::Circle>(obs_center, obs_radius);
+    obs_radius = kRobotRadius + (kRobotRadius * safety_margin);
 }
 
 void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
@@ -25,13 +23,16 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
     out_static->add(in.field_obstacles);
     out_static->add(in.virtual_obstacles);
 
+    rj_geometry::Point obs_center{0.0, 0.0};
+    double obs_radius{1.0};
+
     // Add their robots as static obstacles (inflated based on velocity).
-    // See calc_static_robot_obs() docstring for more info.
     for (int shell = 0; shell < kNumShells; shell++) {
         const RobotState& their_robot = in.world_state->their_robots.at(shell);
+        fill_robot_obstacle(their_robot, obs_center, obs_radius);
 
         if (their_robot.visible) {
-            out_static->add(calc_static_robot_obs(their_robot));
+            out_static->add(std::make_shared<rj_geometry::Circle>(obs_center, obs_radius));
         }
     }
 
@@ -44,14 +45,12 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
             continue;
         }
 
-        std::shared_ptr<rj_geometry::Circle> obs_ptr = calc_static_robot_obs(robot);
-
         if (out_dynamic != nullptr && in.planned_trajectories.at(shell) != nullptr) {
             // Dynamic obstacle
-            out_dynamic->emplace_back(obs_ptr->radius(), in.planned_trajectories.at(shell));
+            out_dynamic->emplace_back(obs_radius, in.planned_trajectories.at(shell));
         } else {
             // Static obstacle
-            out_static->add(obs_ptr);
+            out_static->add(std::make_shared<rj_geometry::Circle>(obs_center, obs_radius));
         }
     }
 

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -45,9 +45,10 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
             continue;
         }
 
-        if (out_dynamic != nullptr && in.planned_trajectories.at(shell) != nullptr) {
+        const Trajectory* ptr_to_traj = std::get<0>(in.planned_trajectories->get(shell)).get();
+        if (out_dynamic != nullptr && ptr_to_traj != nullptr) {
             // Dynamic obstacle
-            out_dynamic->emplace_back(obs_radius, in.planned_trajectories.at(shell));
+            out_dynamic->emplace_back(obs_radius, ptr_to_traj);
         } else {
             // Static obstacle
             out_static->add(std::make_shared<rj_geometry::Circle>(obs_center, obs_radius));

--- a/soccer/src/soccer/planning/planner/plan_request.hpp
+++ b/soccer/src/soccer/planning/planner/plan_request.hpp
@@ -12,9 +12,9 @@
 #include "planning/dynamic_obstacle.hpp"
 #include "planning/instant.hpp"
 #include "planning/robot_constraints.hpp"
+#include "planning/trajectory_collection.hpp"
 #include "ros_debug_drawer.hpp"
 #include "world_state.hpp"
-#include "planning/trajectory_collection.hpp"
 
 namespace planning {
 
@@ -27,9 +27,8 @@ namespace planning {
 struct PlanRequest {
     PlanRequest(RobotInstant start, MotionCommand command,  // NOLINT
                 RobotConstraints constraints, rj_geometry::ShapeSet field_obstacles,
-                rj_geometry::ShapeSet virtual_obstacles,
-                TrajectoryCollection *planned_trajectories, unsigned shell_id,
-                const WorldState* world_state, int8_t priority = 0,
+                rj_geometry::ShapeSet virtual_obstacles, TrajectoryCollection* planned_trajectories,
+                unsigned shell_id, const WorldState* world_state, int8_t priority = 0,
                 rj_drawing::RosDebugDrawer* debug_drawer = nullptr, bool ball_sense = false)
         : start(start),
           motion_command(command),  // NOLINT
@@ -73,7 +72,7 @@ struct PlanRequest {
      * Trajectories for each of the robots that has already been planned.
      * nullptr for unplanned robots.
      */
-    TrajectoryCollection *planned_trajectories;
+    TrajectoryCollection* planned_trajectories;
 
     /**
      * The robot's shell ID. Used for debug drawing.
@@ -128,7 +127,8 @@ struct PlanRequest {
  * Numbers tuned by looking at output of planning/test_scripts/visualize_obs.py.
  *
  */
-void fill_robot_obstacle(const RobotState& robot, rj_geometry::Point& obs_center, double& obs_radius);
+void fill_robot_obstacle(const RobotState& robot, rj_geometry::Point& obs_center,
+                         double& obs_radius);
 
 /**
  * Fill the obstacle fields.

--- a/soccer/src/soccer/planning/planner/plan_request.hpp
+++ b/soccer/src/soccer/planning/planner/plan_request.hpp
@@ -14,6 +14,7 @@
 #include "planning/robot_constraints.hpp"
 #include "ros_debug_drawer.hpp"
 #include "world_state.hpp"
+#include "planning/trajectory_collection.hpp"
 
 namespace planning {
 
@@ -27,7 +28,7 @@ struct PlanRequest {
     PlanRequest(RobotInstant start, MotionCommand command,  // NOLINT
                 RobotConstraints constraints, rj_geometry::ShapeSet field_obstacles,
                 rj_geometry::ShapeSet virtual_obstacles,
-                std::array<const Trajectory*, kNumShells> planned_trajectories, unsigned shell_id,
+                TrajectoryCollection *planned_trajectories, unsigned shell_id,
                 const WorldState* world_state, int8_t priority = 0,
                 rj_drawing::RosDebugDrawer* debug_drawer = nullptr, bool ball_sense = false)
         : start(start),
@@ -72,7 +73,7 @@ struct PlanRequest {
      * Trajectories for each of the robots that has already been planned.
      * nullptr for unplanned robots.
      */
-    std::array<const Trajectory*, kNumShells> planned_trajectories;
+    TrajectoryCollection *planned_trajectories;
 
     /**
      * The robot's shell ID. Used for debug drawing.

--- a/soccer/src/soccer/planning/planner/plan_request.hpp
+++ b/soccer/src/soccer/planning/planner/plan_request.hpp
@@ -103,6 +103,7 @@ struct PlanRequest {
 };
 
 /**
+ * TODO: fix this doc
  * Create static circle obstacle for one of the robots.
  *
  * Shift the circle off-center depending on their robot's current velocity.
@@ -125,10 +126,8 @@ struct PlanRequest {
  *
  * Numbers tuned by looking at output of planning/test_scripts/visualize_obs.py.
  *
- * @param robot ptr to robot that needs obstacle made
- * @return shared_ptr to new Circle obstacle with inflated radius and center
  */
-std::shared_ptr<rj_geometry::Circle> calc_static_robot_obs(const RobotState& robot);
+void fill_robot_obstacle(const RobotState& robot, rj_geometry::Point& obs_center, double& obs_radius);
 
 /**
  * Fill the obstacle fields.

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -182,8 +182,7 @@ std::optional<RJ::Seconds> PlannerForRobot::get_time_left() const {
     // TODO(p-nayak): why does this say 3s even when the robot is on its point?
     // get the Traj out of the relevant [Trajectory, priority] tuple in
     // robot_trajectories_
-    const auto latest_trajs = robot_trajectories_->get();
-    const auto& [latest_traj, priority] = latest_trajs.at(robot_id_);
+    const auto& [latest_traj, priority] = robot_trajectories_->get(robot_id_);
     if (!latest_traj) {
         return std::nullopt;
     }
@@ -207,18 +206,21 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     }
 
     // make a copy instead of getting the actual shared_ptr to Trajectory
-    const auto robot_trajectories_hold = robot_trajectories_->get();
-    std::array<const Trajectory*, kNumShells> planned_trajectories = {};
+    /* std::array<std::optional<Trajectory>, kNumShells> planned_trajectories; */
 
-    for (int i = 0; i < kNumShells; i++) {
-        // TODO(Kevin): check that priority works (seems like
-        // robot_trajectories_ is passed on init, when no planning has occured
-        // yet)
-        const auto& [trajectory, priority] = robot_trajectories_hold.at(i);
-        if (i != robot_id_ && priority >= intent.priority) {
-            planned_trajectories.at(i) = trajectory.get();
-        }
-    }
+    /* for (int i = 0; i < kNumShells; i++) { */
+    /*     // TODO(Kevin): check that priority works (seems like */
+    /*     // robot_trajectories_ is passed on init, when no planning has occured */
+    /*     // yet) */
+    /*     const auto& [trajectory, priority] = robot_trajectories_->get(i); */
+    /*     if (i != robot_id_ && priority >= intent.priority) { */
+    /*         if (!trajectory) { */
+    /*             planned_trajectories[i] = std::nullopt; */
+    /*         } else { */
+    /*             planned_trajectories[i] = std::make_optional<const Trajectory>(*trajectory.get()); */
+    /*         } */
+    /*     } */
+    /* } */
 
     // TODO(Kyle): Send constraints from gameplay
     RobotConstraints constraints;
@@ -231,7 +233,7 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
                        constraints,
                        std::move(real_obstacles),
                        std::move(virtual_obstacles),
-                       planned_trajectories,
+                       robot_trajectories_,
                        static_cast<unsigned int>(robot_id_),
                        world_state,
                        intent.priority,

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -206,6 +206,7 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
         virtual_obstacles.add(def_area_obstacles);
     }
 
+    // make a copy instead of getting the actual shared_ptr to Trajectory
     const auto robot_trajectories_hold = robot_trajectories_->get();
     std::array<const Trajectory*, kNumShells> planned_trajectories = {};
 

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -117,11 +117,11 @@ void PlannerNode::execute(const std::shared_ptr<GoalHandleRobotMove> goal_handle
         my_robot_planner->execute_trajectory(rj_convert::convert_from_ros(goal->robot_intent));
 
         // send feedback
-        std::shared_ptr<RobotMove::Feedback> feedback = std::make_shared<RobotMove::Feedback>();
-        if (auto time_left = my_robot_planner->get_time_left()) {
-            feedback->time_left = rj_convert::convert_to_ros(time_left.value());
-            goal_handle->publish_feedback(feedback);
-        }
+        /* std::shared_ptr<RobotMove::Feedback> feedback = std::make_shared<RobotMove::Feedback>(); */
+        /* if (auto time_left = my_robot_planner->get_time_left()) { */
+        /*     feedback->time_left = rj_convert::convert_to_ros(time_left.value()); */
+        /*     goal_handle->publish_feedback(feedback); */
+        /* } */
 
         // when done, tell client goal is done, break loop
         // TODO(p-nayak): when done, publish empty motion command to this robot's trajectory
@@ -173,8 +173,8 @@ void PlannerForRobot::execute_trajectory(const RobotIntent& intent) {
         auto trajectory = plan_for_robot(plan_request);
         trajectory_pub_->publish(rj_convert::convert_to_ros(trajectory));
         // store all latest trajectories in a mutex-locked shared map
-        robot_trajectories_->put(robot_id_, std::make_shared<Trajectory>(std::move(trajectory)),
-                                 intent.priority);
+        /* robot_trajectories_->put(robot_id_, std::make_shared<Trajectory>(std::move(trajectory)), */
+        /*                          intent.priority); */
     }
 }
 
@@ -182,11 +182,12 @@ std::optional<RJ::Seconds> PlannerForRobot::get_time_left() const {
     // TODO(p-nayak): why does this say 3s even when the robot is on its point?
     // get the Traj out of the relevant [Trajectory, priority] tuple in
     // robot_trajectories_
-    const auto& [latest_traj, priority] = robot_trajectories_->get(robot_id_);
-    if (!latest_traj) {
-        return std::nullopt;
-    }
-    return latest_traj->end_time() - RJ::now();
+    /* const auto& [latest_traj, priority] = robot_trajectories_->get(robot_id_); */
+    /* if (!latest_traj) { */
+    /*     return std::nullopt; */
+    /* } */
+    /* return latest_traj->end_time() - RJ::now(); */
+    return std::nullopt;
 }
 
 PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -117,7 +117,8 @@ void PlannerNode::execute(const std::shared_ptr<GoalHandleRobotMove> goal_handle
         my_robot_planner->execute_trajectory(rj_convert::convert_from_ros(goal->robot_intent));
 
         // send feedback
-        /* std::shared_ptr<RobotMove::Feedback> feedback = std::make_shared<RobotMove::Feedback>(); */
+        /* std::shared_ptr<RobotMove::Feedback> feedback = std::make_shared<RobotMove::Feedback>();
+         */
         /* if (auto time_left = my_robot_planner->get_time_left()) { */
         /*     feedback->time_left = rj_convert::convert_to_ros(time_left.value()); */
         /*     goal_handle->publish_feedback(feedback); */
@@ -173,7 +174,8 @@ void PlannerForRobot::execute_trajectory(const RobotIntent& intent) {
         auto trajectory = plan_for_robot(plan_request);
         trajectory_pub_->publish(rj_convert::convert_to_ros(trajectory));
         // store all latest trajectories in a mutex-locked shared map
-        /* robot_trajectories_->put(robot_id_, std::make_shared<Trajectory>(std::move(trajectory)), */
+        /* robot_trajectories_->put(robot_id_, std::make_shared<Trajectory>(std::move(trajectory)),
+         */
         /*                          intent.priority); */
     }
 }
@@ -182,6 +184,8 @@ std::optional<RJ::Seconds> PlannerForRobot::get_time_left() const {
     // TODO(p-nayak): why does this say 3s even when the robot is on its point?
     // get the Traj out of the relevant [Trajectory, priority] tuple in
     // robot_trajectories_
+
+    // TODO (PR #1970): fix TrajectoryCollection
     /* const auto& [latest_traj, priority] = robot_trajectories_->get(robot_id_); */
     /* if (!latest_traj) { */
     /*     return std::nullopt; */
@@ -218,7 +222,8 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     /*         if (!trajectory) { */
     /*             planned_trajectories[i] = std::nullopt; */
     /*         } else { */
-    /*             planned_trajectories[i] = std::make_optional<const Trajectory>(*trajectory.get()); */
+    /*             planned_trajectories[i] = std::make_optional<const
+     * Trajectory>(*trajectory.get()); */
     /*         } */
     /*     } */
     /* } */

--- a/soccer/src/soccer/planning/planner_node.hpp
+++ b/soccer/src/soccer/planning/planner_node.hpp
@@ -21,37 +21,9 @@
 #include "robot_intent.hpp"
 #include "trajectory.hpp"
 #include "world_state.hpp"
+#include "planning/trajectory_collection.hpp"
 
 namespace planning {
-
-/**
- * A collection of per-robot trajectories.
- */
-class TrajectoryCollection {
-public:
-    // Per-robot (trajectory, priority)
-    using Entry = std::tuple<std::shared_ptr<const Trajectory>, int>;
-
-    std::array<Entry, kNumShells> get() {
-        std::lock_guard lock(lock_);
-        return robot_trajectories_;
-    }
-    // TODO: add "copy()" function here
-
-    void put(int robot_id, std::shared_ptr<const Trajectory> trajectory, int priority) {
-        // associate a (Trajectory, priority) tuple with a robot id
-        std::lock_guard lock(lock_);
-        try {
-            robot_trajectories_.at(robot_id) = std::make_tuple(std::move(trajectory), priority);
-        } catch (std::exception& exception) {
-            std::cout << exception.what() << std::endl;
-        }
-    }
-
-private:
-    std::mutex lock_;
-    std::array<Entry, kNumShells> robot_trajectories_ = {};
-};
 
 class SharedStateInfo {
 public:

--- a/soccer/src/soccer/planning/planner_node.hpp
+++ b/soccer/src/soccer/planning/planner_node.hpp
@@ -17,11 +17,11 @@
 #include "node.hpp"
 #include "planner/plan_request.hpp"
 #include "planner/planner.hpp"
+#include "planning/trajectory_collection.hpp"
 #include "planning_params.hpp"
 #include "robot_intent.hpp"
 #include "trajectory.hpp"
 #include "world_state.hpp"
-#include "planning/trajectory_collection.hpp"
 
 namespace planning {
 

--- a/soccer/src/soccer/planning/planner_node.hpp
+++ b/soccer/src/soccer/planning/planner_node.hpp
@@ -36,6 +36,7 @@ public:
         std::lock_guard lock(lock_);
         return robot_trajectories_;
     }
+    // TODO: add "copy()" function here
 
     void put(int robot_id, std::shared_ptr<const Trajectory> trajectory, int priority) {
         // associate a (Trajectory, priority) tuple with a robot id
@@ -263,8 +264,8 @@ private:
         ServerTaskState(const ServerTaskState&& state) = delete;
         ServerTaskState& operator=(const ServerTaskState&& state) = delete;
 
-        std::atomic_bool is_executing{false};
-        std::atomic_bool new_task_waiting_signal{false};
+        volatile std::atomic_bool is_executing{false};
+        volatile std::atomic_bool new_task_waiting_signal{false};
     };
 
     // create an array, kNumShells long, of ServerTaskState structs for

--- a/soccer/src/soccer/planning/trajectory.cpp
+++ b/soccer/src/soccer/planning/trajectory.cpp
@@ -187,7 +187,7 @@ Trajectory::Cursor Trajectory::cursor(RJ::Time start_time) const {
     return Cursor{*this, start_time};
 }
 
-Trajectory::Cursor Trajectory::cursor_begin() const { return Cursor{*this, instants_.begin()}; }
+Trajectory::Cursor Trajectory::cursor_begin() const { return Cursor{*this, instants_begin()}; }
 
 void Trajectory::draw(DebugDrawer* drawer,
                       std::optional<rj_geometry::Point> alt_text_position) const {

--- a/soccer/src/soccer/planning/trajectory.hpp
+++ b/soccer/src/soccer/planning/trajectory.hpp
@@ -210,20 +210,20 @@ public:
     /**
      * @copydoc Trajectory::instants_end()
      */
-    [[nodiscard]] auto instants_begin() { 
+    [[nodiscard]] auto instants_begin() {
         if (instants_.empty() || instants_.begin() == instants_.end()) {
             throw std::runtime_error("instants_ is empty, this cannot work!");
         }
-        return instants_.begin(); 
+        return instants_.begin();
     }
     /**
      * @copydoc Trajectory::instants_end()
      */
-    [[nodiscard]] auto instants_begin() const { 
+    [[nodiscard]] auto instants_begin() const {
         if (instants_.empty() || instants_.begin() == instants_.end()) {
             throw std::runtime_error("instants_ is empty, this cannot work!");
         }
-        return instants_.cbegin(); 
+        return instants_.cbegin();
     }
 
     /**

--- a/soccer/src/soccer/planning/trajectory.hpp
+++ b/soccer/src/soccer/planning/trajectory.hpp
@@ -7,6 +7,7 @@
 #include "debug_drawer.hpp"
 #include "instant.hpp"
 #include "planning/dynamic_obstacle.hpp"
+#include "spdlog/spdlog.h"
 
 namespace planning {
 
@@ -205,15 +206,25 @@ public:
     /**
      * @copydoc Trajectory::instants_end()
      */
-    [[nodiscard]] auto instants_end() const { return instants_.end(); }
+    [[nodiscard]] auto instants_end() const { return instants_.cend(); }
     /**
      * @copydoc Trajectory::instants_end()
      */
-    [[nodiscard]] auto instants_begin() { return instants_.begin(); }
+    [[nodiscard]] auto instants_begin() { 
+        if (instants_.empty() || instants_.begin() == instants_.end()) {
+            throw std::runtime_error("instants_ is empty, this cannot work!");
+        }
+        return instants_.begin(); 
+    }
     /**
      * @copydoc Trajectory::instants_end()
      */
-    [[nodiscard]] auto instants_begin() const { return instants_.begin(); }
+    [[nodiscard]] auto instants_begin() const { 
+        if (instants_.empty() || instants_.begin() == instants_.end()) {
+            throw std::runtime_error("instants_ is empty, this cannot work!");
+        }
+        return instants_.cbegin(); 
+    }
 
     /**
      * @brief Check if this is an empty path.

--- a/soccer/src/soccer/planning/trajectory_collection.cpp
+++ b/soccer/src/soccer/planning/trajectory_collection.cpp
@@ -1,0 +1,23 @@
+#include "planning/trajectory_collection.hpp"
+
+namespace planning {
+
+std::array<Entry, kNumShells> TrajectoryCollection::get() {
+    std::lock_guard lock(lock_);
+    return robot_trajectories_;
+}
+
+Entry TrajectoryCollection::get(int robot_id) {
+    std::lock_guard(entry_locks.at(robot_id));
+    // TODO: return the whole tuple?
+    return robot_trajectories_.at(robot_id);
+}
+// TODO: add "copy()" function here
+
+void TrajectoryCollection::put(int robot_id, std::shared_ptr<const Trajectory> trajectory, int priority) {
+    // associate a (Trajectory, priority) tuple with a robot id
+    std::lock_guard lock(entry_locks.at(robot_id));
+    robot_trajectories_.at(robot_id) = std::make_tuple(std::move(trajectory), priority);
+}
+
+}

--- a/soccer/src/soccer/planning/trajectory_collection.cpp
+++ b/soccer/src/soccer/planning/trajectory_collection.cpp
@@ -14,10 +14,11 @@ Entry TrajectoryCollection::get(int robot_id) {
 }
 // TODO: add "copy()" function here
 
-void TrajectoryCollection::put(int robot_id, std::shared_ptr<const Trajectory> trajectory, int priority) {
+void TrajectoryCollection::put(int robot_id, std::shared_ptr<const Trajectory> trajectory,
+                               int priority) {
     // associate a (Trajectory, priority) tuple with a robot id
     std::lock_guard lock(entry_locks.at(robot_id));
     robot_trajectories_.at(robot_id) = std::make_tuple(std::move(trajectory), priority);
 }
 
-}
+}  // namespace planning

--- a/soccer/src/soccer/planning/trajectory_collection.hpp
+++ b/soccer/src/soccer/planning/trajectory_collection.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "trajectory.hpp"
+#include "rj_constants/constants.hpp"
+
+namespace planning {
+
+// Per-robot (trajectory, priority)
+using Entry = std::tuple<std::shared_ptr<const Trajectory>, int>;
+
+/**
+ * A collection of per-robot trajectories.
+ */
+class TrajectoryCollection {
+public:
+    std::array<Entry, kNumShells> get();
+
+    Entry get(int robot_id);
+
+    void put(int robot_id, std::shared_ptr<const Trajectory> trajectory, int priority);
+
+private:
+    std::mutex lock_;
+    std::array<std::mutex, kNumShells> entry_locks;
+    std::array<Entry, kNumShells> robot_trajectories_ = {};
+};
+
+}

--- a/soccer/src/soccer/planning/trajectory_collection.hpp
+++ b/soccer/src/soccer/planning/trajectory_collection.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "trajectory.hpp"
 #include "rj_constants/constants.hpp"
+#include "trajectory.hpp"
 
 namespace planning {
 
@@ -25,4 +25,4 @@ private:
     std::array<Entry, kNumShells> robot_trajectories_ = {};
 };
 
-}
+}  // namespace planning

--- a/soccer/src/soccer/planning/trajectory_collection.hpp
+++ b/soccer/src/soccer/planning/trajectory_collection.hpp
@@ -10,6 +10,7 @@ using Entry = std::tuple<std::shared_ptr<const Trajectory>, int>;
 
 /**
  * A collection of per-robot trajectories.
+// TODO (PR #1970): fix TrajectoryCollection
  */
 class TrajectoryCollection {
 public:

--- a/soccer/src/soccer/planning/trajectory_utils.cpp
+++ b/soccer/src/soccer/planning/trajectory_utils.cpp
@@ -130,7 +130,8 @@ bool trajectory_hits_dynamic(const Trajectory& trajectory,
                     // obstacle (from the check above), so this is definitely the
                     // earliest one.
                     if (out_hit_obstacle != nullptr) {
-                        *out_hit_obstacle = rj_geometry::Circle(obstacle_position, obs.circle.radius());
+                        *out_hit_obstacle =
+                            rj_geometry::Circle(obstacle_position, obs.circle.radius());
                     }
                     maybe_hit_time = cursor.time();
                 }
@@ -138,7 +139,6 @@ bool trajectory_hits_dynamic(const Trajectory& trajectory,
         }
     } catch (...) {
         SPDLOG_ERROR("exception caught !!!");
-
     }
 
     if (maybe_hit_time.has_value() && out_hit_time != nullptr) {

--- a/soccer/src/soccer/planning/trajectory_utils.cpp
+++ b/soccer/src/soccer/planning/trajectory_utils.cpp
@@ -97,6 +97,9 @@ bool trajectory_hits_dynamic(const Trajectory& trajectory,
             throw std::runtime_error("Empty trajectory in dynamic obstacle");
         }
 
+        // TODO: REMOVE THIS
+        obs.path->cursor_begin();
+
         cursor.seek(start_time);
 
         // Inflate obstacles by our robot's radius.

--- a/soccer/src/soccer/planning/trajectory_utils.cpp
+++ b/soccer/src/soccer/planning/trajectory_utils.cpp
@@ -92,48 +92,53 @@ bool trajectory_hits_dynamic(const Trajectory& trajectory,
     // hit the obstacle that happened to be first in the list.
     std::optional<RJ::Time> maybe_hit_time = std::nullopt;
 
-    for (const DynamicObstacle& obs : obstacles) {
-        if (obs.path->empty()) {
-            throw std::runtime_error("Empty trajectory in dynamic obstacle");
-        }
-
-        // TODO: REMOVE THIS
-        obs.path->cursor_begin();
-
-        cursor.seek(start_time);
-
-        // Inflate obstacles by our robot's radius.
-        const double total_radius = obs.circle.radius() + kRobotRadius;
-
-        // Only use the trajectory cursor in the loop condition; we use the
-        // static position after the obstacle cursor runs off the end.
-        for (auto cursor_obstacle = obs.path->cursor_begin(); cursor.has_value();
-             cursor_obstacle.advance(dt), cursor.advance(dt)) {
-            // If the earlier calculated hit was before this point, stop looking
-            // at this obstacle.
-            if (maybe_hit_time.has_value() && maybe_hit_time.value() < cursor.time()) {
-                break;
+    try {
+        for (const DynamicObstacle& obs : obstacles) {
+            if (obs.path->empty()) {
+                throw std::runtime_error("Empty trajectory in dynamic obstacle");
             }
 
-            rj_geometry::Point obstacle_position;
-            if (cursor_obstacle.has_value()) {
-                obstacle_position = cursor_obstacle.value().position();
-            } else {
-                obstacle_position = obs.path->last().position();
-            }
+            // TODO: REMOVE THIS
+            obs.path->cursor_begin();
 
-            rj_geometry::Point robot_position = cursor.value().position();
+            cursor.seek(start_time);
 
-            if (robot_position.dist_to(obstacle_position) < total_radius) {
-                // We would already have broken out if we had an earlier
-                // obstacle (from the check above), so this is definitely the
-                // earliest one.
-                if (out_hit_obstacle != nullptr) {
-                    *out_hit_obstacle = rj_geometry::Circle(obstacle_position, obs.circle.radius());
+            // Inflate obstacles by our robot's radius.
+            const double total_radius = obs.circle.radius() + kRobotRadius;
+
+            // Only use the trajectory cursor in the loop condition; we use the
+            // static position after the obstacle cursor runs off the end.
+            for (auto cursor_obstacle = obs.path->cursor_begin(); cursor.has_value();
+                 cursor_obstacle.advance(dt), cursor.advance(dt)) {
+                // If the earlier calculated hit was before this point, stop looking
+                // at this obstacle.
+                if (maybe_hit_time.has_value() && maybe_hit_time.value() < cursor.time()) {
+                    break;
                 }
-                maybe_hit_time = cursor.time();
+
+                rj_geometry::Point obstacle_position;
+                if (cursor_obstacle.has_value()) {
+                    obstacle_position = cursor_obstacle.value().position();
+                } else {
+                    obstacle_position = obs.path->last().position();
+                }
+
+                rj_geometry::Point robot_position = cursor.value().position();
+
+                if (robot_position.dist_to(obstacle_position) < total_radius) {
+                    // We would already have broken out if we had an earlier
+                    // obstacle (from the check above), so this is definitely the
+                    // earliest one.
+                    if (out_hit_obstacle != nullptr) {
+                        *out_hit_obstacle = rj_geometry::Circle(obstacle_position, obs.circle.radius());
+                    }
+                    maybe_hit_time = cursor.time();
+                }
             }
         }
+    } catch (...) {
+        SPDLOG_ERROR("exception caught !!!");
+
     }
 
     if (maybe_hit_time.has_value() && out_hit_time != nullptr) {

--- a/soccer/src/soccer/planning/trajectory_utils.hpp
+++ b/soccer/src/soccer/planning/trajectory_utils.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "trajectory.hpp"
 #include <spdlog/spdlog.h>
+
+#include "trajectory.hpp"
 
 namespace planning {
 

--- a/soccer/src/soccer/planning/trajectory_utils.hpp
+++ b/soccer/src/soccer/planning/trajectory_utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "trajectory.hpp"
+#include <spdlog/spdlog.h>
 
 namespace planning {
 


### PR DESCRIPTION
## Description
Fixes the planner node race condition by disabling use of the shared TrajectoryCollection object. (This is clearly not the best way to go about it, since now we don't account for our own planned trajectories when we plan new motion paths.)

For now, since my other PR #1953 relies on this and is blocking everything else, I am inclined to merge it (then merge #1953). Future steps include:
 * add our robots as dynamic obstacles (like we do for the opponent robots) to mitigate self-crashes
 * actually fix TrajectoryCollection instead of disabling it like I did

Some useful tips for actually fixing it:
1) run lldb on the planner node to get a backtrace like this:
```
(terminal 1) ros2 run rj_robocup planner_node
(terminal 2) sudo lldb-10 -n planner_node
(terminal 3) make run-sim
```
This order allows the debugger to catch the planner node crashing before the whole system launches.

2) the crash seemed to occur on the `robot_trajectories_->put(...)` call, not the `->get(...)` call

3) for some reason the mutex stuff tried in `trajectory_collection.hpp` did not fix this crash, unclear why

## Associated / Resolved Issue
Fixes crashing in #1953 which stops that from blocking everything else.

## Design Documents
[Link](link-to-design-doc)

## Steps to Test
### Test Case 1
1. Run sim 

**Expected result:** no crash

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack