### PR TITLE
Link Sim and Framework and add to Makefile

### DIFF
--- a/launch/framework.bash
+++ b/launch/framework.bash
@@ -1,2 +1,2 @@
 echo "launching ER-Force framework and our UI"
-(trap 'kill 0' SIGINT; find ~ -name 'simulator-cli' -type f -exec '{}' -g 2020B ';' & make run-sim & wait)
+(trap 'kill 0' SIGINT; find ~ -name 'simulator-cli' -type f -exec '{}' -g 2020B ';' & make run-sim-only & wait)

--- a/launch/framework.bash
+++ b/launch/framework.bash
@@ -1,0 +1,2 @@
+echo "launching ER-Force framework and our UI"
+~/framework/build/bin/simulator-cli & make run-sim

--- a/launch/framework.bash
+++ b/launch/framework.bash
@@ -1,2 +1,2 @@
 echo "launching ER-Force framework and our UI"
-~/framework/build/bin/simulator-cli & make run-sim
+(trap 'kill 0' SIGINT; find ~ -name 'simulator-cli' -type f -exec '{}' -g 2020B ';' & make run-sim & wait)

--- a/launch/framework.bash
+++ b/launch/framework.bash
@@ -1,2 +1,11 @@
+#!/bin/bash
+# this script launches the ER-force framework and our simulator UI simultaneously and allows you to kill both at once using ctrl-c
+# you may need to press ctrl-c twice
 echo "launching ER-Force framework and our UI"
+# in a subshell: 
+# first trap SIGINT to kill the entire subshell
+# then find the location of simulator-cli in the home directory and run it with args -g 2020B (in background)
+# then run sim through makefile shortcut (in background)
+# finally wait, so that the simulator-cli process isn't lost/disowned when run-sim-only dies before it does.
 (trap 'kill 0' SIGINT; find ~ -name 'simulator-cli' -type f -exec '{}' -g 2020B ';' & make run-sim-only & wait)
+

--- a/launch/framework.bash
+++ b/launch/framework.bash
@@ -7,5 +7,5 @@ echo "launching ER-Force framework and our UI"
 # then find the location of simulator-cli in the home directory and run it with args -g 2020B (in background)
 # then run sim through makefile shortcut (in background)
 # finally wait, so that the simulator-cli process isn't lost/disowned when run-sim-only dies before it does.
-(trap 'kill 0' SIGINT; find ~ -name 'simulator-cli' -type f -exec '{}' -g 2020B ';' & make run-sim-only & wait)
+(trap 'kill 0' SIGINT; find ~ -name 'simulator-cli' -type f -exec '{}' -g 2020B ';' & make run-our-stack & wait)
 

--- a/makefile
+++ b/makefile
@@ -65,8 +65,12 @@ again:
 run-soccer:
 	ros2 launch rj_robocup soccer.launch.py
 
-# run sim with default flags
+# run framework and sim simultaneously (via bash script)
 run-sim:
+	./launch/framework.bash
+
+# run sim with default flags
+run-sim-only:
 	ros2 launch rj_robocup soccer.launch.py run_sim:=True
 
 # run sim with external referee (SSL Game Controller)

--- a/makefile
+++ b/makefile
@@ -62,15 +62,16 @@ again:
 # run soccer with default flags
 # TODO: lots of the default flags are for sim, except run_sim
 # fix this so defaults launch sim, with special cases for real
-run-soccer:
-	ros2 launch rj_robocup soccer.launch.py
+# run-soccer:
+# 	ros2 launch rj_robocup soccer.launch.py
 
-# run framework and sim simultaneously (via bash script)
+# run ER-Force's framework and our stack simultaneously (via bash script)
 run-sim:
 	./launch/framework.bash
 
-# run sim with default flags
-run-sim-only:
+# run our stack with default flags
+# TODO: actually name our software stack something
+run-our-stack:
 	ros2 launch rj_robocup soccer.launch.py run_sim:=True
 
 # run sim with external referee (SSL Game Controller)


### PR DESCRIPTION
## Description
This PR creates a bash script to run framework (assuming simulator-cli is built and somewhere in the home directory) and the simulation with the same parent process, so they are killed at the same time. This is to limit instances of framework running on the same network. 

## Associated / Resolved Issue
[ClickUp card](https://app.clickup.com/t/384g763)

## Design Documents

## Steps to Test
### Test Case 1
1. `cd robocup-software && . source.bash`
2. `make run-sim`
3. Let sim open, then press ctrl-c twice in the shell.

**Expected result:**
When the sim runs, framework automatically runs in the background. You should see six robots on the sim field. When ctrl-c is pressed, first the sim is killed and then the framework is killed. `ps -a` should show no sim or framework related processes left

## Key Files to Review
 * launch/framework.bash
 * makefile


## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack

