### PR TITLE
New goalie idle task

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -76,7 +76,8 @@ more information).
 
 .. code-block:: bash
 
-    git pull git checkout ros2
+    git pull 
+    git checkout ros2
 
 Then, source the ROS setup file. This allows your shell to use ROS commands.
 
@@ -143,10 +144,15 @@ terminal, you can launch sim with:
 
 .. code-block:: bash
 
-   . ./source.bash make run-sim
+   . ./source.bash 
+   make run-sim
 
 ``source.bash`` is an alias for the two source commands you saw above, and
-``make run-sim`` is an alias for ``ros2 launch rj_robocup sim.launch.py``.
+``make run-sim`` will launch both ER-Force's Framework (the physics simulator)
+and our stack (``ros2 launch rj_robocup sim.launch.py``). 
+
+To stop this process (like any other) press CTRL-C in the command line. You may
+have to press CTRL-C twice.
 
 Since Python is not compiled, if you're exclusively working on Python files, and
 staying in one terminal, it's likely that you'll mostly only need:
@@ -162,7 +168,8 @@ machine, though, you can build again more quickly with:
 
 .. code-block:: bash
 
-   make again . ./source.bash
+   make again 
+   . ./source.bash
 
 The ``source.bash`` line is necessary to source the file in ``install/``, which
 is refreshed on each build. (**Note:** this does not build any CMake-related
@@ -173,9 +180,10 @@ details, but in short:
 
 .. code-block:: bash
 
-   make all         # builds with full debugging symbols make debug       #
-   alias for make all make all-release # builds with 0 debugging symbols make
-   perf        # builds with some debugging symbols; preferred method
+   make all         # builds with full debugging symbols 
+   make debug       # alias for make all 
+   make all-release # builds with 0 debugging symbols 
+   make perf        # builds with some debugging symbols; preferred method
 
 TODO(Kevin): add description of running on field comp (move that md file over
 too)

--- a/rj_msgs/CMakeLists.txt
+++ b/rj_msgs/CMakeLists.txt
@@ -40,6 +40,7 @@ rosidl_generate_interfaces(
 
   msg/LinearMotionInstant.msg
   msg/EmptyMotionCommand.msg
+  msg/GoalieIdleMotionCommand.msg
   msg/PathTargetMotionCommand.msg
   msg/WorldVelMotionCommand.msg
   msg/PivotMotionCommand.msg

--- a/rj_msgs/msg/MotionCommand.msg
+++ b/rj_msgs/msg/MotionCommand.msg
@@ -6,3 +6,4 @@ SettleMotionCommand[<=1] settle_command
 CollectMotionCommand[<=1] collect_command
 LineKickMotionCommand[<=1] line_kick_command
 InterceptMotionCommand[<=1] intercept_command
+GoalieIdleMotionCommand[<=1] goalie_idle_command

--- a/soccer/src/soccer/CMakeLists.txt
+++ b/soccer/src/soccer/CMakeLists.txt
@@ -39,6 +39,7 @@ set(ROBOCUP_LIB_SRC
     planning/planner/pivot_path_planner.cpp
     planning/planner/plan_request.cpp
     planning/planner/settle_planner.cpp
+    planning/planner/goalie_idle_planner.cpp
     planning/planner_node.cpp
     planning/trajectory.cpp
     planning/trajectory_utils.cpp

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
@@ -3,8 +3,62 @@
 namespace planning {
 
 Trajectory GoalieIdlePlanner::plan(const PlanRequest& plan_request) {
-    Trajectory temp_trajectory;
-    return temp_trajectory;
+    // lots of this is duplicated from PathTargetPlanner, because there's not
+    // an easy way to convert from one PlanRequest to another
+
+    // Collect obstacles
+    rj_geometry::ShapeSet static_obstacles;
+    std::vector<DynamicObstacle> dynamic_obstacles;
+    Trajectory ball_trajectory;
+    bool ignore_ball = true;
+    fill_obstacles(plan_request, &static_obstacles, &dynamic_obstacles, ignore_ball,
+                   &ball_trajectory);
+
+    // If we start inside of an obstacle, give up and let another planner take
+    // care of it.
+    if (static_obstacles.hit(plan_request.start.position())) {
+        reset();
+        return Trajectory();
+    }
+
+    // Create a new PathTargetCommand to fill in with desired idle_pt
+    auto command = PathTargetCommand{};
+    auto idle_pt = get_idle_pt(plan_request.world_state);
+    command.goal.position = idle_pt;
+
+    // Make robot face ball
+    auto angle_function = AngleFns::face_point(plan_request.world_state->ball.position);
+
+    // call Replanner to generate a Trajectory
+    Trajectory trajectory = Replanner::create_plan(
+        Replanner::PlanParams{plan_request.start, command.goal, static_obstacles, dynamic_obstacles,
+                              plan_request.constraints, angle_function, RJ::Seconds(3.0)},
+        std::move(previous_));
+
+    // Debug drawing
+    if (plan_request.debug_drawer != nullptr) {
+        plan_request.debug_drawer->draw_circle(
+            rj_geometry::Circle(command.goal.position, static_cast<float>(draw_radius)),
+            draw_color);
+    }
+
+    // Cache current Trajectory, return
+    previous_ = trajectory;
+    return trajectory;
+}
+
+rj_geometry::Point GoalieIdlePlanner::get_idle_pt(const WorldState* world_state) const {
+    rj_geometry::Point ball_pos = world_state->ball.position;
+    // TODO: make this depend on team +/-x
+    rj_geometry::Point goal_pt{0.0, 0.0};
+
+    // TODO: move closer/farther from ball as a linear % of distance from ball
+    double goalie_dist = 0.5;
+    rj_geometry::Point idle_pt = (ball_pos - goal_pt).norm();
+    idle_pt *= goalie_dist;
+    // TODO: clamp y to 0
+
+    return idle_pt;
 }
 
 void GoalieIdlePlanner::reset() {}

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
@@ -47,16 +47,15 @@ Trajectory GoalieIdlePlanner::plan(const PlanRequest& plan_request) {
     return trajectory;
 }
 
-rj_geometry::Point GoalieIdlePlanner::get_idle_pt(const WorldState* world_state) const {
+rj_geometry::Point GoalieIdlePlanner::get_idle_pt(const WorldState* world_state) {
     rj_geometry::Point ball_pos = world_state->ball.position;
-    // TODO: make this depend on team +/-x
+    // TODO(Kevin): make this depend on team +/-x
     rj_geometry::Point goal_pt{0.0, 0.0};
 
-    // TODO: move closer/farther from ball as a linear % of distance from ball
     double goalie_dist = 0.5;
     rj_geometry::Point idle_pt = (ball_pos - goal_pt).norm();
     idle_pt *= goalie_dist;
-    // TODO: clamp y to 0
+    // TODO(Kevin): clamp y to 0 so goalie doesn't go backwards
 
     return idle_pt;
 }

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
@@ -1,0 +1,14 @@
+#include "planning/planner/goalie_idle_planner.hpp"
+
+namespace planning {
+
+Trajectory GoalieIdlePlanner::plan(const PlanRequest& plan_request) {
+    Trajectory temp_trajectory;
+    return temp_trajectory;
+}
+
+void GoalieIdlePlanner::reset() {}
+
+bool GoalieIdlePlanner::is_done() const { return false; }
+
+}  // namespace planning

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
+#include <spdlog/spdlog.h>
+
 #include "planning/instant.hpp"
+#include "planning/planner/path_target_planner.hpp"
 #include "planning/planner/planner.hpp"
 #include "planning/primitives/replanner.hpp"
 #include "planning/trajectory.hpp"
 #include "rj_geometry/point.hpp"
+/* #include <rj_msgs/msg/path_target_motion_command.hpp> */
+#include "planning/planner/motion_command.hpp"
+#include "planning/primitives/angle_planning.hpp"
 
 namespace planning {
 /**
@@ -17,10 +23,20 @@ public:
 
     Trajectory plan(const PlanRequest& plan_request) override;
 
+    /*
+     * @return Point for Goalie to stand in when no shot is coming. Expects
+     * ball to be slow.
+     */
+    rj_geometry::Point get_idle_pt(const WorldState* world_state) const;
+
     void reset() override;
     [[nodiscard]] bool is_done() const override;
 
+    double draw_radius = kRobotRadius;
+    QColor draw_color = Qt::black;
+
 private:
+    Trajectory previous_{};
 };
 
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
@@ -21,16 +21,18 @@ class GoalieIdlePlanner : public PlannerForCommandType<GoalieIdleCommand> {
 public:
     GoalieIdlePlanner() : PlannerForCommandType<GoalieIdleCommand>("goalie_idle") {}
 
+    /*
+     * From Planner superclass (see planner.hpp).
+     */
     Trajectory plan(const PlanRequest& plan_request) override;
+    void reset() override;
+    [[nodiscard]] bool is_done() const override;
 
     /*
      * @return Point for Goalie to stand in when no shot is coming. Expects
      * ball to be slow.
      */
-    rj_geometry::Point get_idle_pt(const WorldState* world_state) const;
-
-    void reset() override;
-    [[nodiscard]] bool is_done() const override;
+    static rj_geometry::Point get_idle_pt(const WorldState* world_state);
 
     double draw_radius = kRobotRadius;
     QColor draw_color = Qt::black;

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "planning/instant.hpp"
+#include "planning/planner/planner.hpp"
+#include "planning/primitives/replanner.hpp"
+#include "planning/trajectory.hpp"
+#include "rj_geometry/point.hpp"
+
+namespace planning {
+/**
+ * @brief This planner gives the goalie a way to track the ball when it's not
+ * otherwise occupied.
+ */
+class GoalieIdlePlanner : public PlannerForCommandType<GoalieIdleCommand> {
+public:
+    GoalieIdlePlanner() : PlannerForCommandType<GoalieIdleCommand>("goalie_idle") {}
+
+    Trajectory plan(const PlanRequest& plan_request) override;
+
+    void reset() override;
+    [[nodiscard]] bool is_done() const override;
+
+private:
+};
+
+}  // namespace planning

--- a/soccer/src/soccer/planning/planner/motion_command.hpp
+++ b/soccer/src/soccer/planning/planner/motion_command.hpp
@@ -44,8 +44,7 @@ struct TargetFacePoint {
     rj_geometry::Point face_point;
 };
 
-using AngleOverride =
-    std::variant<TargetFaceTangent, TargetFaceAngle, TargetFacePoint>;
+using AngleOverride = std::variant<TargetFaceTangent, TargetFaceAngle, TargetFacePoint>;
 /**
  * Move to a particular target with a particular velocity, avoiding obstacles.
  */
@@ -227,6 +226,8 @@ ASSOCIATE_CPP_ROS(planning::CollectCommand, rj_msgs::msg::CollectMotionCommand);
 
 template <>
 struct RosConverter<planning::GoalieIdleCommand, rj_msgs::msg::GoalieIdleMotionCommand> {
+    // clang-format is disagreeing with itself here, so I disabled it for this block
+    // clang-format off
     static rj_msgs::msg::GoalieIdleMotionCommand to_ros(
         [[maybe_unused]] const planning::GoalieIdleCommand& from) {
         return rj_msgs::build<rj_msgs::msg::GoalieIdleMotionCommand>();
@@ -236,6 +237,7 @@ struct RosConverter<planning::GoalieIdleCommand, rj_msgs::msg::GoalieIdleMotionC
         [[maybe_unused]] const rj_msgs::msg::GoalieIdleMotionCommand& from) {
         return planning::GoalieIdleCommand{};
     }
+    // clang-format on
 };
 
 ASSOCIATE_CPP_ROS(planning::GoalieIdleCommand, rj_msgs::msg::GoalieIdleMotionCommand);

--- a/soccer/src/soccer/planning/planner/motion_command.hpp
+++ b/soccer/src/soccer/planning/planner/motion_command.hpp
@@ -50,7 +50,7 @@ using AngleOverride =
  * Move to a particular target with a particular velocity, avoiding obstacles.
  */
 struct PathTargetCommand {
-    LinearMotionInstant goal;
+    LinearMotionInstant goal{};
     AngleOverride angle_override = TargetFaceTangent{};
     bool ignore_ball = false;
 

--- a/soccer/src/soccer/planning/planner/motion_command.hpp
+++ b/soccer/src/soccer/planning/planner/motion_command.hpp
@@ -8,6 +8,7 @@
 #include <rj_geometry/pose.hpp>
 #include <rj_msgs/msg/collect_motion_command.hpp>
 #include <rj_msgs/msg/empty_motion_command.hpp>
+#include <rj_msgs/msg/goalie_idle_motion_command.hpp>
 #include <rj_msgs/msg/intercept_motion_command.hpp>
 #include <rj_msgs/msg/line_kick_motion_command.hpp>
 #include <rj_msgs/msg/linear_motion_instant.hpp>
@@ -91,10 +92,14 @@ struct InterceptCommand {
     rj_geometry::Point target;
 };
 
+/*
+ * Make the Goalie track the ball when not saving shots.
+ */
+struct GoalieIdleCommand {};
+
 using MotionCommand =
-    std::variant<EmptyCommand, PathTargetCommand, WorldVelCommand, PivotCommand,
-                 SettleCommand, CollectCommand, LineKickCommand,
-                 InterceptCommand>;
+    std::variant<EmptyCommand, PathTargetCommand, WorldVelCommand, PivotCommand, SettleCommand,
+                 CollectCommand, LineKickCommand, InterceptCommand, GoalieIdleCommand>;
 
 }  // namespace planning
 
@@ -221,6 +226,21 @@ struct RosConverter<planning::CollectCommand, rj_msgs::msg::CollectMotionCommand
 ASSOCIATE_CPP_ROS(planning::CollectCommand, rj_msgs::msg::CollectMotionCommand);
 
 template <>
+struct RosConverter<planning::GoalieIdleCommand, rj_msgs::msg::GoalieIdleMotionCommand> {
+    static rj_msgs::msg::GoalieIdleMotionCommand to_ros(
+        [[maybe_unused]] const planning::GoalieIdleCommand& from) {
+        return rj_msgs::build<rj_msgs::msg::GoalieIdleMotionCommand>();
+    }
+
+    static planning::GoalieIdleCommand from_ros(
+        [[maybe_unused]] const rj_msgs::msg::GoalieIdleMotionCommand& from) {
+        return planning::GoalieIdleCommand{};
+    }
+};
+
+ASSOCIATE_CPP_ROS(planning::GoalieIdleCommand, rj_msgs::msg::GoalieIdleMotionCommand);
+
+template <>
 struct RosConverter<planning::LineKickCommand, rj_msgs::msg::LineKickMotionCommand> {
     static rj_msgs::msg::LineKickMotionCommand to_ros([
         [maybe_unused]] const planning::LineKickCommand& from) {
@@ -255,6 +275,7 @@ ASSOCIATE_CPP_ROS(planning::InterceptCommand, rj_msgs::msg::InterceptMotionComma
 template <>
 struct RosConverter<planning::MotionCommand, rj_msgs::msg::MotionCommand> {
     static rj_msgs::msg::MotionCommand to_ros(const planning::MotionCommand& from) {
+        // TODO(Kevin): wtf is this
         rj_msgs::msg::MotionCommand result;
         if (const auto* empty = std::get_if<planning::EmptyCommand>(&from)) {
             result.empty_command.emplace_back(convert_to_ros(*empty));
@@ -272,6 +293,8 @@ struct RosConverter<planning::MotionCommand, rj_msgs::msg::MotionCommand> {
             result.line_kick_command.emplace_back(convert_to_ros(*line_kick));
         } else if (const auto* intercept = std::get_if<planning::InterceptCommand>(&from)) {
             result.intercept_command.emplace_back(convert_to_ros(*intercept));
+        } else if (const auto* goalie_idle = std::get_if<planning::GoalieIdleCommand>(&from)) {
+            result.goalie_idle_command.emplace_back(convert_to_ros(*goalie_idle));
         } else {
             throw std::runtime_error("Invalid variant of MotionCommand");
         }
@@ -296,6 +319,8 @@ struct RosConverter<planning::MotionCommand, rj_msgs::msg::MotionCommand> {
             result = convert_from_ros(from.line_kick_command.front());
         } else if (!from.intercept_command.empty()) {
             result = convert_from_ros(from.intercept_command.front());
+        } else if (!from.goalie_idle_command.empty()) {
+            result = convert_from_ros(from.goalie_idle_command.front());
         } else {
             throw std::runtime_error("Invalid variant of MotionCommand");
         }

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -8,6 +8,7 @@
 #include "instant.hpp"
 #include "planning/planner/collect_planner.hpp"
 #include "planning/planner/escape_obstacles_path_planner.hpp"
+#include "planning/planner/goalie_idle_planner.hpp"
 #include "planning/planner/line_kick_planner.hpp"
 #include "planning/planner/path_target_planner.hpp"
 #include "planning/planner/pivot_path_planner.hpp"
@@ -150,6 +151,7 @@ PlannerForRobot::PlannerForRobot(int robot_id, rclcpp::Node* node,
       debug_draw_{
           node->create_publisher<rj_drawing_msgs::msg::DebugDraw>(viz::topics::kDebugDrawPub, 10),
           fmt::format("planning_{}", robot_id)} {
+    planners_.push_back(std::make_shared<GoalieIdlePlanner>());
     planners_.push_back(std::make_shared<PathTargetPlanner>());
     planners_.push_back(std::make_shared<SettlePlanner>());
     planners_.push_back(std::make_shared<CollectPlanner>());

--- a/soccer/src/soccer/planning/tests/conversion_tests.cpp
+++ b/soccer/src/soccer/planning/tests/conversion_tests.cpp
@@ -49,6 +49,10 @@ bool operator==(const Trajectory& a, const Trajectory& b) {
     return a.instants() == b.instants() && a.time_created() == b.time_created() &&
            a.angles_valid() == b.angles_valid();
 }
+bool operator==([[maybe_unused]] const GoalieIdleCommand& a,
+                [[maybe_unused]] const GoalieIdleCommand& b) {
+    return true;
+}
 
 namespace testing {
 
@@ -79,6 +83,9 @@ TEST(RosConversions, SettleCommand) {
 
 // NOLINTNEXTLINE
 TEST(RosConversions, CollectCommand) { test_lossless_convert_cpp_value(CollectCommand{}); }
+
+// NOLINTNEXTLINE
+TEST(RosConversions, GoalieIdleCommand) { test_lossless_convert_cpp_value(GoalieIdleCommand{}); }
 
 // NOLINTNEXTLINE
 TEST(RosConversions, LineKickCommand) {

--- a/soccer/src/soccer/robot_intent.hpp
+++ b/soccer/src/soccer/robot_intent.hpp
@@ -37,7 +37,8 @@ struct RobotIntent {
         if (std::holds_alternative<planning::PathTargetCommand>(motion_command)) {
             return std::get<planning::PathTargetCommand>(motion_command) ==
                    std::get<planning::PathTargetCommand>(r.motion_command);
-        } else if (std::holds_alternative<planning::GoalieIdleCommand>(motion_command)) {
+        }
+        if (std::holds_alternative<planning::GoalieIdleCommand>(motion_command)) {
             // if both are GoalieIdleCommands, they are equal (takes no fields)
             return std::holds_alternative<planning::GoalieIdleCommand>(r.motion_command);
         }

--- a/soccer/src/soccer/robot_intent.hpp
+++ b/soccer/src/soccer/robot_intent.hpp
@@ -37,9 +37,13 @@ struct RobotIntent {
         if (std::holds_alternative<planning::PathTargetCommand>(motion_command)) {
             return std::get<planning::PathTargetCommand>(motion_command) ==
                    std::get<planning::PathTargetCommand>(r.motion_command);
+        } else if (std::holds_alternative<planning::GoalieIdleCommand>(motion_command)) {
+            // if both are GoalieIdleCommands, they are equal (takes no fields)
+            return std::holds_alternative<planning::GoalieIdleCommand>(r.motion_command);
         }
-        // TODO(Kevin): fill in other motion command types (and maybe think of a
-        // better design?)
+
+        // TODO(Kevin): redesign this, there are too many equality checks
+        // needed in current state
 
         // default to address equality
         return this == &r;

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -64,6 +64,7 @@ void AgentActionClient::get_task() {
 
     auto task = current_position_->get_task();
     if (task != last_task_) {
+        /* SPDLOG_INFO("sending new task"); */
         last_task_ = task;
         send_new_goal();
     }

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -15,6 +15,16 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
         return get_empty_intent();
     }
 
+    // send idle command a few times in case it doesn't get picked up on init
+    if (send_idle_ct_ < 5) {
+        auto goalie_idle = rj_msgs::msg::GoalieIdleMotionCommand{};
+        intent.motion_command.goalie_idle_command = {goalie_idle};
+
+        send_idle_ct_++;
+        return intent;
+    }
+
+    /*
     if (check_is_done()) {
         move_ct++;
     }
@@ -40,6 +50,7 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
     // (waiting on field pts to be given to world_state)
 
     return intent;
+    */
 }
 
 rj_geometry::Point Goalie::get_block_pt(WorldState* world_state) const {

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -51,7 +51,7 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
     return intent;
 }
 
-rj_geometry::Point Goalie::get_block_pt(WorldState* world_state, bool& needs_to_block) const {
+rj_geometry::Point Goalie::get_block_pt(WorldState* world_state, bool& needs_to_block) {
     // TODO: make intercept planner do what its header file does, so we don't need this
     // also, fix the intercept planner so we don't have to pass in the ball
     // point every tick
@@ -71,7 +71,7 @@ rj_geometry::Point Goalie::get_block_pt(WorldState* world_state, bool& needs_to_
     double cross_x = ball_pos.x() + ball_vel.x() * time_to_cross;
 
     // if shot is going out of goal, ignore it
-    if (std::abs(cross_x) > 0.6) {  // TODO: add field to world_state to avoid hardcoding
+    if (std::abs(cross_x) > 0.6) {  // TODO(Kevin): add field to world_state to avoid hardcoding
         needs_to_block = false;
         return rj_geometry::Point{-1, -1};  // intentionally invalid
     }

--- a/soccer/src/soccer/strategy/agent/position/goalie.hpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.hpp
@@ -38,7 +38,7 @@ private:
      *
      * Assumes ball is not slow.
      */
-    rj_geometry::Point get_block_pt(WorldState* world_state, bool& needs_to_block) const;
+    static rj_geometry::Point get_block_pt(WorldState* world_state, bool& needs_to_block);
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/goalie.hpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.hpp
@@ -8,6 +8,8 @@
 #include <rj_geometry/geometry_conversions.hpp>
 #include <rj_geometry/point.hpp>
 #include <rj_msgs/msg/empty_motion_command.hpp>
+#include <rj_msgs/msg/goalie_idle_motion_command.hpp>
+#include <rj_msgs/msg/path_target_motion_command.hpp>
 
 #include "position.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -28,19 +30,15 @@ public:
     rj_msgs::msg::RobotIntent get_task() override;
 
 private:
-    // temp to move back and forth
-    int move_ct = 0;
+    // temp
+    int send_idle_ct_ = 0;
 
     /*
-     * @return Point for Goalie to block a shot. Calls get_idle_pt() if ball is
-     * slow or shot will miss the goal.
+     * @return Point for Goalie to block a shot.
+     *
+     * Assumes ball is not slow.
      */
     rj_geometry::Point get_block_pt(WorldState* world_state) const;
-
-    /*
-     * @return Point for Goalie to stand in when no shot is coming. Expects
-     * ball to be slow.
-     */
     rj_geometry::Point get_idle_pt(WorldState* world_state) const;
 };
 

--- a/soccer/src/soccer/strategy/agent/position/goalie.hpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.hpp
@@ -38,8 +38,7 @@ private:
      *
      * Assumes ball is not slow.
      */
-    rj_geometry::Point get_block_pt(WorldState* world_state) const;
-    rj_geometry::Point get_idle_pt(WorldState* world_state) const;
+    rj_geometry::Point get_block_pt(WorldState* world_state, bool& needs_to_block) const;
 };
 
 }  // namespace strategy


### PR DESCRIPTION
## Description
Makes Goalie's idle behavior (what it does when not blocking shots) much smoother by turning it into a planner instead of repeated calls to PathTargetPlanner. 

Also exposes some key weaknesses of the current planning stack (see below).

## Associated / Resolved Issue
[ClickUp card](https://app.clickup.com/t/396mwu6)

## Steps to Test
### Test Case 1
1. Build, run sim.
2. Move ball around (slowly).
3. Take some shots on goal.
4. Compare with what is currently on `ros2`.

**Expected result:** Goalie should idle when ball is slow and intercept when ball is fast. The idle behavior, specifically, should look much cleaner than it does on `ros2`.

## Key Files to Review
short PR, all of them

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack

## Addendum: Planning Gripes

1. It's hard to add new planners (the changes made in `planning/tests/conversion_tests.cpp` are vital to get it to link properly, which is not intuitive at all)
2. Most tasks are just some extension of PathTargetPlanner, including this one, but since PathTargetPlanner is a templated class linked to PathTargetMotionCommand.msg, I can't use it in another planner very easily.
3. The [equality check](https://github.com/RoboJackets/robocup-software/pull/1980/files#diff-7a4b491bf7b4c369564c340fdcc53ef9ceb30d1668a41e4063ac34ee174704b4R67) in `agent_action_client.cpp` currently uses the built-in equality check autogenerated for `RobotIntent.msg`, which doesn't correctly handle the way we've formatted `MotionCommand.msg` as a series of 1-element arrays of different msg types. (`MotionCommand.msg` is a bit janky in and of itself for that reason, btw.) 
 * The workaround for this is to use `rj_convert::convert_from_ros(...)` to convert the msg to a struct (as defined in `robot_intent.hpp`, which will then use that struct's operator== overload. 

In my opinion, it would be nicer to separate the C++ struct and the ROS msg type,  rather than having both refer to the same thing. Something like a pure C++ TaskPlanner superclass, where the subclasses are other classes representing different task types (GoalieIdle, PathTarget, etc.) and can call each other. The superclass should then translate different task types to a single simple `PlanRequest.msg` which has just `robot_id`, `goal_instant`, `face_pt`, `ignore_ball`.

This would simplify our current PlannerNode to what we currently consider PathTargetPlanner, and increase the complexity of the strategy side to do some translation of semantic "tasks" into concrete motion planning requests before sending them to PlannerNode via ROS.
