### PR TITLE
Planning/strategy interface refactor

### DIFF
--- a/rj_geometry/include/rj_geometry/point.hpp
+++ b/rj_geometry/include/rj_geometry/point.hpp
@@ -7,6 +7,7 @@
 #include <Eigen/Dense>
 #include <QtCore/QPointF>
 #include <boost/functional/hash.hpp>
+#include <spdlog/spdlog.h>
 
 #include <rj_geometry/util.hpp>
 #include <rj_geometry_msgs/msg/point.hpp>
@@ -173,9 +174,9 @@ public:
 
     /**
      * compares two points to see if both x and y are the same
-     * adds the == operator
+     * with the == operator and approx. double equality
      */
-    [[nodiscard]] bool operator==(Point other) const { return this->nearly_equals(other); }
+    [[nodiscard]] bool operator==(const Point& other) const { return this->nearly_equals(other); }
 
     /**
      * this is the negation of operator operator !=
@@ -382,7 +383,7 @@ public:
      * @tolerance maximum allowed difference in x/y coord to be considered equal
      * @return true if x/y of this Point are both less than tolerance away from other
      */
-    [[nodiscard]] bool nearly_equals(Point other, double tolerance = 1e-4) const {
+    [[nodiscard]] bool nearly_equals(const Point& other, double tolerance = 1e-4) const {
         return nearly_equal(static_cast<float>(x()), static_cast<float>(other.x()), tolerance) &&
                nearly_equal(static_cast<float>(y()), static_cast<float>(other.y()), tolerance);
     }

--- a/rj_msgs/CMakeLists.txt
+++ b/rj_msgs/CMakeLists.txt
@@ -40,6 +40,7 @@ rosidl_generate_interfaces(
 
   msg/LinearMotionInstant.msg
   msg/EmptyMotionCommand.msg
+  msg/GoalieIdleMotionCommand.msg
   msg/PathTargetMotionCommand.msg
   msg/WorldVelMotionCommand.msg
   msg/PivotMotionCommand.msg

--- a/rj_msgs/msg/InterceptMotionCommand.msg
+++ b/rj_msgs/msg/InterceptMotionCommand.msg
@@ -1,1 +1,0 @@
-rj_geometry_msgs/Point target

--- a/rj_msgs/msg/InterceptMotionCommand.msg
+++ b/rj_msgs/msg/InterceptMotionCommand.msg
@@ -1,0 +1,1 @@
+rj_geometry_msgs/Point target

--- a/rj_msgs/msg/MotionCommand.msg
+++ b/rj_msgs/msg/MotionCommand.msg
@@ -6,3 +6,4 @@ SettleMotionCommand[<=1] settle_command
 CollectMotionCommand[<=1] collect_command
 LineKickMotionCommand[<=1] line_kick_command
 InterceptMotionCommand[<=1] intercept_command
+GoalieIdleMotionCommand[<=1] goalie_idle_command

--- a/rj_msgs/msg/MotionCommand.msg
+++ b/rj_msgs/msg/MotionCommand.msg
@@ -1,3 +1,4 @@
+string name
 EmptyMotionCommand[<=1] empty_command
 PathTargetMotionCommand[<=1] path_target_command
 WorldVelMotionCommand[<=1] world_vel_command

--- a/rj_msgs/msg/MotionCommand.msg
+++ b/rj_msgs/msg/MotionCommand.msg
@@ -1,4 +1,3 @@
-string name
 EmptyMotionCommand[<=1] empty_command
 PathTargetMotionCommand[<=1] path_target_command
 WorldVelMotionCommand[<=1] world_vel_command

--- a/rj_msgs/msg/PathTargetMotionCommand.msg
+++ b/rj_msgs/msg/PathTargetMotionCommand.msg
@@ -1,4 +1,5 @@
 LinearMotionInstant target
 float64[<=1] override_angle
 rj_geometry_msgs/Point[<=1] override_face_point
+bool face_ball
 bool ignore_ball

--- a/rj_msgs/msg/RobotIntent.msg
+++ b/rj_msgs/msg/RobotIntent.msg
@@ -8,6 +8,7 @@ uint8 TRIGGER_MODE_IMMEDIATE = 1
 uint8 TRIGGER_MODE_ON_BREAK_BEAM = 2
 
 MotionCommand motion_command
+string motion_command_name
 
 # Set of obstacles added by plays
 rj_geometry_msgs/ShapeSet local_obstacles

--- a/soccer/src/soccer/CMakeLists.txt
+++ b/soccer/src/soccer/CMakeLists.txt
@@ -39,6 +39,7 @@ set(ROBOCUP_LIB_SRC
     planning/planner/pivot_path_planner.cpp
     planning/planner/plan_request.cpp
     planning/planner/settle_planner.cpp
+    planning/planner/goalie_idle_planner.cpp
     planning/planner_node.cpp
     planning/trajectory.cpp
     planning/trajectory_utils.cpp

--- a/soccer/src/soccer/CMakeLists.txt
+++ b/soccer/src/soccer/CMakeLists.txt
@@ -14,6 +14,7 @@ set(ROBOCUP_LIB_SRC
     battery_profile.cpp
     global_params.cpp
     logger.cpp
+    robot_intent.cpp
     control/manipulator_control.cpp
     control/motion_control.cpp
     control/motion_control_node.cpp

--- a/soccer/src/soccer/CMakeLists.txt
+++ b/soccer/src/soccer/CMakeLists.txt
@@ -32,6 +32,7 @@ set(ROBOCUP_LIB_SRC
     planning/primitives/rrt_util.cpp
     planning/primitives/trapezoidal_motion.cpp
     planning/primitives/velocity_profiling.cpp
+    planning/planner/motion_command.cpp
     planning/planner/collect_planner.cpp
     planning/planner/escape_obstacles_path_planner.cpp
     planning/planner/intercept_planner.cpp

--- a/soccer/src/soccer/planning/planner/collect_planner.cpp
+++ b/soccer/src/soccer/planning/planner/collect_planner.cpp
@@ -18,7 +18,7 @@ Trajectory CollectPlanner::plan(const PlanRequest& plan_request) {
 
     const RJ::Time cur_time = plan_request.start.stamp;
 
-    const auto& command = std::get<CollectCommand>(plan_request.motion_command);
+    const auto& command = std::get<CollectMotionCommand>(plan_request.motion_command);
 
     // Start state for specified robot
     RobotInstant start_instant = plan_request.start;

--- a/soccer/src/soccer/planning/planner/collect_planner.hpp
+++ b/soccer/src/soccer/planning/planner/collect_planner.hpp
@@ -11,7 +11,7 @@ namespace planning {
  * @brief Planner that tries to move onto and gain control of a slow moving
  * ball.
  */
-class CollectPlanner : public PlannerForCommandType<CollectCommand> {
+class CollectPlanner : public PlannerForCommandType<CollectMotionCommand> {
 public:
     enum CollectPathPlannerStates {
         // From start of subbehavior to the start of the slow part of the
@@ -24,7 +24,7 @@ public:
     };
 
     CollectPlanner()
-        : PlannerForCommandType<CollectCommand>("collect"),
+        : PlannerForCommandType<CollectMotionCommand>("collect"),
           average_ball_vel_(0, 0),
           approach_direction_(0, 0) {}
 

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
@@ -21,8 +21,8 @@ Trajectory GoalieIdlePlanner::plan(const PlanRequest& plan_request) {
         return Trajectory();
     }
 
-    // Create a new PathTargetCommand to fill in with desired idle_pt
-    auto command = PathTargetCommand{};
+    // Create a new PathTargetMotionCommand to fill in with desired idle_pt
+    auto command = PathTargetMotionCommand{};
     auto idle_pt = get_idle_pt(plan_request.world_state);
     command.goal.position = idle_pt;
 

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
@@ -3,8 +3,62 @@
 namespace planning {
 
 Trajectory GoalieIdlePlanner::plan(const PlanRequest& plan_request) {
-    Trajectory temp_trajectory;
-    return temp_trajectory;
+    // lots of this is duplicated from PathTargetPlanner, because there's not
+    // an easy way to convert from one PlanRequest to another
+
+    // Collect obstacles
+    rj_geometry::ShapeSet static_obstacles;
+    std::vector<DynamicObstacle> dynamic_obstacles;
+    Trajectory ball_trajectory;
+    bool ignore_ball = true;
+    fill_obstacles(plan_request, &static_obstacles, &dynamic_obstacles, ignore_ball,
+                   &ball_trajectory);
+
+    // If we start inside of an obstacle, give up and let another planner take
+    // care of it.
+    if (static_obstacles.hit(plan_request.start.position())) {
+        reset();
+        return Trajectory();
+    }
+
+    // Create a new PathTargetCommand to fill in with desired idle_pt
+    auto command = PathTargetCommand{};
+    auto idle_pt = get_idle_pt(plan_request.world_state);
+    command.goal.position = idle_pt;
+
+    // Make robot face ball
+    auto angle_function = AngleFns::face_point(plan_request.world_state->ball.position);
+
+    // call Replanner to generate a Trajectory
+    Trajectory trajectory = Replanner::create_plan(
+        Replanner::PlanParams{plan_request.start, command.goal, static_obstacles, dynamic_obstacles,
+                              plan_request.constraints, angle_function, RJ::Seconds(3.0)},
+        std::move(previous_));
+
+    // Debug drawing
+    if (plan_request.debug_drawer != nullptr) {
+        plan_request.debug_drawer->draw_circle(
+            rj_geometry::Circle(command.goal.position, static_cast<float>(draw_radius)),
+            draw_color);
+    }
+
+    // Cache current Trajectory, return
+    previous_ = trajectory;
+    return trajectory;
+}
+
+rj_geometry::Point GoalieIdlePlanner::get_idle_pt(const WorldState* world_state) const {
+    rj_geometry::Point ball_pos = world_state->ball.position;
+    // TODO: make this depend on team +/-x
+    rj_geometry::Point goal_pt{0.0, 0.0};
+
+    // TODO: move closer/farther from ball as a linear % of distance from ball
+    double goalie_dist = 0.5;
+    rj_geometry::Point idle_pt = (ball_pos - goal_pt).norm();
+    idle_pt *= goalie_dist;
+    // TODO: clamp y to 0
+
+    return idle_pt;
 }
 
 void GoalieIdlePlanner::reset() {}

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
@@ -47,16 +47,15 @@ Trajectory GoalieIdlePlanner::plan(const PlanRequest& plan_request) {
     return trajectory;
 }
 
-rj_geometry::Point GoalieIdlePlanner::get_idle_pt(const WorldState* world_state) const {
+rj_geometry::Point GoalieIdlePlanner::get_idle_pt(const WorldState* world_state) {
     rj_geometry::Point ball_pos = world_state->ball.position;
-    // TODO: make this depend on team +/-x
+    // TODO(Kevin): make this depend on team +/-x
     rj_geometry::Point goal_pt{0.0, 0.0};
 
-    // TODO: move closer/farther from ball as a linear % of distance from ball
     double goalie_dist = 0.5;
     rj_geometry::Point idle_pt = (ball_pos - goal_pt).norm();
     idle_pt *= goalie_dist;
-    // TODO: clamp y to 0
+    // TODO(Kevin): clamp y to 0 so goalie doesn't go backwards
 
     return idle_pt;
 }

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.cpp
@@ -1,0 +1,14 @@
+#include "planning/planner/goalie_idle_planner.hpp"
+
+namespace planning {
+
+Trajectory GoalieIdlePlanner::plan(const PlanRequest& plan_request) {
+    Trajectory temp_trajectory;
+    return temp_trajectory;
+}
+
+void GoalieIdlePlanner::reset() {}
+
+bool GoalieIdlePlanner::is_done() const { return false; }
+
+}  // namespace planning

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
+#include <spdlog/spdlog.h>
+
 #include "planning/instant.hpp"
+#include "planning/planner/path_target_planner.hpp"
 #include "planning/planner/planner.hpp"
 #include "planning/primitives/replanner.hpp"
 #include "planning/trajectory.hpp"
 #include "rj_geometry/point.hpp"
+/* #include <rj_msgs/msg/path_target_motion_command.hpp> */
+#include "planning/planner/motion_command.hpp"
+#include "planning/primitives/angle_planning.hpp"
 
 namespace planning {
 /**
@@ -17,10 +23,20 @@ public:
 
     Trajectory plan(const PlanRequest& plan_request) override;
 
+    /*
+     * @return Point for Goalie to stand in when no shot is coming. Expects
+     * ball to be slow.
+     */
+    rj_geometry::Point get_idle_pt(const WorldState* world_state) const;
+
     void reset() override;
     [[nodiscard]] bool is_done() const override;
 
+    double draw_radius = kRobotRadius;
+    QColor draw_color = Qt::black;
+
 private:
+    Trajectory previous_{};
 };
 
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
@@ -21,16 +21,18 @@ class GoalieIdlePlanner : public PlannerForCommandType<GoalieIdleCommand> {
 public:
     GoalieIdlePlanner() : PlannerForCommandType<GoalieIdleCommand>("goalie_idle") {}
 
+    /*
+     * From Planner superclass (see planner.hpp).
+     */
     Trajectory plan(const PlanRequest& plan_request) override;
+    void reset() override;
+    [[nodiscard]] bool is_done() const override;
 
     /*
      * @return Point for Goalie to stand in when no shot is coming. Expects
      * ball to be slow.
      */
-    rj_geometry::Point get_idle_pt(const WorldState* world_state) const;
-
-    void reset() override;
-    [[nodiscard]] bool is_done() const override;
+    static rj_geometry::Point get_idle_pt(const WorldState* world_state);
 
     double draw_radius = kRobotRadius;
     QColor draw_color = Qt::black;

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "planning/instant.hpp"
+#include "planning/planner/planner.hpp"
+#include "planning/primitives/replanner.hpp"
+#include "planning/trajectory.hpp"
+#include "rj_geometry/point.hpp"
+
+namespace planning {
+/**
+ * @brief This planner gives the goalie a way to track the ball when it's not
+ * otherwise occupied.
+ */
+class GoalieIdlePlanner : public PlannerForCommandType<GoalieIdleCommand> {
+public:
+    GoalieIdlePlanner() : PlannerForCommandType<GoalieIdleCommand>("goalie_idle") {}
+
+    Trajectory plan(const PlanRequest& plan_request) override;
+
+    void reset() override;
+    [[nodiscard]] bool is_done() const override;
+
+private:
+};
+
+}  // namespace planning

--- a/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
+++ b/soccer/src/soccer/planning/planner/goalie_idle_planner.hpp
@@ -17,9 +17,9 @@ namespace planning {
  * @brief This planner gives the goalie a way to track the ball when it's not
  * otherwise occupied.
  */
-class GoalieIdlePlanner : public PlannerForCommandType<GoalieIdleCommand> {
+class GoalieIdlePlanner : public PlannerForCommandType<GoalieIdleMotionCommand> {
 public:
-    GoalieIdlePlanner() : PlannerForCommandType<GoalieIdleCommand>("goalie_idle") {}
+    GoalieIdlePlanner() : PlannerForCommandType<GoalieIdleMotionCommand>("goalie_idle") {}
 
     /*
      * From Planner superclass (see planner.hpp).

--- a/soccer/src/soccer/planning/planner/intercept_planner.cpp
+++ b/soccer/src/soccer/planning/planner/intercept_planner.cpp
@@ -78,6 +78,9 @@ Trajectory InterceptPlanner::plan(const PlanRequest& plan_request) {
     return trajectory;
 }
 
-bool InterceptPlanner::is_done() const { return false; }
+bool InterceptPlanner::is_done() const {
+    // TODO(Kevin): should return true if ball is slow + in mouth
+    return false;
+}
 
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/intercept_planner.cpp
+++ b/soccer/src/soccer/planning/planner/intercept_planner.cpp
@@ -9,7 +9,7 @@
 namespace planning {
 
 Trajectory InterceptPlanner::plan(const PlanRequest& plan_request) {
-    InterceptCommand command = std::get<InterceptCommand>(plan_request.motion_command);
+    InterceptMotionCommand command = std::get<InterceptMotionCommand>(plan_request.motion_command);
 
     // Start state for the specified robot
     RobotInstant start_instant = plan_request.start;

--- a/soccer/src/soccer/planning/planner/intercept_planner.cpp
+++ b/soccer/src/soccer/planning/planner/intercept_planner.cpp
@@ -9,75 +9,100 @@
 namespace planning {
 
 Trajectory InterceptPlanner::plan(const PlanRequest& plan_request) {
-    InterceptCommand command = std::get<InterceptCommand>(plan_request.motion_command);
+    SPDLOG_INFO("got here!!");
+    // lots of this is duplicated from PathTargetPlanner, because there's not
+    // an easy way to convert from one PlanRequest to another
 
-    // Start state for the specified robot
-    RobotInstant start_instant = plan_request.start;
+    // Collect obstacles
+    rj_geometry::ShapeSet static_obstacles;
+    std::vector<DynamicObstacle> dynamic_obstacles;
+    Trajectory ball_trajectory;
+    bool ignore_ball = true;
+    fill_obstacles(plan_request, &static_obstacles, &dynamic_obstacles, ignore_ball,
+                   &ball_trajectory);
 
-    // All the max velocity / acceleration constraints for translation /
-    // rotation
-    const MotionConstraints& motion_constraints = plan_request.constraints.mot;
+    // If we start inside of an obstacle, give up and let another planner take
+    // care of it.
+    /* if (static_obstacles.hit(plan_request.start.position())) { */
+    /*     reset(); */
+    /*     return Trajectory{}; */
+    /* } */
 
-    BallState ball = plan_request.world_state->ball;
-
-    // Time for ball to hit target point
-    // Target point is projected into ball velocity line
-    rj_geometry::Point target_pos_on_line;
-    RJ::Seconds ball_to_point_time = ball.query_seconds_near(command.target, &target_pos_on_line);
-
-    // vector from robot to target
-    rj_geometry::Point bot_to_target = (target_pos_on_line - start_instant.position());
-
-    // Max speed we can reach given the distance to target and constant
-    // acceleration If we don't constrain the speed, there is a velocity
-    // discontinuity in the middle of the path
-    double max_speed =
-        std::min(start_instant.linear_velocity().mag() +
-                     sqrt(2 * motion_constraints.max_acceleration * bot_to_target.mag()),
-                 motion_constraints.max_speed);
-
-    // Scale the end velocity by % of max velocity to see if we can reach the
-    // target at the same time as the ball
-    Trajectory trajectory;
-
-    int num_iterations = 20;
-    for (int i = 0; i <= num_iterations; i++) {
-        double mag = i * 0.05;
-
-        LinearMotionInstant final_stopping_motion{target_pos_on_line,
-                                                  mag * max_speed * bot_to_target.normalized()};
-
-        trajectory = CreatePath::simple(start_instant.linear_motion(), final_stopping_motion,
-                                        plan_request.constraints.mot, start_instant.stamp);
-
-        // First path where we can reach the point at or before the ball
-        // If the end velocity is not 0, you should reach the point as close
-        // to the ball time as possible to just ram it
-        if (trajectory.duration() <= ball_to_point_time) {
-            std::ostringstream debug_text_out;
-            debug_text_out.precision(2);
-            debug_text_out << "Time " << trajectory.duration().count();
-            trajectory.set_debug_text(debug_text_out.str());
-
-            plan_angles(&trajectory, start_instant, AngleFns::face_point(ball.position),
-                        plan_request.constraints.rot);
-            trajectory.stamp(RJ::now());
-            return trajectory;
-        }
+    // Create a new PathTargetCommand to fill in with desired block point (see
+    // get_block_pt for more details)
+    // TODO: make an easily usable PathTargetPlanner (non-templated)
+    auto command = PathTargetCommand{};
+    auto optional_block_pt = get_block_pt(plan_request.world_state);
+    if (!optional_block_pt.has_value()) {
+        SPDLOG_INFO("intercept_planner is done");
+        is_done_ = true;
+        return Trajectory{};
     }
 
-    // We couldn't get to the target point in time
-    // Just give up and do the max velocity across ball velocity
-    // Which ends up being the path after the final loop
-    trajectory.set_debug_text("GivingUp");
+    command.goal.position = optional_block_pt.value();
 
-    plan_angles(&trajectory, start_instant, AngleFns::face_point(ball.position),
-                plan_request.constraints.rot);
-    trajectory.stamp(RJ::now());
+    // Make robot face ball
+    auto angle_function = AngleFns::face_point(plan_request.world_state->ball.position);
 
+    // call Replanner to generate a Trajectory
+    Trajectory trajectory = Replanner::create_plan(
+        Replanner::PlanParams{plan_request.start, command.goal, static_obstacles, dynamic_obstacles,
+                              plan_request.constraints, angle_function, RJ::Seconds(3.0)},
+        std::move(previous_));
+
+    // Debug drawing
+    if (plan_request.debug_drawer != nullptr) {
+        plan_request.debug_drawer->draw_circle(
+            rj_geometry::Circle(command.goal.position, static_cast<float>(draw_radius)),
+            draw_color);
+    }
+
+    // Cache current Trajectory, return
+    previous_ = trajectory;
+    /* trajectory.set_debug_text("GivingUp"); */
     return trajectory;
 }
 
-bool InterceptPlanner::is_done() const { return false; }
+bool InterceptPlanner::is_done() const { return is_done_; }
+
+std::optional<rj_geometry::Point> InterceptPlanner::get_block_pt(const WorldState* world_state) {
+    if (!shot_on_goal_detected(world_state)) {
+        is_done_ = true;
+        return std::nullopt;
+    }
+
+    rj_geometry::Point ball_pos = world_state->ball.position;
+    rj_geometry::Point ball_vel = world_state->ball.velocity;
+
+    // find x-coord that the ball would cross on the goal line
+    // (0, 0) is our goal, +y points out of goal
+    // assume ball vel will remain constant
+    // TODO(Kevin): account for acceleration?
+    if (ball_vel.y() == 0) {
+        return std::nullopt;
+    }
+    double time_to_cross =
+        std::abs(ball_pos.y() / ball_vel.y());  // impossible for ball_vel.y() to be exactly 0
+    double cross_x = ball_pos.x() + ball_vel.x() * time_to_cross;
+
+    // if shot is off target, ignore it
+    // TODO(Kevin): add field to world_state to avoid hardcoding
+    // TODO(Kevin): add this to shot on goal calculations
+    if (std::abs(cross_x) > 0.5) {
+        is_done_ = true;
+        return std::nullopt;
+    }
+
+    // otherwise, return point needed to block shot
+    rj_geometry::Point block_pt{cross_x, 0.0};  // x coord was solved for y = 0
+    // TODO: move the y coord up if possible?
+    return block_pt;
+}
+
+bool InterceptPlanner::shot_on_goal_detected(const WorldState* world_state) {
+    // TODO: make this also check direction of fast ball
+    rj_geometry::Point ball_vel = world_state->ball.velocity;
+    return ball_vel.mag() > 0.2;
+}
 
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/intercept_planner.hpp
+++ b/soccer/src/soccer/planning/planner/intercept_planner.hpp
@@ -1,52 +1,24 @@
 #pragma once
 
-#include <spdlog/spdlog.h>
-
-#include <rj_geometry/point.hpp>
-
 #include "planner.hpp"
-#include "planning/primitives/replanner.hpp"
 
 namespace planning {
 
 /**
- * Planner which tries to block a shot on goal as quickly as possible
+ * Planner which tries to intercept the path ball as quickly as possible
  * Whether this means moving and stopping in the path of the ball
  * or completely driving through and "slapping" the ball.
  *
- * (More accurate name would be "GoalieBlock", but Intercept kept for legacy
- * reasons.)
+ * Mostly used for the goalie to block shots (w/ a target point of 0,0).
  */
 
 class InterceptPlanner : public PlannerForCommandType<InterceptCommand> {
 public:
-    InterceptPlanner() : PlannerForCommandType<InterceptCommand>("intercept"){};
+    InterceptPlanner()
+        : PlannerForCommandType<InterceptCommand>("InterceptPlanner"){};
 
     Trajectory plan(const PlanRequest& request) override;
 
     [[nodiscard]] bool is_done() const override;
-
-    /*
-     * @return if a shot on goal is coming
-     *
-     * Static so it can be used in Goalie's FSM.
-     */
-    static bool shot_on_goal_detected(const WorldState* world_state);
-
-    double draw_radius = kRobotRadius;
-    QColor draw_color = Qt::black;
-
-private:
-    bool is_done_ = false;
-
-    /*
-     * @return Point for Goalie to block a shot. Assumes ball is not slow.
-     *
-     * TODO(Kevin): make 1 common param for "ball slow/fast" for GoalieIdle and
-     * this planner
-     */
-    std::optional<rj_geometry::Point> get_block_pt(const WorldState* world_state);
-
-    Trajectory previous_{};
 };
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/intercept_planner.hpp
+++ b/soccer/src/soccer/planning/planner/intercept_planner.hpp
@@ -12,10 +12,9 @@ namespace planning {
  * Mostly used for the goalie to block shots (w/ a target point of 0,0).
  */
 
-class InterceptPlanner : public PlannerForCommandType<InterceptCommand> {
+class InterceptPlanner : public PlannerForCommandType<InterceptMotionCommand> {
 public:
-    InterceptPlanner()
-        : PlannerForCommandType<InterceptCommand>("InterceptPlanner"){};
+    InterceptPlanner() : PlannerForCommandType<InterceptMotionCommand>("InterceptPlanner"){};
 
     Trajectory plan(const PlanRequest& request) override;
 

--- a/soccer/src/soccer/planning/planner/intercept_planner.hpp
+++ b/soccer/src/soccer/planning/planner/intercept_planner.hpp
@@ -1,24 +1,52 @@
 #pragma once
 
+#include <spdlog/spdlog.h>
+
+#include <rj_geometry/point.hpp>
+
 #include "planner.hpp"
+#include "planning/primitives/replanner.hpp"
 
 namespace planning {
 
 /**
- * Planner which tries to intercept the path ball as quickly as possible
+ * Planner which tries to block a shot on goal as quickly as possible
  * Whether this means moving and stopping in the path of the ball
  * or completely driving through and "slapping" the ball.
  *
- * Mostly used for the goalie / defenders to block shots
+ * (More accurate name would be "GoalieBlock", but Intercept kept for legacy
+ * reasons.)
  */
 
 class InterceptPlanner : public PlannerForCommandType<InterceptCommand> {
 public:
-    InterceptPlanner()
-        : PlannerForCommandType<InterceptCommand>("InterceptPlanner"){};
+    InterceptPlanner() : PlannerForCommandType<InterceptCommand>("intercept"){};
 
     Trajectory plan(const PlanRequest& request) override;
 
     [[nodiscard]] bool is_done() const override;
+
+    /*
+     * @return if a shot on goal is coming
+     *
+     * Static so it can be used in Goalie's FSM.
+     */
+    static bool shot_on_goal_detected(const WorldState* world_state);
+
+    double draw_radius = kRobotRadius;
+    QColor draw_color = Qt::black;
+
+private:
+    bool is_done_ = false;
+
+    /*
+     * @return Point for Goalie to block a shot. Assumes ball is not slow.
+     *
+     * TODO(Kevin): make 1 common param for "ball slow/fast" for GoalieIdle and
+     * this planner
+     */
+    std::optional<rj_geometry::Point> get_block_pt(const WorldState* world_state);
+
+    Trajectory previous_{};
 };
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/line_kick_planner.cpp
+++ b/soccer/src/soccer/planning/planner/line_kick_planner.cpp
@@ -18,7 +18,7 @@ Trajectory LineKickPlanner::plan(const PlanRequest& plan_request) {
 
     const float ball_avoid_distance = 0.05;
 
-    const auto& command = std::get<LineKickCommand>(plan_request.motion_command);
+    const auto& command = std::get<LineKickMotionCommand>(plan_request.motion_command);
 
     if (plan_request.virtual_obstacles.hit(plan_request.start.position())) {
         prev_path_ = Trajectory{};

--- a/soccer/src/soccer/planning/planner/line_kick_planner.hpp
+++ b/soccer/src/soccer/planning/planner/line_kick_planner.hpp
@@ -19,9 +19,9 @@ namespace planning {
  *
  * TODO(Kyle): Overhaul this entire planner. It's sketchy right now.
  */
-class LineKickPlanner : public PlannerForCommandType<planning::LineKickCommand> {
+class LineKickPlanner : public PlannerForCommandType<planning::LineKickMotionCommand> {
 public:
-    LineKickPlanner() : PlannerForCommandType<planning::LineKickCommand>("LineKickPlanner"){};
+    LineKickPlanner() : PlannerForCommandType<planning::LineKickMotionCommand>("LineKickPlanner"){};
     Trajectory plan(const PlanRequest& plan_request) override;
 
     void reset() override {

--- a/soccer/src/soccer/planning/planner/motion_command.cpp
+++ b/soccer/src/soccer/planning/planner/motion_command.cpp
@@ -2,27 +2,13 @@
 
 namespace planning {
 
-template <class T>
-bool are_equivalent(T const& l, T const& r) {
-    // (2) which will then delegate to T's overloaded==
-    return l == r;
-}
-bool are_equivalent(MotionCommand const& l, MotionCommand const& r) {
-    return std::visit(
-        [&](auto const& l, auto const& r) {
-            // (1) if types of l/r are the same, they will match to are_equivalent's signature
-            return are_equivalent(l, r);
-        },
-        l, r);
-}
-
-bool operator==(const MotionCommand& a, const MotionCommand& b) {
-    // if MotionCommand variant is type T, delegate the comparison to T's overloaded ==
-    // credit: https://devblogs.microsoft.com/oldnewthing/20190620-00/?p=102604#comment-135008
-    return are_equivalent(a, b);
-}
-
-// TODO(Kevin): do something similar for AngleOverride (also a variant)
+/* Kevin: there is some built-in operator== for std::variants that (1) checks
+ * the type of the variant and (2) if the types match, delegates to any
+ * overloaded operator== that compares some specific type of the variant.
+ *
+ * So MotionCommand and AngleOverride don't need an operator== explicitly;
+ * specifying one for each of the possible types of each works the same.
+ */
 
 bool operator==(const LinearMotionInstant& a, const LinearMotionInstant& b) {
     return a.velocity == b.velocity && a.position == b.position;

--- a/soccer/src/soccer/planning/planner/motion_command.cpp
+++ b/soccer/src/soccer/planning/planner/motion_command.cpp
@@ -2,12 +2,33 @@
 
 namespace planning {
 
+template <class T>
+bool are_equivalent(T const& l, T const& r) {
+    // (2) which will then delegate to T's overloaded==
+    return l == r;
+}
+bool are_equivalent(MotionCommand const& l, MotionCommand const& r) {
+    return std::visit(
+        [&](auto const& l, auto const& r) {
+            // (1) if types of l/r are the same, they will match to are_equivalent's signature
+            return are_equivalent(l, r);
+        },
+        l, r);
+}
+
+bool operator==(const MotionCommand& a, const MotionCommand& b) {
+    // if MotionCommand variant is type T, delegate the comparison to T's overloaded ==
+    // credit: https://devblogs.microsoft.com/oldnewthing/20190620-00/?p=102604#comment-135008
+    return are_equivalent(a, b);
+}
+
+// TODO(Kevin): do something similar for AngleOverride (also a variant)
+
 bool operator==(const LinearMotionInstant& a, const LinearMotionInstant& b) {
     return a.velocity == b.velocity && a.position == b.position;
 }
 
 bool operator==(const PathTargetCommand& a, const PathTargetCommand& b) {
-    SPDLOG_ERROR("ptc == reached");
     return a.goal == b.goal && a.angle_override == b.angle_override;
 }
 
@@ -23,6 +44,26 @@ bool operator==([[maybe_unused]] const TargetFaceTangent& a,
 bool operator==(const TargetFaceAngle& a, const TargetFaceAngle& b) { return a.target == b.target; }
 bool operator==(const TargetFacePoint& a, const TargetFacePoint& b) {
     return a.face_point == b.face_point;
+}
+
+bool operator==([[maybe_unused]] const EmptyCommand& a, [[maybe_unused]] const EmptyCommand& b) {
+    return true;
+}
+
+bool operator==(const WorldVelCommand& a, const WorldVelCommand& b) {
+    return a.world_vel == b.world_vel;
+}
+bool operator==(const PivotCommand& a, const PivotCommand& b) {
+    return a.pivot_target == b.pivot_target && a.pivot_point == b.pivot_point;
+}
+bool operator==(const SettleCommand& a, const SettleCommand& b) { return a.target == b.target; }
+bool operator==([[maybe_unused]] const CollectCommand& a,
+                [[maybe_unused]] const CollectCommand& b) {
+    return true;
+}
+bool operator==(const LineKickCommand& a, const LineKickCommand& b) { return a.target == b.target; }
+bool operator==(const InterceptCommand& a, const InterceptCommand& b) {
+    return a.target == b.target;
 }
 
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/motion_command.cpp
+++ b/soccer/src/soccer/planning/planner/motion_command.cpp
@@ -15,12 +15,12 @@ bool operator==(const LinearMotionInstant& a, const LinearMotionInstant& b) {
     return a.velocity == b.velocity && a.position == b.position;
 }
 
-bool operator==(const PathTargetCommand& a, const PathTargetCommand& b) {
+bool operator==(const PathTargetMotionCommand& a, const PathTargetMotionCommand& b) {
     return a.goal == b.goal && a.angle_override == b.angle_override;
 }
 
-bool operator==([[maybe_unused]] const GoalieIdleCommand& a,
-                [[maybe_unused]] const GoalieIdleCommand& b) {
+bool operator==([[maybe_unused]] const GoalieIdleMotionCommand& a,
+                [[maybe_unused]] const GoalieIdleMotionCommand& b) {
     return true;
 }
 
@@ -38,23 +38,28 @@ bool operator==([[maybe_unused]] const TargetFaceBall& a,
     return true;
 }
 
-bool operator==([[maybe_unused]] const EmptyCommand& a, [[maybe_unused]] const EmptyCommand& b) {
+bool operator==([[maybe_unused]] const EmptyMotionCommand& a,
+                [[maybe_unused]] const EmptyMotionCommand& b) {
     return true;
 }
 
-bool operator==(const WorldVelCommand& a, const WorldVelCommand& b) {
+bool operator==(const WorldVelMotionCommand& a, const WorldVelMotionCommand& b) {
     return a.world_vel == b.world_vel;
 }
-bool operator==(const PivotCommand& a, const PivotCommand& b) {
+bool operator==(const PivotMotionCommand& a, const PivotMotionCommand& b) {
     return a.pivot_target == b.pivot_target && a.pivot_point == b.pivot_point;
 }
-bool operator==(const SettleCommand& a, const SettleCommand& b) { return a.target == b.target; }
-bool operator==([[maybe_unused]] const CollectCommand& a,
-                [[maybe_unused]] const CollectCommand& b) {
+bool operator==(const SettleMotionCommand& a, const SettleMotionCommand& b) {
+    return a.target == b.target;
+}
+bool operator==([[maybe_unused]] const CollectMotionCommand& a,
+                [[maybe_unused]] const CollectMotionCommand& b) {
     return true;
 }
-bool operator==(const LineKickCommand& a, const LineKickCommand& b) { return a.target == b.target; }
-bool operator==(const InterceptCommand& a, const InterceptCommand& b) {
+bool operator==(const LineKickMotionCommand& a, const LineKickMotionCommand& b) {
+    return a.target == b.target;
+}
+bool operator==(const InterceptMotionCommand& a, const InterceptMotionCommand& b) {
     return a.target == b.target;
 }
 

--- a/soccer/src/soccer/planning/planner/motion_command.cpp
+++ b/soccer/src/soccer/planning/planner/motion_command.cpp
@@ -6,7 +6,7 @@ namespace planning {
  * the type of the variant and (2) if the types match, delegates to any
  * overloaded operator== that compares some specific type of the variant.
  *
- * So MotionCommand and AngleOverride don't need an operator== explicitly;
+ * So MotionCommand and PathTargetFaceOption don't need an operator== explicitly;
  * specifying one for each of the possible types of each works the same.
  */
 
@@ -16,7 +16,7 @@ bool operator==(const LinearMotionInstant& a, const LinearMotionInstant& b) {
 }
 
 bool operator==(const PathTargetMotionCommand& a, const PathTargetMotionCommand& b) {
-    return a.goal == b.goal && a.angle_override == b.angle_override;
+    return a.goal == b.goal && a.face_option == b.face_option;
 }
 
 bool operator==([[maybe_unused]] const GoalieIdleMotionCommand& a,
@@ -24,17 +24,15 @@ bool operator==([[maybe_unused]] const GoalieIdleMotionCommand& a,
     return true;
 }
 
-bool operator==([[maybe_unused]] const TargetFaceTangent& a,
-                [[maybe_unused]] const TargetFaceTangent& b) {
+bool operator==([[maybe_unused]] const FaceTarget& a, [[maybe_unused]] const FaceTarget& b) {
     return true;
 }
-bool operator==(const TargetFaceAngle& a, const TargetFaceAngle& b) { return a.target == b.target; }
-bool operator==(const TargetFacePoint& a, const TargetFacePoint& b) {
+bool operator==(const FaceAngle& a, const FaceAngle& b) { return a.target == b.target; }
+bool operator==(const FacePoint& a, const FacePoint& b) {
     double tolerance = 0.1;
     return a.face_point.nearly_equals(b.face_point, tolerance);
 }
-bool operator==([[maybe_unused]] const TargetFaceBall& a,
-                [[maybe_unused]] const TargetFaceBall& b) {
+bool operator==([[maybe_unused]] const FaceBall& a, [[maybe_unused]] const FaceBall& b) {
     return true;
 }
 

--- a/soccer/src/soccer/planning/planner/motion_command.cpp
+++ b/soccer/src/soccer/planning/planner/motion_command.cpp
@@ -1,0 +1,28 @@
+#include "motion_command.hpp"
+
+namespace planning {
+
+bool operator==(const LinearMotionInstant& a, const LinearMotionInstant& b) {
+    return a.velocity == b.velocity && a.position == b.position;
+}
+
+bool operator==(const PathTargetCommand& a, const PathTargetCommand& b) {
+    SPDLOG_ERROR("ptc == reached");
+    return a.goal == b.goal && a.angle_override == b.angle_override;
+}
+
+bool operator==([[maybe_unused]] const GoalieIdleCommand& a,
+                [[maybe_unused]] const GoalieIdleCommand& b) {
+    return true;
+}
+
+bool operator==([[maybe_unused]] const TargetFaceTangent& a,
+                [[maybe_unused]] const TargetFaceTangent& b) {
+    return true;
+}
+bool operator==(const TargetFaceAngle& a, const TargetFaceAngle& b) { return a.target == b.target; }
+bool operator==(const TargetFacePoint& a, const TargetFacePoint& b) {
+    return a.face_point == b.face_point;
+}
+
+}  // namespace planning

--- a/soccer/src/soccer/planning/planner/motion_command.cpp
+++ b/soccer/src/soccer/planning/planner/motion_command.cpp
@@ -11,6 +11,7 @@ namespace planning {
  */
 
 bool operator==(const LinearMotionInstant& a, const LinearMotionInstant& b) {
+    // TODO: this should be in instant.hpp/cpp
     return a.velocity == b.velocity && a.position == b.position;
 }
 
@@ -29,7 +30,12 @@ bool operator==([[maybe_unused]] const TargetFaceTangent& a,
 }
 bool operator==(const TargetFaceAngle& a, const TargetFaceAngle& b) { return a.target == b.target; }
 bool operator==(const TargetFacePoint& a, const TargetFacePoint& b) {
-    return a.face_point == b.face_point;
+    double tolerance = 0.1;
+    return a.face_point.nearly_equals(b.face_point, tolerance);
+}
+bool operator==([[maybe_unused]] const TargetFaceBall& a,
+                [[maybe_unused]] const TargetFaceBall& b) {
+    return true;
 }
 
 bool operator==([[maybe_unused]] const EmptyCommand& a, [[maybe_unused]] const EmptyCommand& b) {

--- a/soccer/src/soccer/planning/planner/motion_command.hpp
+++ b/soccer/src/soccer/planning/planner/motion_command.hpp
@@ -44,8 +44,7 @@ struct TargetFacePoint {
     rj_geometry::Point face_point;
 };
 
-using AngleOverride =
-    std::variant<TargetFaceTangent, TargetFaceAngle, TargetFacePoint>;
+using AngleOverride = std::variant<TargetFaceTangent, TargetFaceAngle, TargetFacePoint>;
 /**
  * Move to a particular target with a particular velocity, avoiding obstacles.
  */
@@ -227,6 +226,8 @@ ASSOCIATE_CPP_ROS(planning::CollectCommand, rj_msgs::msg::CollectMotionCommand);
 
 template <>
 struct RosConverter<planning::GoalieIdleCommand, rj_msgs::msg::GoalieIdleMotionCommand> {
+    // clang-format is disagreeing with itself here, so I disabled it for this block
+    // clang-format off
     static rj_msgs::msg::GoalieIdleMotionCommand to_ros(
         [[maybe_unused]] const planning::GoalieIdleCommand& from) {
         return rj_msgs::build<rj_msgs::msg::GoalieIdleMotionCommand>();
@@ -236,6 +237,7 @@ struct RosConverter<planning::GoalieIdleCommand, rj_msgs::msg::GoalieIdleMotionC
         [[maybe_unused]] const rj_msgs::msg::GoalieIdleMotionCommand& from) {
         return planning::GoalieIdleCommand{};
     }
+    // clang-format on
 };
 
 ASSOCIATE_CPP_ROS(planning::GoalieIdleCommand, rj_msgs::msg::GoalieIdleMotionCommand);

--- a/soccer/src/soccer/planning/planner/motion_command.hpp
+++ b/soccer/src/soccer/planning/planner/motion_command.hpp
@@ -82,17 +82,12 @@ struct PivotCommand {
 };
 
 /**
- * Intercept a moving ball, disregarding whether or not we can actually capture
- * it.
- *
- * Designed for goal defense.
+ * See intercept_planner.hpp.
  */
-struct InterceptCommand {
-    rj_geometry::Point target;
-};
+struct InterceptCommand {};
 
 /*
- * Make the Goalie track the ball when not saving shots.
+ * See goalie_idle_planner.hpp.
  */
 struct GoalieIdleCommand {};
 
@@ -262,13 +257,12 @@ template <>
 struct RosConverter<planning::InterceptCommand, rj_msgs::msg::InterceptMotionCommand> {
     static rj_msgs::msg::InterceptMotionCommand to_ros([
         [maybe_unused]] const planning::InterceptCommand& from) {
-        return rj_msgs::build<rj_msgs::msg::InterceptMotionCommand>().target(
-            convert_to_ros(from.target));
+        return rj_msgs::build<rj_msgs::msg::InterceptMotionCommand>();
     }
 
     static planning::InterceptCommand from_ros([
         [maybe_unused]] const rj_msgs::msg::InterceptMotionCommand& from) {
-        return planning::InterceptCommand{convert_from_ros(from.target)};
+        return planning::InterceptCommand{};
     }
 };
 

--- a/soccer/src/soccer/planning/planner/motion_command.hpp
+++ b/soccer/src/soccer/planning/planner/motion_command.hpp
@@ -3,6 +3,8 @@
 #include <variant>
 #include <vector>
 
+#include <spdlog/spdlog.h>
+
 #include <rj_convert/ros_convert.hpp>
 #include <rj_geometry/point.hpp>
 #include <rj_geometry/pose.hpp>
@@ -42,15 +44,26 @@ bool operator==(const LineKickCommand& a, const LineKickCommand& b);
 struct EmptyCommand {};
 bool operator==([[maybe_unused]] const EmptyCommand& a, [[maybe_unused]] const EmptyCommand& b);
 
+/*
+ * Make robot face along its path (for PTMC).
+ */
 struct TargetFaceTangent {};
 bool operator==([[maybe_unused]] const TargetFaceTangent& a,
                 [[maybe_unused]] const TargetFaceTangent& b);
 
+/*
+ * Make robot face a specific heading while traveling (for PTMC).
+ *
+ * TODO(?): heading based on what coord frame? global frame or robot-centric?
+ */
 struct TargetFaceAngle {
     double target;
 };
 bool operator==(const TargetFaceAngle& a, const TargetFaceAngle& b);
 
+/*
+ * Make robot face a specific point while traveling (for PTMC).
+ */
 struct TargetFacePoint {
     rj_geometry::Point face_point;
 };
@@ -58,7 +71,7 @@ bool operator==(const TargetFacePoint& a, const TargetFacePoint& b);
 
 using AngleOverride = std::variant<TargetFaceTangent, TargetFaceAngle, TargetFacePoint>;
 /**
- * Move to a particular target with a particular velocity, avoiding obstacles.
+ * Move to a particular target with a particular ending velocity, avoiding obstacles.
  */
 struct PathTargetCommand {
     LinearMotionInstant goal{};

--- a/soccer/src/soccer/planning/planner/motion_command.hpp
+++ b/soccer/src/soccer/planning/planner/motion_command.hpp
@@ -37,12 +37,18 @@ struct LineKickCommand {
 struct EmptyCommand {};
 
 struct TargetFaceTangent {};
+bool operator==([[maybe_unused]] const TargetFaceTangent& a,
+                [[maybe_unused]] const TargetFaceTangent& b);
+
 struct TargetFaceAngle {
     double target;
 };
+bool operator==(const TargetFaceAngle& a, const TargetFaceAngle& b);
+
 struct TargetFacePoint {
     rj_geometry::Point face_point;
 };
+bool operator==(const TargetFacePoint& a, const TargetFacePoint& b);
 
 using AngleOverride = std::variant<TargetFaceTangent, TargetFaceAngle, TargetFacePoint>;
 /**
@@ -63,6 +69,7 @@ struct PathTargetCommand {
         return (pos_eq && vel_eq && angle_eq && ball_eq);
     }
 };
+bool operator==(const PathTargetCommand& a, const PathTargetCommand& b);
 
 /**
  * Move with a particular velocity.
@@ -95,6 +102,8 @@ struct InterceptCommand {
  * Make the Goalie track the ball when not saving shots.
  */
 struct GoalieIdleCommand {};
+bool operator==([[maybe_unused]] const GoalieIdleCommand& a,
+                [[maybe_unused]] const GoalieIdleCommand& b);
 
 using MotionCommand =
     std::variant<EmptyCommand, PathTargetCommand, WorldVelCommand, PivotCommand, SettleCommand,

--- a/soccer/src/soccer/planning/planner/motion_command.hpp
+++ b/soccer/src/soccer/planning/planner/motion_command.hpp
@@ -50,7 +50,7 @@ using AngleOverride =
  * Move to a particular target with a particular velocity, avoiding obstacles.
  */
 struct PathTargetCommand {
-    LinearMotionInstant goal;
+    LinearMotionInstant goal{};
     AngleOverride angle_override = TargetFaceTangent{};
     bool ignore_ball = false;
 

--- a/soccer/src/soccer/planning/planner/motion_command.hpp
+++ b/soccer/src/soccer/planning/planner/motion_command.hpp
@@ -25,24 +25,26 @@
 #include "planning/trajectory.hpp"
 
 namespace planning {
-struct SettleCommand {
+struct SettleMotionCommand {
     std::optional<rj_geometry::Point> target;
 };
-bool operator==(const SettleCommand& a, const SettleCommand& b);
+bool operator==(const SettleMotionCommand& a, const SettleMotionCommand& b);
 
-struct CollectCommand {};
-bool operator==([[maybe_unused]] const CollectCommand& a, [[maybe_unused]] const CollectCommand& b);
+struct CollectMotionCommand {};
+bool operator==([[maybe_unused]] const CollectMotionCommand& a,
+                [[maybe_unused]] const CollectMotionCommand& b);
 
-struct LineKickCommand {
+struct LineKickMotionCommand {
     rj_geometry::Point target;
 };
-bool operator==(const LineKickCommand& a, const LineKickCommand& b);
+bool operator==(const LineKickMotionCommand& a, const LineKickMotionCommand& b);
 
 /**
  * An empty "do-nothing" motion command.
  */
-struct EmptyCommand {};
-bool operator==([[maybe_unused]] const EmptyCommand& a, [[maybe_unused]] const EmptyCommand& b);
+struct EmptyMotionCommand {};
+bool operator==([[maybe_unused]] const EmptyMotionCommand& a,
+                [[maybe_unused]] const EmptyMotionCommand& b);
 
 /*
  * Make robot face along its path (for PTMC).
@@ -80,31 +82,31 @@ using AngleOverride =
 /**
  * Move to a particular target with a particular ending velocity, avoiding obstacles.
  */
-struct PathTargetCommand {
+struct PathTargetMotionCommand {
     LinearMotionInstant goal{};
     AngleOverride angle_override = TargetFaceTangent{};
     bool ignore_ball = false;
 };
-bool operator==(const PathTargetCommand& a, const PathTargetCommand& b);
+bool operator==(const PathTargetMotionCommand& a, const PathTargetMotionCommand& b);
 
 /**
  * Move with a particular velocity.
  */
-struct WorldVelCommand {
+struct WorldVelMotionCommand {
     rj_geometry::Point world_vel;
 };
-bool operator==(const WorldVelCommand& a, const WorldVelCommand& b);
+bool operator==(const WorldVelMotionCommand& a, const WorldVelMotionCommand& b);
 
 /**
  * Pivot around a given point, with a given target angle.
  *
  * The robot will face the pivot_point throughout the command.
  */
-struct PivotCommand {
+struct PivotMotionCommand {
     rj_geometry::Point pivot_point;
     rj_geometry::Point pivot_target;
 };
-bool operator==(const PivotCommand& a, const PivotCommand& b);
+bool operator==(const PivotMotionCommand& a, const PivotMotionCommand& b);
 
 /**
  * Intercept a moving ball, disregarding whether or not we can actually capture
@@ -112,44 +114,46 @@ bool operator==(const PivotCommand& a, const PivotCommand& b);
  *
  * Designed for goal defense.
  */
-struct InterceptCommand {
+struct InterceptMotionCommand {
     rj_geometry::Point target;
 };
-bool operator==(const InterceptCommand& a, const InterceptCommand& b);
+bool operator==(const InterceptMotionCommand& a, const InterceptMotionCommand& b);
 
 /*
  * Make the Goalie track the ball when not saving shots.
  */
-struct GoalieIdleCommand {};
-bool operator==([[maybe_unused]] const GoalieIdleCommand& a,
-                [[maybe_unused]] const GoalieIdleCommand& b);
+struct GoalieIdleMotionCommand {};
+bool operator==([[maybe_unused]] const GoalieIdleMotionCommand& a,
+                [[maybe_unused]] const GoalieIdleMotionCommand& b);
 
 using MotionCommand =
-    std::variant<EmptyCommand, PathTargetCommand, WorldVelCommand, PivotCommand, SettleCommand,
-                 CollectCommand, LineKickCommand, InterceptCommand, GoalieIdleCommand>;
+    std::variant<EmptyMotionCommand, PathTargetMotionCommand, WorldVelMotionCommand,
+                 PivotMotionCommand, SettleMotionCommand, CollectMotionCommand,
+                 LineKickMotionCommand, InterceptMotionCommand, GoalieIdleMotionCommand>;
 
 }  // namespace planning
 
 namespace rj_convert {
 
 template <>
-struct RosConverter<planning::EmptyCommand, rj_msgs::msg::EmptyMotionCommand> {
-    static rj_msgs::msg::EmptyMotionCommand to_ros([
-        [maybe_unused]] const planning::EmptyCommand& from) {
+struct RosConverter<planning::EmptyMotionCommand, rj_msgs::msg::EmptyMotionCommand> {
+    static rj_msgs::msg::EmptyMotionCommand to_ros(
+        [[maybe_unused]] const planning::EmptyMotionCommand& from) {
         return rj_msgs::msg::EmptyMotionCommand{};
     }
 
-    static planning::EmptyCommand from_ros([
-        [maybe_unused]] const rj_msgs::msg::EmptyMotionCommand& from) {
-        return planning::EmptyCommand{};
+    static planning::EmptyMotionCommand from_ros(
+        [[maybe_unused]] const rj_msgs::msg::EmptyMotionCommand& from) {
+        return planning::EmptyMotionCommand{};
     }
 };
 
-ASSOCIATE_CPP_ROS(planning::EmptyCommand, rj_msgs::msg::EmptyMotionCommand);
+ASSOCIATE_CPP_ROS(planning::EmptyMotionCommand, rj_msgs::msg::EmptyMotionCommand);
 
 template <>
-struct RosConverter<planning::PathTargetCommand, rj_msgs::msg::PathTargetMotionCommand> {
-    static rj_msgs::msg::PathTargetMotionCommand to_ros(const planning::PathTargetCommand& from) {
+struct RosConverter<planning::PathTargetMotionCommand, rj_msgs::msg::PathTargetMotionCommand> {
+    static rj_msgs::msg::PathTargetMotionCommand to_ros(
+        const planning::PathTargetMotionCommand& from) {
         rj_msgs::msg::PathTargetMotionCommand result;
         result.target = convert_to_ros(from.goal);
 
@@ -170,8 +174,9 @@ struct RosConverter<planning::PathTargetCommand, rj_msgs::msg::PathTargetMotionC
         return result;
     }
 
-    static planning::PathTargetCommand from_ros(const rj_msgs::msg::PathTargetMotionCommand& from) {
-        planning::PathTargetCommand result;
+    static planning::PathTargetMotionCommand from_ros(
+        const rj_msgs::msg::PathTargetMotionCommand& from) {
+        planning::PathTargetMotionCommand result;
         result.goal = convert_from_ros(from.target);
         if (!from.override_angle.empty()) {
             result.angle_override = planning::TargetFaceAngle{from.override_angle.front()};
@@ -189,41 +194,42 @@ struct RosConverter<planning::PathTargetCommand, rj_msgs::msg::PathTargetMotionC
     }
 };
 
-ASSOCIATE_CPP_ROS(planning::PathTargetCommand, rj_msgs::msg::PathTargetMotionCommand);
+ASSOCIATE_CPP_ROS(planning::PathTargetMotionCommand, rj_msgs::msg::PathTargetMotionCommand);
 
 template <>
-struct RosConverter<planning::WorldVelCommand, rj_msgs::msg::WorldVelMotionCommand> {
-    static rj_msgs::msg::WorldVelMotionCommand to_ros(const planning::WorldVelCommand& from) {
+struct RosConverter<planning::WorldVelMotionCommand, rj_msgs::msg::WorldVelMotionCommand> {
+    static rj_msgs::msg::WorldVelMotionCommand to_ros(const planning::WorldVelMotionCommand& from) {
         return rj_msgs::build<rj_msgs::msg::WorldVelMotionCommand>().world_vel(
             convert_to_ros(from.world_vel));
     }
 
-    static planning::WorldVelCommand from_ros(const rj_msgs::msg::WorldVelMotionCommand& from) {
-        return planning::WorldVelCommand{convert_from_ros(from.world_vel)};
+    static planning::WorldVelMotionCommand from_ros(
+        const rj_msgs::msg::WorldVelMotionCommand& from) {
+        return planning::WorldVelMotionCommand{convert_from_ros(from.world_vel)};
     }
 };
 
-ASSOCIATE_CPP_ROS(planning::WorldVelCommand, rj_msgs::msg::WorldVelMotionCommand);
+ASSOCIATE_CPP_ROS(planning::WorldVelMotionCommand, rj_msgs::msg::WorldVelMotionCommand);
 
 template <>
-struct RosConverter<planning::PivotCommand, rj_msgs::msg::PivotMotionCommand> {
-    static rj_msgs::msg::PivotMotionCommand to_ros(const planning::PivotCommand& from) {
+struct RosConverter<planning::PivotMotionCommand, rj_msgs::msg::PivotMotionCommand> {
+    static rj_msgs::msg::PivotMotionCommand to_ros(const planning::PivotMotionCommand& from) {
         return rj_msgs::build<rj_msgs::msg::PivotMotionCommand>()
             .pivot_point(convert_to_ros(from.pivot_point))
             .pivot_target(convert_to_ros(from.pivot_target));
     }
 
-    static planning::PivotCommand from_ros(const rj_msgs::msg::PivotMotionCommand& from) {
-        return planning::PivotCommand{convert_from_ros(from.pivot_point),
-                                      convert_from_ros(from.pivot_target)};
+    static planning::PivotMotionCommand from_ros(const rj_msgs::msg::PivotMotionCommand& from) {
+        return planning::PivotMotionCommand{convert_from_ros(from.pivot_point),
+                                            convert_from_ros(from.pivot_target)};
     }
 };
 
-ASSOCIATE_CPP_ROS(planning::PivotCommand, rj_msgs::msg::PivotMotionCommand);
+ASSOCIATE_CPP_ROS(planning::PivotMotionCommand, rj_msgs::msg::PivotMotionCommand);
 
 template <>
-struct RosConverter<planning::SettleCommand, rj_msgs::msg::SettleMotionCommand> {
-    static rj_msgs::msg::SettleMotionCommand to_ros(const planning::SettleCommand& from) {
+struct RosConverter<planning::SettleMotionCommand, rj_msgs::msg::SettleMotionCommand> {
+    static rj_msgs::msg::SettleMotionCommand to_ros(const planning::SettleMotionCommand& from) {
         rj_msgs::msg::SettleMotionCommand result;
         if (from.target.has_value()) {
             result.maybe_target.push_back(convert_to_ros(from.target.value()));
@@ -231,8 +237,8 @@ struct RosConverter<planning::SettleCommand, rj_msgs::msg::SettleMotionCommand> 
         return result;
     }
 
-    static planning::SettleCommand from_ros(const rj_msgs::msg::SettleMotionCommand& from) {
-        planning::SettleCommand result;
+    static planning::SettleMotionCommand from_ros(const rj_msgs::msg::SettleMotionCommand& from) {
+        planning::SettleMotionCommand result;
         if (!from.maybe_target.empty()) {
             result.target = convert_from_ros(from.maybe_target.front());
         }
@@ -240,95 +246,97 @@ struct RosConverter<planning::SettleCommand, rj_msgs::msg::SettleMotionCommand> 
     }
 };
 
-ASSOCIATE_CPP_ROS(planning::SettleCommand, rj_msgs::msg::SettleMotionCommand);
+ASSOCIATE_CPP_ROS(planning::SettleMotionCommand, rj_msgs::msg::SettleMotionCommand);
 
 template <>
-struct RosConverter<planning::CollectCommand, rj_msgs::msg::CollectMotionCommand> {
-    static rj_msgs::msg::CollectMotionCommand to_ros([
-        [maybe_unused]] const planning::CollectCommand& from) {
+struct RosConverter<planning::CollectMotionCommand, rj_msgs::msg::CollectMotionCommand> {
+    static rj_msgs::msg::CollectMotionCommand to_ros(
+        [[maybe_unused]] const planning::CollectMotionCommand& from) {
         return rj_msgs::build<rj_msgs::msg::CollectMotionCommand>();
     }
 
-    static planning::CollectCommand from_ros([
-        [maybe_unused]] const rj_msgs::msg::CollectMotionCommand& from) {
-        return planning::CollectCommand{};
+    static planning::CollectMotionCommand from_ros(
+        [[maybe_unused]] const rj_msgs::msg::CollectMotionCommand& from) {
+        return planning::CollectMotionCommand{};
     }
 };
 
-ASSOCIATE_CPP_ROS(planning::CollectCommand, rj_msgs::msg::CollectMotionCommand);
+ASSOCIATE_CPP_ROS(planning::CollectMotionCommand, rj_msgs::msg::CollectMotionCommand);
 
 template <>
-struct RosConverter<planning::GoalieIdleCommand, rj_msgs::msg::GoalieIdleMotionCommand> {
+struct RosConverter<planning::GoalieIdleMotionCommand, rj_msgs::msg::GoalieIdleMotionCommand> {
     // clang-format is disagreeing with itself here, so I disabled it for this block
     // clang-format off
     static rj_msgs::msg::GoalieIdleMotionCommand to_ros(
-        [[maybe_unused]] const planning::GoalieIdleCommand& from) {
+        [[maybe_unused]] const planning::GoalieIdleMotionCommand& from) {
         return rj_msgs::build<rj_msgs::msg::GoalieIdleMotionCommand>();
     }
 
-    static planning::GoalieIdleCommand from_ros(
+    static planning::GoalieIdleMotionCommand from_ros(
         [[maybe_unused]] const rj_msgs::msg::GoalieIdleMotionCommand& from) {
-        return planning::GoalieIdleCommand{};
+        return planning::GoalieIdleMotionCommand{};
     }
     // clang-format on
 };
 
-ASSOCIATE_CPP_ROS(planning::GoalieIdleCommand, rj_msgs::msg::GoalieIdleMotionCommand);
+ASSOCIATE_CPP_ROS(planning::GoalieIdleMotionCommand, rj_msgs::msg::GoalieIdleMotionCommand);
 
 template <>
-struct RosConverter<planning::LineKickCommand, rj_msgs::msg::LineKickMotionCommand> {
-    static rj_msgs::msg::LineKickMotionCommand to_ros([
-        [maybe_unused]] const planning::LineKickCommand& from) {
+struct RosConverter<planning::LineKickMotionCommand, rj_msgs::msg::LineKickMotionCommand> {
+    static rj_msgs::msg::LineKickMotionCommand to_ros(
+        [[maybe_unused]] const planning::LineKickMotionCommand& from) {
         return rj_msgs::build<rj_msgs::msg::LineKickMotionCommand>().target(
             convert_to_ros(from.target));
     }
 
-    static planning::LineKickCommand from_ros([
-        [maybe_unused]] const rj_msgs::msg::LineKickMotionCommand& from) {
-        return planning::LineKickCommand{convert_from_ros(from.target)};
+    static planning::LineKickMotionCommand from_ros(
+        [[maybe_unused]] const rj_msgs::msg::LineKickMotionCommand& from) {
+        return planning::LineKickMotionCommand{convert_from_ros(from.target)};
     }
 };
 
-ASSOCIATE_CPP_ROS(planning::LineKickCommand, rj_msgs::msg::LineKickMotionCommand);
+ASSOCIATE_CPP_ROS(planning::LineKickMotionCommand, rj_msgs::msg::LineKickMotionCommand);
 
 template <>
-struct RosConverter<planning::InterceptCommand, rj_msgs::msg::InterceptMotionCommand> {
-    static rj_msgs::msg::InterceptMotionCommand to_ros([
-        [maybe_unused]] const planning::InterceptCommand& from) {
+struct RosConverter<planning::InterceptMotionCommand, rj_msgs::msg::InterceptMotionCommand> {
+    static rj_msgs::msg::InterceptMotionCommand to_ros(
+        [[maybe_unused]] const planning::InterceptMotionCommand& from) {
         return rj_msgs::build<rj_msgs::msg::InterceptMotionCommand>().target(
             convert_to_ros(from.target));
     }
 
-    static planning::InterceptCommand from_ros([
-        [maybe_unused]] const rj_msgs::msg::InterceptMotionCommand& from) {
-        return planning::InterceptCommand{convert_from_ros(from.target)};
+    static planning::InterceptMotionCommand from_ros(
+        [[maybe_unused]] const rj_msgs::msg::InterceptMotionCommand& from) {
+        return planning::InterceptMotionCommand{convert_from_ros(from.target)};
     }
 };
 
-ASSOCIATE_CPP_ROS(planning::InterceptCommand, rj_msgs::msg::InterceptMotionCommand);
+ASSOCIATE_CPP_ROS(planning::InterceptMotionCommand, rj_msgs::msg::InterceptMotionCommand);
 
 template <>
 struct RosConverter<planning::MotionCommand, rj_msgs::msg::MotionCommand> {
     static rj_msgs::msg::MotionCommand to_ros(const planning::MotionCommand& from) {
         // TODO(Kevin): wtf is this
         rj_msgs::msg::MotionCommand result;
-        if (const auto* empty = std::get_if<planning::EmptyCommand>(&from)) {
+        if (const auto* empty = std::get_if<planning::EmptyMotionCommand>(&from)) {
             result.empty_command.emplace_back(convert_to_ros(*empty));
-        } else if (const auto* path_target = std::get_if<planning::PathTargetCommand>(&from)) {
+        } else if (const auto* path_target =
+                       std::get_if<planning::PathTargetMotionCommand>(&from)) {
             result.path_target_command.emplace_back(convert_to_ros(*path_target));
-        } else if (const auto* world_vel = std::get_if<planning::WorldVelCommand>(&from)) {
+        } else if (const auto* world_vel = std::get_if<planning::WorldVelMotionCommand>(&from)) {
             result.world_vel_command.emplace_back(convert_to_ros(*world_vel));
-        } else if (const auto* pivot = std::get_if<planning::PivotCommand>(&from)) {
+        } else if (const auto* pivot = std::get_if<planning::PivotMotionCommand>(&from)) {
             result.pivot_command.emplace_back(convert_to_ros(*pivot));
-        } else if (const auto* settle = std::get_if<planning::SettleCommand>(&from)) {
+        } else if (const auto* settle = std::get_if<planning::SettleMotionCommand>(&from)) {
             result.settle_command.emplace_back(convert_to_ros(*settle));
-        } else if (const auto* collect = std::get_if<planning::CollectCommand>(&from)) {
+        } else if (const auto* collect = std::get_if<planning::CollectMotionCommand>(&from)) {
             result.collect_command.emplace_back(convert_to_ros(*collect));
-        } else if (const auto* line_kick = std::get_if<planning::LineKickCommand>(&from)) {
+        } else if (const auto* line_kick = std::get_if<planning::LineKickMotionCommand>(&from)) {
             result.line_kick_command.emplace_back(convert_to_ros(*line_kick));
-        } else if (const auto* intercept = std::get_if<planning::InterceptCommand>(&from)) {
+        } else if (const auto* intercept = std::get_if<planning::InterceptMotionCommand>(&from)) {
             result.intercept_command.emplace_back(convert_to_ros(*intercept));
-        } else if (const auto* goalie_idle = std::get_if<planning::GoalieIdleCommand>(&from)) {
+        } else if (const auto* goalie_idle =
+                       std::get_if<planning::GoalieIdleMotionCommand>(&from)) {
             result.goalie_idle_command.emplace_back(convert_to_ros(*goalie_idle));
         } else {
             throw std::runtime_error("Invalid variant of MotionCommand");

--- a/soccer/src/soccer/planning/planner/motion_command.hpp
+++ b/soccer/src/soccer/planning/planner/motion_command.hpp
@@ -8,6 +8,7 @@
 #include <rj_geometry/pose.hpp>
 #include <rj_msgs/msg/collect_motion_command.hpp>
 #include <rj_msgs/msg/empty_motion_command.hpp>
+#include <rj_msgs/msg/goalie_idle_motion_command.hpp>
 #include <rj_msgs/msg/intercept_motion_command.hpp>
 #include <rj_msgs/msg/line_kick_motion_command.hpp>
 #include <rj_msgs/msg/linear_motion_instant.hpp>
@@ -91,10 +92,14 @@ struct InterceptCommand {
     rj_geometry::Point target;
 };
 
+/*
+ * Make the Goalie track the ball when not saving shots.
+ */
+struct GoalieIdleCommand {};
+
 using MotionCommand =
-    std::variant<EmptyCommand, PathTargetCommand, WorldVelCommand, PivotCommand,
-                 SettleCommand, CollectCommand, LineKickCommand,
-                 InterceptCommand>;
+    std::variant<EmptyCommand, PathTargetCommand, WorldVelCommand, PivotCommand, SettleCommand,
+                 CollectCommand, LineKickCommand, InterceptCommand, GoalieIdleCommand>;
 
 }  // namespace planning
 
@@ -221,6 +226,21 @@ struct RosConverter<planning::CollectCommand, rj_msgs::msg::CollectMotionCommand
 ASSOCIATE_CPP_ROS(planning::CollectCommand, rj_msgs::msg::CollectMotionCommand);
 
 template <>
+struct RosConverter<planning::GoalieIdleCommand, rj_msgs::msg::GoalieIdleMotionCommand> {
+    static rj_msgs::msg::GoalieIdleMotionCommand to_ros(
+        [[maybe_unused]] const planning::GoalieIdleCommand& from) {
+        return rj_msgs::build<rj_msgs::msg::GoalieIdleMotionCommand>();
+    }
+
+    static planning::GoalieIdleCommand from_ros(
+        [[maybe_unused]] const rj_msgs::msg::GoalieIdleMotionCommand& from) {
+        return planning::GoalieIdleCommand{};
+    }
+};
+
+ASSOCIATE_CPP_ROS(planning::GoalieIdleCommand, rj_msgs::msg::GoalieIdleMotionCommand);
+
+template <>
 struct RosConverter<planning::LineKickCommand, rj_msgs::msg::LineKickMotionCommand> {
     static rj_msgs::msg::LineKickMotionCommand to_ros([
         [maybe_unused]] const planning::LineKickCommand& from) {
@@ -255,6 +275,7 @@ ASSOCIATE_CPP_ROS(planning::InterceptCommand, rj_msgs::msg::InterceptMotionComma
 template <>
 struct RosConverter<planning::MotionCommand, rj_msgs::msg::MotionCommand> {
     static rj_msgs::msg::MotionCommand to_ros(const planning::MotionCommand& from) {
+        // TODO(Kevin): wtf is this
         rj_msgs::msg::MotionCommand result;
         if (const auto* empty = std::get_if<planning::EmptyCommand>(&from)) {
             result.empty_command.emplace_back(convert_to_ros(*empty));
@@ -272,6 +293,8 @@ struct RosConverter<planning::MotionCommand, rj_msgs::msg::MotionCommand> {
             result.line_kick_command.emplace_back(convert_to_ros(*line_kick));
         } else if (const auto* intercept = std::get_if<planning::InterceptCommand>(&from)) {
             result.intercept_command.emplace_back(convert_to_ros(*intercept));
+        } else if (const auto* goalie_idle = std::get_if<planning::GoalieIdleCommand>(&from)) {
+            result.goalie_idle_command.emplace_back(convert_to_ros(*goalie_idle));
         } else {
             throw std::runtime_error("Invalid variant of MotionCommand");
         }
@@ -296,6 +319,8 @@ struct RosConverter<planning::MotionCommand, rj_msgs::msg::MotionCommand> {
             result = convert_from_ros(from.line_kick_command.front());
         } else if (!from.intercept_command.empty()) {
             result = convert_from_ros(from.intercept_command.front());
+        } else if (!from.goalie_idle_command.empty()) {
+            result = convert_from_ros(from.goalie_idle_command.front());
         } else {
             throw std::runtime_error("Invalid variant of MotionCommand");
         }

--- a/soccer/src/soccer/planning/planner/motion_command.hpp
+++ b/soccer/src/soccer/planning/planner/motion_command.hpp
@@ -82,12 +82,17 @@ struct PivotCommand {
 };
 
 /**
- * See intercept_planner.hpp.
+ * Intercept a moving ball, disregarding whether or not we can actually capture
+ * it.
+ *
+ * Designed for goal defense.
  */
-struct InterceptCommand {};
+struct InterceptCommand {
+    rj_geometry::Point target;
+};
 
 /*
- * See goalie_idle_planner.hpp.
+ * Make the Goalie track the ball when not saving shots.
  */
 struct GoalieIdleCommand {};
 
@@ -257,12 +262,13 @@ template <>
 struct RosConverter<planning::InterceptCommand, rj_msgs::msg::InterceptMotionCommand> {
     static rj_msgs::msg::InterceptMotionCommand to_ros([
         [maybe_unused]] const planning::InterceptCommand& from) {
-        return rj_msgs::build<rj_msgs::msg::InterceptMotionCommand>();
+        return rj_msgs::build<rj_msgs::msg::InterceptMotionCommand>().target(
+            convert_to_ros(from.target));
     }
 
     static planning::InterceptCommand from_ros([
         [maybe_unused]] const rj_msgs::msg::InterceptMotionCommand& from) {
-        return planning::InterceptCommand{};
+        return planning::InterceptCommand{convert_from_ros(from.target)};
     }
 };
 

--- a/soccer/src/soccer/planning/planner/motion_command.hpp
+++ b/soccer/src/soccer/planning/planner/motion_command.hpp
@@ -26,15 +26,21 @@ namespace planning {
 struct SettleCommand {
     std::optional<rj_geometry::Point> target;
 };
+bool operator==(const SettleCommand& a, const SettleCommand& b);
+
 struct CollectCommand {};
+bool operator==([[maybe_unused]] const CollectCommand& a, [[maybe_unused]] const CollectCommand& b);
+
 struct LineKickCommand {
     rj_geometry::Point target;
 };
+bool operator==(const LineKickCommand& a, const LineKickCommand& b);
 
 /**
  * An empty "do-nothing" motion command.
  */
 struct EmptyCommand {};
+bool operator==([[maybe_unused]] const EmptyCommand& a, [[maybe_unused]] const EmptyCommand& b);
 
 struct TargetFaceTangent {};
 bool operator==([[maybe_unused]] const TargetFaceTangent& a,
@@ -58,16 +64,6 @@ struct PathTargetCommand {
     LinearMotionInstant goal{};
     AngleOverride angle_override = TargetFaceTangent{};
     bool ignore_ball = false;
-
-    bool operator==(const PathTargetCommand& ptc) {
-        bool pos_eq = goal.position == ptc.goal.position;
-        bool vel_eq = goal.velocity == ptc.goal.velocity;
-        // TODO(Kevin): fix this to actually compare std::variants
-        bool angle_eq = true;
-        /* bool angle_eq = goal.velocity == ptc.goal.velocity; */
-        bool ball_eq = ignore_ball == ptc.ignore_ball;
-        return (pos_eq && vel_eq && angle_eq && ball_eq);
-    }
 };
 bool operator==(const PathTargetCommand& a, const PathTargetCommand& b);
 
@@ -77,6 +73,7 @@ bool operator==(const PathTargetCommand& a, const PathTargetCommand& b);
 struct WorldVelCommand {
     rj_geometry::Point world_vel;
 };
+bool operator==(const WorldVelCommand& a, const WorldVelCommand& b);
 
 /**
  * Pivot around a given point, with a given target angle.
@@ -87,6 +84,7 @@ struct PivotCommand {
     rj_geometry::Point pivot_point;
     rj_geometry::Point pivot_target;
 };
+bool operator==(const PivotCommand& a, const PivotCommand& b);
 
 /**
  * Intercept a moving ball, disregarding whether or not we can actually capture
@@ -97,6 +95,7 @@ struct PivotCommand {
 struct InterceptCommand {
     rj_geometry::Point target;
 };
+bool operator==(const InterceptCommand& a, const InterceptCommand& b);
 
 /*
  * Make the Goalie track the ball when not saving shots.

--- a/soccer/src/soccer/planning/planner/path_target_planner.cpp
+++ b/soccer/src/soccer/planning/planner/path_target_planner.cpp
@@ -18,7 +18,7 @@ Trajectory PathTargetPlanner::plan(const PlanRequest& request) {
     ShapeSet static_obstacles;
     std::vector<DynamicObstacle> dynamic_obstacles;
     Trajectory ball_trajectory;
-    auto command = std::get<PathTargetCommand>(request.motion_command);
+    auto command = std::get<PathTargetMotionCommand>(request.motion_command);
     fill_obstacles(request, &static_obstacles, &dynamic_obstacles, !command.ignore_ball,
                    &ball_trajectory);
 
@@ -72,7 +72,7 @@ bool PathTargetPlanner::is_done() const {
 }
 
 AngleFunction PathTargetPlanner::get_angle_function(const PlanRequest& request) {
-    auto angle_override = std::get<PathTargetCommand>(request.motion_command).angle_override;
+    auto angle_override = std::get<PathTargetMotionCommand>(request.motion_command).angle_override;
 
     if (std::holds_alternative<TargetFacePoint>(angle_override)) {
         return AngleFns::face_point(std::get<TargetFacePoint>(angle_override).face_point);

--- a/soccer/src/soccer/planning/planner/path_target_planner.cpp
+++ b/soccer/src/soccer/planning/planner/path_target_planner.cpp
@@ -72,19 +72,19 @@ bool PathTargetPlanner::is_done() const {
 }
 
 AngleFunction PathTargetPlanner::get_angle_function(const PlanRequest& request) {
-    auto angle_override = std::get<PathTargetMotionCommand>(request.motion_command).angle_override;
+    auto face_option = std::get<PathTargetMotionCommand>(request.motion_command).face_option;
 
-    if (std::holds_alternative<TargetFacePoint>(angle_override)) {
-        return AngleFns::face_point(std::get<TargetFacePoint>(angle_override).face_point);
+    if (std::holds_alternative<FacePoint>(face_option)) {
+        return AngleFns::face_point(std::get<FacePoint>(face_option).face_point);
     }
 
-    if (std::holds_alternative<TargetFaceBall>(angle_override)) {
+    if (std::holds_alternative<FaceBall>(face_option)) {
         auto ball_pos = request.world_state->ball.position;
         return AngleFns::face_point(ball_pos);
     }
 
-    if (std::holds_alternative<TargetFaceAngle>(angle_override)) {
-        return AngleFns::face_angle(std::get<TargetFaceAngle>(angle_override).target);
+    if (std::holds_alternative<FaceAngle>(face_option)) {
+        return AngleFns::face_angle(std::get<FaceAngle>(face_option).target);
     }
 
     // default to facing tangent to path

--- a/soccer/src/soccer/planning/planner/path_target_planner.cpp
+++ b/soccer/src/soccer/planning/planner/path_target_planner.cpp
@@ -36,12 +36,6 @@ Trajectory PathTargetPlanner::plan(const PlanRequest& request) {
     cached_goal_instant_ = goal_instant;
     cached_start_instant_ = request.start.linear_motion();
 
-    // Debug drawing
-    if (request.debug_drawer != nullptr) {
-        request.debug_drawer->draw_circle(Circle(goal_point, static_cast<float>(draw_radius)),
-                                          draw_color);
-    }
-
     AngleFunction angle_function = get_angle_function(request);
 
     // Call into the sub-object to actually execute the plan.

--- a/soccer/src/soccer/planning/planner/path_target_planner.hpp
+++ b/soccer/src/soccer/planning/planner/path_target_planner.hpp
@@ -27,6 +27,15 @@ public:
     [[nodiscard]] bool is_done() const override;
 
 private:
+    /*
+     * Get the right AngleFunction (for control) from the
+     * PTMC-specific AngleOverride options listed in
+     * motion_command.hpp.
+     *
+     * @param PlanRequest containing a PTMC
+     * @return AngleFunction that corresponds to input
+     * AngleOverride in given PlanRequest
+     */
     [[nodiscard]] static AngleFunction get_angle_function(
         const PlanRequest& request);
 

--- a/soccer/src/soccer/planning/planner/path_target_planner.hpp
+++ b/soccer/src/soccer/planning/planner/path_target_planner.hpp
@@ -26,9 +26,6 @@ public:
 
     [[nodiscard]] bool is_done() const override;
 
-    double draw_radius = kRobotRadius;
-    QColor draw_color = Qt::black;
-
 private:
     [[nodiscard]] static AngleFunction get_angle_function(
         const PlanRequest& request);

--- a/soccer/src/soccer/planning/planner/path_target_planner.hpp
+++ b/soccer/src/soccer/planning/planner/path_target_planner.hpp
@@ -29,12 +29,12 @@ public:
 private:
     /*
      * Get the right AngleFunction (for control) from the
-     * PTMC-specific AngleOverride options listed in
+     * PTMC-specific PathTargetFaceOption options listed in
      * motion_command.hpp.
      *
      * @param PlanRequest containing a PTMC
      * @return AngleFunction that corresponds to input
-     * AngleOverride in given PlanRequest
+     * PathTargetFaceOption in given PlanRequest
      */
     [[nodiscard]] static AngleFunction get_angle_function(
         const PlanRequest& request);

--- a/soccer/src/soccer/planning/planner/path_target_planner.hpp
+++ b/soccer/src/soccer/planning/planner/path_target_planner.hpp
@@ -11,7 +11,7 @@
 
 namespace planning {
 
-class PathTargetPlanner : public PlannerForCommandType<PathTargetCommand> {
+class PathTargetPlanner : public PlannerForCommandType<PathTargetMotionCommand> {
 public:
     PathTargetPlanner() : PlannerForCommandType("PathTargetPlanner") {}
     ~PathTargetPlanner() override = default;

--- a/soccer/src/soccer/planning/planner/pivot_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/pivot_path_planner.cpp
@@ -27,7 +27,7 @@ Trajectory PivotPathPlanner::plan(const PlanRequest& request) {
     std::vector<DynamicObstacle> dynamic_obstacles;
     fill_obstacles(request, &static_obstacles, &dynamic_obstacles, false);
 
-    const auto& command = std::get<PivotCommand>(request.motion_command);
+    const auto& command = std::get<PivotMotionCommand>(request.motion_command);
 
     double radius = pivot::PARAM_radius_multiplier * kRobotRadius;
     auto pivot_point = command.pivot_point;

--- a/soccer/src/soccer/planning/planner/pivot_path_planner.hpp
+++ b/soccer/src/soccer/planning/planner/pivot_path_planner.hpp
@@ -3,10 +3,9 @@
 #include "planner.hpp"
 
 namespace planning {
-class PivotPathPlanner : public PlannerForCommandType<PivotCommand> {
+class PivotPathPlanner : public PlannerForCommandType<PivotMotionCommand> {
 public:
-    PivotPathPlanner()
-        : PlannerForCommandType<PivotCommand>("PivotPathPlanner") {}
+    PivotPathPlanner() : PlannerForCommandType<PivotMotionCommand>("PivotPathPlanner") {}
     ~PivotPathPlanner() override = default;
 
     PivotPathPlanner(PivotPathPlanner&&) noexcept = default;

--- a/soccer/src/soccer/planning/planner/settle_planner.cpp
+++ b/soccer/src/soccer/planning/planner/settle_planner.cpp
@@ -23,7 +23,7 @@ Trajectory SettlePlanner::plan(const PlanRequest& plan_request) {
 
     const RJ::Time cur_time = plan_request.start.stamp;
 
-    auto command = std::get<SettleCommand>(plan_request.motion_command);
+    auto command = std::get<SettleMotionCommand>(plan_request.motion_command);
 
     // The direction we will try and bounce the ball when we dampen it to
     // speed up actions after capture

--- a/soccer/src/soccer/planning/planner/settle_planner.hpp
+++ b/soccer/src/soccer/planning/planner/settle_planner.hpp
@@ -12,7 +12,7 @@ namespace planning {
 /**
  * @brief Planner which tries to move around the ball to intercept it
  */
-class SettlePlanner : public PlannerForCommandType<SettleCommand> {
+class SettlePlanner : public PlannerForCommandType<SettleMotionCommand> {
 public:
     enum class SettlePlannerStates {
         // Moves to the ball path in front of it

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -8,6 +8,7 @@
 #include "instant.hpp"
 #include "planning/planner/collect_planner.hpp"
 #include "planning/planner/escape_obstacles_path_planner.hpp"
+#include "planning/planner/goalie_idle_planner.hpp"
 #include "planning/planner/line_kick_planner.hpp"
 #include "planning/planner/path_target_planner.hpp"
 #include "planning/planner/pivot_path_planner.hpp"
@@ -150,6 +151,7 @@ PlannerForRobot::PlannerForRobot(int robot_id, rclcpp::Node* node,
       debug_draw_{
           node->create_publisher<rj_drawing_msgs::msg::DebugDraw>(viz::topics::kDebugDrawPub, 10),
           fmt::format("planning_{}", robot_id)} {
+    planners_.push_back(std::make_shared<GoalieIdlePlanner>());
     planners_.push_back(std::make_shared<PathTargetPlanner>());
     planners_.push_back(std::make_shared<SettlePlanner>());
     planners_.push_back(std::make_shared<CollectPlanner>());

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -287,9 +287,6 @@ Trajectory PlannerForRobot::plan_for_robot(const planning::PlanRequest& request)
         // If this planner could possibly plan for this command, try to make
         // a plan.
         if (trajectory.empty() && planner->is_applicable(request.motion_command)) {
-            if (request.shell_id == 0) {
-                SPDLOG_INFO("planner applied: {}", planner->name());
-            }
             current_planner_ = planner;
             trajectory = planner->plan(request);
         }

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -314,11 +314,15 @@ Trajectory PlannerForRobot::plan_for_robot(const planning::PlanRequest& request)
         trajectory = Trajectory{{request.start}};
         trajectory.set_debug_text("Error: No Valid Planners");
     } else {
+        // draw robot's desired path
         std::vector<rj_geometry::Point> path;
         std::transform(trajectory.instants().begin(), trajectory.instants().end(),
                        std::back_inserter(path),
                        [](const auto& instant) { return instant.position(); });
         debug_draw_.draw_path(path);
+
+        // draw robot's desired endpoint
+        debug_draw_.draw_circle(rj_geometry::Circle(path.back(), kRobotRadius), Qt::black);
     }
     debug_draw_.draw_shapes(shared_state_->global_obstacles(), QColor(255, 0, 0, 30));
     debug_draw_.draw_shapes(request.virtual_obstacles, QColor(255, 0, 0, 30));

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -9,6 +9,7 @@
 #include "planning/planner/collect_planner.hpp"
 #include "planning/planner/escape_obstacles_path_planner.hpp"
 #include "planning/planner/goalie_idle_planner.hpp"
+#include "planning/planner/intercept_planner.hpp"
 #include "planning/planner/line_kick_planner.hpp"
 #include "planning/planner/path_target_planner.hpp"
 #include "planning/planner/pivot_path_planner.hpp"
@@ -152,6 +153,7 @@ PlannerForRobot::PlannerForRobot(int robot_id, rclcpp::Node* node,
           node->create_publisher<rj_drawing_msgs::msg::DebugDraw>(viz::topics::kDebugDrawPub, 10),
           fmt::format("planning_{}", robot_id)} {
     planners_.push_back(std::make_shared<GoalieIdlePlanner>());
+    planners_.push_back(std::make_shared<InterceptPlanner>());
     planners_.push_back(std::make_shared<PathTargetPlanner>());
     planners_.push_back(std::make_shared<SettlePlanner>());
     planners_.push_back(std::make_shared<CollectPlanner>());
@@ -285,6 +287,9 @@ Trajectory PlannerForRobot::plan_for_robot(const planning::PlanRequest& request)
         // If this planner could possibly plan for this command, try to make
         // a plan.
         if (trajectory.empty() && planner->is_applicable(request.motion_command)) {
+            if (request.shell_id == 0) {
+                SPDLOG_INFO("planner applied: {}", planner->name());
+            }
             current_planner_ = planner;
             trajectory = planner->plan(request);
         }

--- a/soccer/src/soccer/planning/tests/conversion_tests.cpp
+++ b/soccer/src/soccer/planning/tests/conversion_tests.cpp
@@ -10,24 +10,8 @@ using rj_geometry::Twist;
 
 namespace planning {
 
-bool operator==(const LinearMotionInstant& a, const LinearMotionInstant& b) {
-    return a.velocity == b.velocity && a.position == b.position;
-}
-
-bool operator==([[maybe_unused]] const TargetFaceTangent& a,
-                [[maybe_unused]] const TargetFaceTangent& b) {
-    return true;
-}
-bool operator==(const TargetFaceAngle& a, const TargetFaceAngle& b) { return a.target == b.target; }
-bool operator==(const TargetFacePoint& a, const TargetFacePoint& b) {
-    return a.face_point == b.face_point;
-}
-
 bool operator==([[maybe_unused]] const EmptyCommand& a, [[maybe_unused]] const EmptyCommand& b) {
     return true;
-}
-bool operator==(const PathTargetCommand& a, const PathTargetCommand& b) {
-    return a.goal == b.goal && a.angle_override == b.angle_override;
 }
 bool operator==(const WorldVelCommand& a, const WorldVelCommand& b) {
     return a.world_vel == b.world_vel;
@@ -48,10 +32,6 @@ bool operator==(const Trajectory& a, const Trajectory& b) {
     // Don't check debug text, as that doesn't get converted over ROS
     return a.instants() == b.instants() && a.time_created() == b.time_created() &&
            a.angles_valid() == b.angles_valid();
-}
-bool operator==([[maybe_unused]] const GoalieIdleCommand& a,
-                [[maybe_unused]] const GoalieIdleCommand& b) {
-    return true;
 }
 
 namespace testing {

--- a/soccer/src/soccer/planning/tests/conversion_tests.cpp
+++ b/soccer/src/soccer/planning/tests/conversion_tests.cpp
@@ -14,55 +14,60 @@ namespace planning {
 namespace testing {
 
 // NOLINTNEXTLINE
-TEST(RosConversions, EmptyMotionCommand) { test_lossless_convert_cpp_value(EmptyCommand{}); }
+TEST(RosConversions, EmptyMotionCommand) { test_lossless_convert_cpp_value(EmptyMotionCommand{}); }
 
 // NOLINTNEXTLINE
-TEST(RosConversions, PathTargetCommand) {
-    PathTargetCommand path_target{LinearMotionInstant(Point(1.0, 2.0), Point(3.0, 4.0)),
-                                  TargetFacePoint{Point(1.0, 2.0)}};
+TEST(RosConversions, PathTargetMotionCommand) {
+    PathTargetMotionCommand path_target{LinearMotionInstant(Point(1.0, 2.0), Point(3.0, 4.0)),
+                                        TargetFacePoint{Point(1.0, 2.0)}};
     test_lossless_convert_cpp_value(path_target);
 }
 
 // NOLINTNEXTLINE
-TEST(RosConversions, WorldVelCommand) {
-    test_lossless_convert_cpp_value(WorldVelCommand{Point(1.0, 2.0)});
+TEST(RosConversions, WorldVelMotionCommand) {
+    test_lossless_convert_cpp_value(WorldVelMotionCommand{Point(1.0, 2.0)});
 }
 
 // NOLINTNEXTLINE
-TEST(RosConversions, PivotCommand) {
-    test_lossless_convert_cpp_value(PivotCommand{Point(1.0, 2.0), Point(3.0, 4.0)});
+TEST(RosConversions, PivotMotionCommand) {
+    test_lossless_convert_cpp_value(PivotMotionCommand{Point(1.0, 2.0), Point(3.0, 4.0)});
 }
 
 // NOLINTNEXTLINE
-TEST(RosConversions, SettleCommand) {
-    test_lossless_convert_cpp_value(SettleCommand{Point(1.0, 2.0)});
+TEST(RosConversions, SettleMotionCommand) {
+    test_lossless_convert_cpp_value(SettleMotionCommand{Point(1.0, 2.0)});
 }
 
 // NOLINTNEXTLINE
-TEST(RosConversions, CollectCommand) { test_lossless_convert_cpp_value(CollectCommand{}); }
-
-// NOLINTNEXTLINE
-TEST(RosConversions, GoalieIdleCommand) { test_lossless_convert_cpp_value(GoalieIdleCommand{}); }
-
-// NOLINTNEXTLINE
-TEST(RosConversions, LineKickCommand) {
-    test_lossless_convert_cpp_value(LineKickCommand{Point(1.0, 2.0)});
+TEST(RosConversions, CollectMotionCommand) {
+    test_lossless_convert_cpp_value(CollectMotionCommand{});
 }
 
 // NOLINTNEXTLINE
-TEST(RosConversions, InterceptCommand) {
-    test_lossless_convert_cpp_value(InterceptCommand{Point(1.0, 2.0)});
+TEST(RosConversions, GoalieIdleMotionCommand) {
+    test_lossless_convert_cpp_value(GoalieIdleMotionCommand{});
+}
+
+// NOLINTNEXTLINE
+TEST(RosConversions, LineKickMotionCommand) {
+    test_lossless_convert_cpp_value(LineKickMotionCommand{Point(1.0, 2.0)});
+}
+
+// NOLINTNEXTLINE
+TEST(RosConversions, InterceptMotionCommand) {
+    test_lossless_convert_cpp_value(InterceptMotionCommand{Point(1.0, 2.0)});
 }
 
 // NOLINTNEXTLINE
 TEST(RosConversions, MotionCommand) {
-    PathTargetCommand path_target{LinearMotionInstant(Point(1.0, 2.0), Point(3.0, 4.0)),
-                                  TargetFacePoint{Point(1.0, 2.0)}};
-    test_lossless_convert_cpp_value(MotionCommand{EmptyCommand{}});
+    PathTargetMotionCommand path_target{LinearMotionInstant(Point(1.0, 2.0), Point(3.0, 4.0)),
+                                        TargetFacePoint{Point(1.0, 2.0)}};
+    test_lossless_convert_cpp_value(MotionCommand{EmptyMotionCommand{}});
     test_lossless_convert_cpp_value(MotionCommand{path_target});
-    test_lossless_convert_cpp_value(MotionCommand{WorldVelCommand{Point(1.0, 2.0)}});
-    test_lossless_convert_cpp_value(MotionCommand{PivotCommand{Point(1.0, 2.0), Point(3.0, 4.0)}});
-    test_lossless_convert_cpp_value(MotionCommand{InterceptCommand{Point(1.0, 2.0)}});
+    test_lossless_convert_cpp_value(MotionCommand{WorldVelMotionCommand{Point(1.0, 2.0)}});
+    test_lossless_convert_cpp_value(
+        MotionCommand{PivotMotionCommand{Point(1.0, 2.0), Point(3.0, 4.0)}});
+    test_lossless_convert_cpp_value(MotionCommand{InterceptMotionCommand{Point(1.0, 2.0)}});
 }
 
 // NOLINTNEXTLINE

--- a/soccer/src/soccer/planning/tests/conversion_tests.cpp
+++ b/soccer/src/soccer/planning/tests/conversion_tests.cpp
@@ -41,7 +41,9 @@ bool operator==([[maybe_unused]] const CollectCommand& a,
     return true;
 }
 bool operator==(const LineKickCommand& a, const LineKickCommand& b) { return a.target == b.target; }
-bool operator==(const InterceptCommand& a, const InterceptCommand& b) { return true; }
+bool operator==(const InterceptCommand& a, const InterceptCommand& b) {
+    return a.target == b.target;
+}
 bool operator==(const Trajectory& a, const Trajectory& b) {
     // Don't check debug text, as that doesn't get converted over ROS
     return a.instants() == b.instants() && a.time_created() == b.time_created() &&
@@ -91,7 +93,9 @@ TEST(RosConversions, LineKickCommand) {
 }
 
 // NOLINTNEXTLINE
-TEST(RosConversions, InterceptCommand) { test_lossless_convert_cpp_value(InterceptCommand{}); }
+TEST(RosConversions, InterceptCommand) {
+    test_lossless_convert_cpp_value(InterceptCommand{Point(1.0, 2.0)});
+}
 
 // NOLINTNEXTLINE
 TEST(RosConversions, MotionCommand) {
@@ -101,7 +105,7 @@ TEST(RosConversions, MotionCommand) {
     test_lossless_convert_cpp_value(MotionCommand{path_target});
     test_lossless_convert_cpp_value(MotionCommand{WorldVelCommand{Point(1.0, 2.0)}});
     test_lossless_convert_cpp_value(MotionCommand{PivotCommand{Point(1.0, 2.0), Point(3.0, 4.0)}});
-    test_lossless_convert_cpp_value(MotionCommand{InterceptCommand{}});
+    test_lossless_convert_cpp_value(MotionCommand{InterceptCommand{Point(1.0, 2.0)}});
 }
 
 // NOLINTNEXTLINE

--- a/soccer/src/soccer/planning/tests/conversion_tests.cpp
+++ b/soccer/src/soccer/planning/tests/conversion_tests.cpp
@@ -41,9 +41,7 @@ bool operator==([[maybe_unused]] const CollectCommand& a,
     return true;
 }
 bool operator==(const LineKickCommand& a, const LineKickCommand& b) { return a.target == b.target; }
-bool operator==(const InterceptCommand& a, const InterceptCommand& b) {
-    return a.target == b.target;
-}
+bool operator==(const InterceptCommand& a, const InterceptCommand& b) { return true; }
 bool operator==(const Trajectory& a, const Trajectory& b) {
     // Don't check debug text, as that doesn't get converted over ROS
     return a.instants() == b.instants() && a.time_created() == b.time_created() &&
@@ -93,9 +91,7 @@ TEST(RosConversions, LineKickCommand) {
 }
 
 // NOLINTNEXTLINE
-TEST(RosConversions, InterceptCommand) {
-    test_lossless_convert_cpp_value(InterceptCommand{Point(1.0, 2.0)});
-}
+TEST(RosConversions, InterceptCommand) { test_lossless_convert_cpp_value(InterceptCommand{}); }
 
 // NOLINTNEXTLINE
 TEST(RosConversions, MotionCommand) {
@@ -105,7 +101,7 @@ TEST(RosConversions, MotionCommand) {
     test_lossless_convert_cpp_value(MotionCommand{path_target});
     test_lossless_convert_cpp_value(MotionCommand{WorldVelCommand{Point(1.0, 2.0)}});
     test_lossless_convert_cpp_value(MotionCommand{PivotCommand{Point(1.0, 2.0), Point(3.0, 4.0)}});
-    test_lossless_convert_cpp_value(MotionCommand{InterceptCommand{Point(1.0, 2.0)}});
+    test_lossless_convert_cpp_value(MotionCommand{InterceptCommand{}});
 }
 
 // NOLINTNEXTLINE

--- a/soccer/src/soccer/planning/tests/conversion_tests.cpp
+++ b/soccer/src/soccer/planning/tests/conversion_tests.cpp
@@ -49,6 +49,10 @@ bool operator==(const Trajectory& a, const Trajectory& b) {
     return a.instants() == b.instants() && a.time_created() == b.time_created() &&
            a.angles_valid() == b.angles_valid();
 }
+bool operator==([[maybe_unused]] const GoalieIdleCommand& a,
+                [[maybe_unused]] const GoalieIdleCommand& b) {
+    return true;
+}
 
 namespace testing {
 
@@ -79,6 +83,9 @@ TEST(RosConversions, SettleCommand) {
 
 // NOLINTNEXTLINE
 TEST(RosConversions, CollectCommand) { test_lossless_convert_cpp_value(CollectCommand{}); }
+
+// NOLINTNEXTLINE
+TEST(RosConversions, GoalieIdleCommand) { test_lossless_convert_cpp_value(GoalieIdleCommand{}); }
 
 // NOLINTNEXTLINE
 TEST(RosConversions, LineKickCommand) {

--- a/soccer/src/soccer/planning/tests/conversion_tests.cpp
+++ b/soccer/src/soccer/planning/tests/conversion_tests.cpp
@@ -3,36 +3,13 @@
 #include <rj_convert/testing/ros_convert_testing.hpp>
 
 #include "planning/planner/motion_command.hpp"
+#include "planning/trajectory.hpp"
 
 using rj_geometry::Point;
 using rj_geometry::Pose;
 using rj_geometry::Twist;
 
 namespace planning {
-
-bool operator==([[maybe_unused]] const EmptyCommand& a, [[maybe_unused]] const EmptyCommand& b) {
-    return true;
-}
-bool operator==(const WorldVelCommand& a, const WorldVelCommand& b) {
-    return a.world_vel == b.world_vel;
-}
-bool operator==(const PivotCommand& a, const PivotCommand& b) {
-    return a.pivot_target == b.pivot_target && a.pivot_point == b.pivot_point;
-}
-bool operator==(const SettleCommand& a, const SettleCommand& b) { return a.target == b.target; }
-bool operator==([[maybe_unused]] const CollectCommand& a,
-                [[maybe_unused]] const CollectCommand& b) {
-    return true;
-}
-bool operator==(const LineKickCommand& a, const LineKickCommand& b) { return a.target == b.target; }
-bool operator==(const InterceptCommand& a, const InterceptCommand& b) {
-    return a.target == b.target;
-}
-bool operator==(const Trajectory& a, const Trajectory& b) {
-    // Don't check debug text, as that doesn't get converted over ROS
-    return a.instants() == b.instants() && a.time_created() == b.time_created() &&
-           a.angles_valid() == b.angles_valid();
-}
 
 namespace testing {
 

--- a/soccer/src/soccer/planning/tests/conversion_tests.cpp
+++ b/soccer/src/soccer/planning/tests/conversion_tests.cpp
@@ -19,7 +19,7 @@ TEST(RosConversions, EmptyMotionCommand) { test_lossless_convert_cpp_value(Empty
 // NOLINTNEXTLINE
 TEST(RosConversions, PathTargetMotionCommand) {
     PathTargetMotionCommand path_target{LinearMotionInstant(Point(1.0, 2.0), Point(3.0, 4.0)),
-                                        TargetFacePoint{Point(1.0, 2.0)}};
+                                        FacePoint{Point(1.0, 2.0)}};
     test_lossless_convert_cpp_value(path_target);
 }
 
@@ -61,7 +61,7 @@ TEST(RosConversions, InterceptMotionCommand) {
 // NOLINTNEXTLINE
 TEST(RosConversions, MotionCommand) {
     PathTargetMotionCommand path_target{LinearMotionInstant(Point(1.0, 2.0), Point(3.0, 4.0)),
-                                        TargetFacePoint{Point(1.0, 2.0)}};
+                                        FacePoint{Point(1.0, 2.0)}};
     test_lossless_convert_cpp_value(MotionCommand{EmptyMotionCommand{}});
     test_lossless_convert_cpp_value(MotionCommand{path_target});
     test_lossless_convert_cpp_value(MotionCommand{WorldVelMotionCommand{Point(1.0, 2.0)}});

--- a/soccer/src/soccer/planning/tests/planner_test.cpp
+++ b/soccer/src/soccer/planning/tests/planner_test.cpp
@@ -48,7 +48,7 @@ TEST(Planning, path_target_random) {
 
         LinearMotionInstant goal = random_instant(&gen).linear_motion();
         PlanRequest request{start,
-                            PathTargetCommand{goal},
+                            PathTargetMotionCommand{goal},
                             RobotConstraints{},
                             obstacles,
                             {},
@@ -88,7 +88,7 @@ TEST(Planning, collect_basic) {
     world_state.ball.velocity = Point{0, 0};
     world_state.ball.timestamp = RJ::now();
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
-                        CollectCommand{},
+                        CollectMotionCommand{},
                         RobotConstraints{},
                         ShapeSet{},
                         {},
@@ -110,7 +110,7 @@ TEST(Planning, collect_obstructed) {
     ShapeSet obstacles;
     obstacles.add(std::make_shared<Circle>(Point{.5, .5}, .2));
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
-                        CollectCommand{},
+                        CollectMotionCommand{},
                         RobotConstraints{},
                         obstacles,
                         {},
@@ -135,7 +135,7 @@ TEST(Planning, collect_pointless_obs) {
     obstacles.add(std::make_shared<Circle>(Point{-2, 3}, .2));
     obstacles.add(std::make_shared<Circle>(Point{0, 5}, .2));
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
-                        CollectCommand{},
+                        CollectMotionCommand{},
                         RobotConstraints{},
                         obstacles,
                         {},
@@ -157,7 +157,7 @@ TEST(Planning, collect_moving_ball_quick) {
     ShapeSet obstacles;
     obstacles.add(std::make_shared<Circle>(Point{0, .5}, .2));
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
-                        CollectCommand{},
+                        CollectMotionCommand{},
                         RobotConstraints{},
                         obstacles,
                         {},
@@ -179,7 +179,7 @@ TEST(Planning, collect_moving_ball_slow) {
     ShapeSet obstacles;
     obstacles.add(std::make_shared<Circle>(Point{-0.5, .5}, .2));
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
-                        CollectCommand{},
+                        CollectMotionCommand{},
                         RobotConstraints{},
                         obstacles,
                         {},
@@ -201,7 +201,7 @@ TEST(Planning, collect_moving_ball_slow_2) {
     ShapeSet obstacles;
     obstacles.add(std::make_shared<Circle>(Point{0, .5}, .2));
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
-                        CollectCommand{},
+                        CollectMotionCommand{},
                         RobotConstraints{},
                         obstacles,
                         {},
@@ -235,7 +235,7 @@ TEST(Planning, collect_random) {
                 .2));
         }
         PlanRequest request{RobotInstant{{}, {}, RJ::now()},
-                            CollectCommand{},
+                            CollectMotionCommand{},
                             RobotConstraints{},
                             obstacles,
                             {},
@@ -266,7 +266,7 @@ TEST(Planning, settle_basic) {
     ShapeSet obstacles;
     obstacles.add(std::make_shared<Circle>(Point{.5, .5}, .2));
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
-                        SettleCommand{},
+                        SettleMotionCommand{},
                         RobotConstraints{},
                         obstacles,
                         {},
@@ -290,7 +290,7 @@ TEST(Planning, settle_pointless_obs) {
     ShapeSet obstacles;
     obstacles.add(std::make_shared<Circle>(Point{-1, 1.0}, .2));
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
-                        SettleCommand{},
+                        SettleMotionCommand{},
                         RobotConstraints{},
                         obstacles,
                         {},
@@ -325,7 +325,7 @@ TEST(Planning, settle_random) {
                 .2));
         }
         PlanRequest request{RobotInstant{{}, {}, RJ::now()},
-                            SettleCommand{},
+                            SettleMotionCommand{},
                             RobotConstraints{},
                             obstacles,
                             {},

--- a/soccer/src/soccer/planning/trajectory.cpp
+++ b/soccer/src/soccer/planning/trajectory.cpp
@@ -344,4 +344,10 @@ void Trajectory::Cursor::next_knot() {
     }
 }
 
+bool operator==(const Trajectory& a, const Trajectory& b) {
+    // Don't check debug text, as that doesn't get converted over ROS
+    return a.instants() == b.instants() && a.time_created() == b.time_created() &&
+           a.angles_valid() == b.angles_valid();
+}
+
 }  // namespace planning

--- a/soccer/src/soccer/planning/trajectory.hpp
+++ b/soccer/src/soccer/planning/trajectory.hpp
@@ -447,6 +447,8 @@ private:
     bool has_angle_profile_{false};
 };
 
+bool operator==(const Trajectory& a, const Trajectory& b);
+
 }  // namespace planning
 
 namespace rj_convert {

--- a/soccer/src/soccer/robot_intent.cpp
+++ b/soccer/src/soccer/robot_intent.cpp
@@ -1,25 +1,8 @@
 #include "robot_intent.hpp"
 
 bool operator==(const RobotIntent& r1, const RobotIntent& r2) {
-    SPDLOG_ERROR("deprecated custom struct RI operator called!");
-    // if motion_command is a PathTargetCommand
-    // TODO: surely there is a way to iterate over all types and just do this?
-    if (std::holds_alternative<planning::PathTargetCommand>(r1.motion_command) &&
-        std::holds_alternative<planning::PathTargetCommand>(r2.motion_command)) {
-        return std::get<planning::PathTargetCommand>(r1.motion_command) ==
-               std::get<planning::PathTargetCommand>(r2.motion_command);
-        /* return true; */
-    }
-
-    if (std::holds_alternative<planning::GoalieIdleCommand>(r1.motion_command) &&
-        std::holds_alternative<planning::GoalieIdleCommand>(r2.motion_command)) {
-        return std::get<planning::GoalieIdleCommand>(r1.motion_command) ==
-               std::get<planning::GoalieIdleCommand>(r2.motion_command);
-        /* return true; */
-    }
-
-    // default to address equality
-    return &r1 == &r2;
+    // matches if robot_ids match and motion_commands match
+    return (r1.robot_id == r2.robot_id) && (r1.motion_command == r2.motion_command);
 }
 
 bool operator!=(const RobotIntent& r1, const RobotIntent& r2) { return !(r1 == r2); }

--- a/soccer/src/soccer/robot_intent.cpp
+++ b/soccer/src/soccer/robot_intent.cpp
@@ -1,0 +1,24 @@
+#include "robot_intent.hpp"
+
+bool operator==(const RobotIntent& r1, const RobotIntent& r2) {
+    SPDLOG_ERROR("deprecated custom struct RI operator called!");
+    // if motion_command is a PathTargetCommand
+    // TODO: surely there is a way to iterate over all types and just do this?
+    if (std::holds_alternative<planning::PathTargetCommand>(r1.motion_command) &&
+        std::holds_alternative<planning::PathTargetCommand>(r2.motion_command)) {
+        // TODO: fix this? conversion_tests.cpp doesn't seem to be resolving this operator
+        /* return std::get<planning::PathTargetCommand>(r1.motion_command) == */
+        /*        std::get<planning::PathTargetCommand>(r2.motion_command); */
+        return true;
+    }
+
+    if (std::holds_alternative<planning::GoalieIdleCommand>(r1.motion_command) &&
+        std::holds_alternative<planning::GoalieIdleCommand>(r2.motion_command)) {
+        return true;
+    }
+
+    // default to address equality
+    return &r1 == &r2;
+}
+
+bool operator!=(const RobotIntent& r1, const RobotIntent& r2) { return !(r1 == r2); }

--- a/soccer/src/soccer/robot_intent.cpp
+++ b/soccer/src/soccer/robot_intent.cpp
@@ -2,6 +2,7 @@
 
 bool operator==(const RobotIntent& r1, const RobotIntent& r2) {
     // matches if robot_ids match and motion_commands match
+    // ignores all other fields! (unimportant)
     return (r1.robot_id == r2.robot_id) && (r1.motion_command == r2.motion_command);
 }
 

--- a/soccer/src/soccer/robot_intent.cpp
+++ b/soccer/src/soccer/robot_intent.cpp
@@ -6,15 +6,16 @@ bool operator==(const RobotIntent& r1, const RobotIntent& r2) {
     // TODO: surely there is a way to iterate over all types and just do this?
     if (std::holds_alternative<planning::PathTargetCommand>(r1.motion_command) &&
         std::holds_alternative<planning::PathTargetCommand>(r2.motion_command)) {
-        // TODO: fix this? conversion_tests.cpp doesn't seem to be resolving this operator
-        /* return std::get<planning::PathTargetCommand>(r1.motion_command) == */
-        /*        std::get<planning::PathTargetCommand>(r2.motion_command); */
-        return true;
+        return std::get<planning::PathTargetCommand>(r1.motion_command) ==
+               std::get<planning::PathTargetCommand>(r2.motion_command);
+        /* return true; */
     }
 
     if (std::holds_alternative<planning::GoalieIdleCommand>(r1.motion_command) &&
         std::holds_alternative<planning::GoalieIdleCommand>(r2.motion_command)) {
-        return true;
+        return std::get<planning::GoalieIdleCommand>(r1.motion_command) ==
+               std::get<planning::GoalieIdleCommand>(r2.motion_command);
+        /* return true; */
     }
 
     // default to address equality

--- a/soccer/src/soccer/robot_intent.hpp
+++ b/soccer/src/soccer/robot_intent.hpp
@@ -37,7 +37,8 @@ struct RobotIntent {
         if (std::holds_alternative<planning::PathTargetCommand>(motion_command)) {
             return std::get<planning::PathTargetCommand>(motion_command) ==
                    std::get<planning::PathTargetCommand>(r.motion_command);
-        } else if (std::holds_alternative<planning::GoalieIdleCommand>(motion_command)) {
+        }
+        if (std::holds_alternative<planning::GoalieIdleCommand>(motion_command)) {
             // if both are GoalieIdleCommands, they are equal (takes no fields)
             return std::holds_alternative<planning::GoalieIdleCommand>(r.motion_command);
         }

--- a/soccer/src/soccer/robot_intent.hpp
+++ b/soccer/src/soccer/robot_intent.hpp
@@ -16,6 +16,10 @@ struct RobotIntent {
     enum class TriggerMode { STAND_DOWN, IMMEDIATE, ON_BREAK_BEAM };
 
     planning::MotionCommand motion_command;
+    // useful for introspection
+    // (since MotionCommand is an std::variant, it is hard to figure out which
+    // specific type is being used)
+    std::string motion_command_name;
 
     /// Set of obstacles added by plays
     rj_geometry::ShapeSet local_obstacles;
@@ -44,6 +48,7 @@ struct RosConverter<RobotIntent, rj_msgs::msg::RobotIntent> {
         return rj_msgs::build<rj_msgs::msg::RobotIntent>()
             .robot_id(static_cast<uint8_t>(from.robot_id))
             .motion_command(convert_to_ros(from.motion_command))
+            .motion_command_name(static_cast<std::string>(from.motion_command_name))
             .local_obstacles(convert_to_ros(from.local_obstacles))
             .shoot_mode(static_cast<uint8_t>(from.shoot_mode))
             .trigger_mode(static_cast<uint8_t>(from.trigger_mode))
@@ -57,6 +62,7 @@ struct RosConverter<RobotIntent, rj_msgs::msg::RobotIntent> {
         RobotIntent result;
         result.robot_id = static_cast<uint8_t>(from.robot_id);
         result.motion_command = convert_from_ros(from.motion_command);
+        result.motion_command_name = static_cast<std::string>(from.motion_command_name);
         result.local_obstacles = convert_from_ros(from.local_obstacles);
         result.shoot_mode = static_cast<RobotIntent::ShootMode>(from.shoot_mode);
         result.trigger_mode = static_cast<RobotIntent::TriggerMode>(from.trigger_mode);

--- a/soccer/src/soccer/robot_intent.hpp
+++ b/soccer/src/soccer/robot_intent.hpp
@@ -28,28 +28,13 @@ struct RobotIntent {
     bool is_active = false;
 
     int8_t priority = 0;
-
-    /*
-     * @brief overloads == to allow comparison of two RobotIntents with ==
-     */
-    bool operator==(const RobotIntent r) {
-        // if motion_command is a PathTargetCommand
-        if (std::holds_alternative<planning::PathTargetCommand>(motion_command)) {
-            return std::get<planning::PathTargetCommand>(motion_command) ==
-                   std::get<planning::PathTargetCommand>(r.motion_command);
-        }
-        if (std::holds_alternative<planning::GoalieIdleCommand>(motion_command)) {
-            // if both are GoalieIdleCommands, they are equal (takes no fields)
-            return std::holds_alternative<planning::GoalieIdleCommand>(r.motion_command);
-        }
-
-        // TODO(Kevin): redesign this, there are too many equality checks
-        // needed in current state
-
-        // default to address equality
-        return this == &r;
-    }
 };
+
+/*
+ * @brief overload equality operators to allow RobotIntent==RobotIntent
+ */
+bool operator==(const RobotIntent& r1, const RobotIntent& r2);
+bool operator!=(const RobotIntent& r1, const RobotIntent& r2);
 
 namespace rj_convert {
 

--- a/soccer/src/soccer/robot_intent.hpp
+++ b/soccer/src/soccer/robot_intent.hpp
@@ -37,9 +37,13 @@ struct RobotIntent {
         if (std::holds_alternative<planning::PathTargetCommand>(motion_command)) {
             return std::get<planning::PathTargetCommand>(motion_command) ==
                    std::get<planning::PathTargetCommand>(r.motion_command);
+        } else if (std::holds_alternative<planning::GoalieIdleCommand>(motion_command)) {
+            // if both are GoalieIdleCommands, they are equal (takes no fields)
+            return std::holds_alternative<planning::GoalieIdleCommand>(r.motion_command);
         }
-        // TODO(Kevin): fill in other motion command types (and maybe think of a
-        // better design?)
+
+        // TODO(Kevin): redesign this, there are too many equality checks
+        // needed in current state
 
         // default to address equality
         return this == &r;

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -68,19 +68,20 @@ void AgentActionClient::get_task() {
 
         // note that this comparison uses the ROS built-in msg type
         // so any custom operator== overloads written don't apply
+        // TODO(Kevin): fix this by making Positions return RobotIntent structs, not msgs
         if (task != last_task_) {
-            if (robot_id_ == 0) {
-                SPDLOG_INFO("sending new task {}", task.motion_command.name);
-            }
+            /* if (robot_id_ == 0) { */
+            /*     SPDLOG_INFO("sending new task {}", task.motion_command.name); */
+            /* } */
             last_task_ = task;
             send_new_goal();
         } else {
-            if (robot_id_ == 0) {
-                SPDLOG_INFO("NOT sending new task {}", task.motion_command.name);
-            }
+            /* if (robot_id_ == 0) { */
+            /*     SPDLOG_INFO("NOT sending new task {}", task.motion_command.name); */
+            /* } */
         }
     } else {
-        SPDLOG_INFO("no new task");
+        /* SPDLOG_INFO("no new task"); */
     }
 }
 

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -111,21 +111,21 @@ void AgentActionClient::goal_response_callback(
     std::shared_future<GoalHandleRobotMove::SharedPtr> future) {
     auto goal_handle = future.get();
     if (!goal_handle) {
-        current_position_->goal_canceled_ = true;
+        current_position_->set_goal_canceled();
     }
 }
 
 void AgentActionClient::feedback_callback(
     GoalHandleRobotMove::SharedPtr, const std::shared_ptr<const RobotMove::Feedback> feedback) {
     double time_left = rj_convert::convert_from_ros(feedback->time_left).count();
-    current_position_->time_left_ = time_left;
+    current_position_->set_time_left(time_left);
 }
 
 void AgentActionClient::result_callback(const GoalHandleRobotMove::WrappedResult& result) {
     switch (result.code) {
         case rclcpp_action::ResultCode::SUCCEEDED:
             // TODO: handle other return codes
-            current_position_->is_done_ = true;
+            current_position_->set_is_done();
             break;
         case rclcpp_action::ResultCode::ABORTED:
             return;

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -69,20 +69,10 @@ void AgentActionClient::get_task() {
         // note that because these are our RobotIntent structs, this comparison
         // uses our custom struct overloads
         if (task != last_task_) {
-            if (robot_id_ == 0) {
-                /* SPDLOG_INFO("sending new task {}", task.motion_command.name); */
-                SPDLOG_INFO("sending new task");
-            }
+            SPDLOG_INFO("robot {} has new task '{}'", robot_id_, task.motion_command_name);
             last_task_ = task;
             send_new_goal();
-        } else {
-            if (robot_id_ == 0) {
-                /* SPDLOG_INFO("NOT sending new task {}", task.motion_command.name); */
-                SPDLOG_INFO("NOT sending new task");
-            }
         }
-    } else {
-        SPDLOG_INFO("no new task");
     }
 }
 

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -62,11 +62,20 @@ void AgentActionClient::get_task() {
         }
     }
 
-    auto task = current_position_->get_task();
+    rj_msgs::msg::RobotIntent task = current_position_->get_task();
+
+    // note that this comparison uses the ROS built-in msg type
+    // so any custom operator== overloads written don't apply
     if (task != last_task_) {
-        /* SPDLOG_INFO("sending new task"); */
+        if (robot_id_ == 0) {
+            SPDLOG_INFO("sending new task {}", task.motion_command.name);
+        }
         last_task_ = task;
         send_new_goal();
+    } else {
+        if (robot_id_ == 0) {
+            SPDLOG_INFO("NOT sending new task {}", task.motion_command.name);
+        }
     }
 }
 

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -64,6 +64,7 @@ void AgentActionClient::get_task() {
 
     auto task = current_position_->get_task();
     if (task != last_task_) {
+        /* SPDLOG_INFO("sending new task"); */
         last_task_ = task;
         send_new_goal();
     }

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -62,20 +62,25 @@ void AgentActionClient::get_task() {
         }
     }
 
-    rj_msgs::msg::RobotIntent task = current_position_->get_task();
+    auto optional_task = current_position_->get_task();
+    if (optional_task.has_value()) {
+        rj_msgs::msg::RobotIntent task = optional_task.value();
 
-    // note that this comparison uses the ROS built-in msg type
-    // so any custom operator== overloads written don't apply
-    if (task != last_task_) {
-        if (robot_id_ == 0) {
-            SPDLOG_INFO("sending new task {}", task.motion_command.name);
+        // note that this comparison uses the ROS built-in msg type
+        // so any custom operator== overloads written don't apply
+        if (task != last_task_) {
+            if (robot_id_ == 0) {
+                SPDLOG_INFO("sending new task {}", task.motion_command.name);
+            }
+            last_task_ = task;
+            send_new_goal();
+        } else {
+            if (robot_id_ == 0) {
+                SPDLOG_INFO("NOT sending new task {}", task.motion_command.name);
+            }
         }
-        last_task_ = task;
-        send_new_goal();
     } else {
-        if (robot_id_ == 0) {
-            SPDLOG_INFO("NOT sending new task {}", task.motion_command.name);
-        }
+        SPDLOG_INFO("no new task");
     }
 }
 

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -64,24 +64,25 @@ void AgentActionClient::get_task() {
 
     auto optional_task = current_position_->get_task();
     if (optional_task.has_value()) {
-        rj_msgs::msg::RobotIntent task = optional_task.value();
+        RobotIntent task = optional_task.value();
 
-        // note that this comparison uses the ROS built-in msg type
-        // so any custom operator== overloads written don't apply
-        // TODO(Kevin): fix this by making Positions return RobotIntent structs, not msgs
+        // note that because these are our RobotIntent structs, this comparison
+        // uses our custom struct overloads
         if (task != last_task_) {
-            /* if (robot_id_ == 0) { */
-            /*     SPDLOG_INFO("sending new task {}", task.motion_command.name); */
-            /* } */
+            if (robot_id_ == 0) {
+                /* SPDLOG_INFO("sending new task {}", task.motion_command.name); */
+                SPDLOG_INFO("sending new task");
+            }
             last_task_ = task;
             send_new_goal();
         } else {
-            /* if (robot_id_ == 0) { */
-            /*     SPDLOG_INFO("NOT sending new task {}", task.motion_command.name); */
-            /* } */
+            if (robot_id_ == 0) {
+                /* SPDLOG_INFO("NOT sending new task {}", task.motion_command.name); */
+                SPDLOG_INFO("NOT sending new task");
+            }
         }
     } else {
-        /* SPDLOG_INFO("no new task"); */
+        SPDLOG_INFO("no new task");
     }
 }
 
@@ -94,7 +95,8 @@ void AgentActionClient::send_new_goal() {
     }
 
     auto goal_msg = RobotMove::Goal();
-    goal_msg.robot_intent = last_task_;
+    // must convert to ROS msg form in order to be sent across ROS nodes
+    goal_msg.robot_intent = rj_convert::convert_to_ros(last_task_);
 
     auto send_goal_options = rclcpp_action::Client<RobotMove>::SendGoalOptions();
     send_goal_options.goal_response_callback =

--- a/soccer/src/soccer/strategy/agent/agent_action_client.hpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.hpp
@@ -13,9 +13,11 @@
 #include <rj_msgs/msg/world_state.hpp>
 #include <rj_utils/logging.hpp>
 
+#include "planning/planner/motion_command.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "rj_msgs/action/robot_move.hpp"
+#include "robot_intent.hpp"
 #include "strategy/agent/position/defense.hpp"
 #include "strategy/agent/position/goalie.hpp"
 #include "strategy/agent/position/offense.hpp"
@@ -68,7 +70,9 @@ private:
      */
     void get_task();
     rclcpp::TimerBase::SharedPtr get_task_timer_;
-    rj_msgs::msg::RobotIntent last_task_;
+    // note that this is our RobotIntent struct (robot_intent.hpp), not a
+    // pre-generated ROS msg type
+    RobotIntent last_task_;
 
     // const because should never be changed, but initializer list will allow
     // us to set this once initially

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -4,7 +4,7 @@ namespace strategy {
 
 Defense::Defense(int r_id) : Position(r_id) { position_name_ = "Defense"; }
 
-rj_msgs::msg::RobotIntent Defense::get_task() {
+std::optional<rj_msgs::msg::RobotIntent> Defense::get_task() {
     // init an intent with our robot id
     rj_msgs::msg::RobotIntent intent;
     intent.robot_id = robot_id_;

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -4,16 +4,7 @@ namespace strategy {
 
 Defense::Defense(int r_id) : Position(r_id) { position_name_ = "Defense"; }
 
-std::optional<rj_msgs::msg::RobotIntent> Defense::get_task() {
-    // init an intent with our robot id
-    rj_msgs::msg::RobotIntent intent;
-    intent.robot_id = robot_id_;
-
-    // if world_state invalid, return empty_intent
-    if (!assert_world_state_valid()) {
-        return get_empty_intent();
-    }
-
+std::optional<RobotIntent> Defense::derived_get_task(RobotIntent intent) {
     if (check_is_done()) {
         // toggle move pts
         move_ct_++;
@@ -23,20 +14,26 @@ std::optional<rj_msgs::msg::RobotIntent> Defense::get_task() {
     WorldState* world_state = this->world_state();
 
     // oscillate along horizontal line (temp)
-    auto ptmc = rj_msgs::msg::PathTargetMotionCommand{};
+    auto ptc = planning::PathTargetCommand{};
     double x = -3.0;
     if (move_ct_ % 2 == 1) {
         x = 3.0;
     }
+
     rj_geometry::Point pt{x, 3.0};
-    ptmc.target.position = rj_convert::convert_to_ros(pt);
+    ptc.goal.position = pt;
+
+    rj_geometry::Point vel{0.0, 0.0};
+    ptc.goal.velocity = vel;
 
     rj_geometry::Point ball_pos = world_state->ball.position;
-    auto face_pt = ball_pos;
-    ptmc.override_face_point = {rj_convert::convert_to_ros(face_pt)};
-    ptmc.ignore_ball = false;
-    intent.motion_command.path_target_command = {ptmc};
+    planning::TargetFacePoint face_pt = planning::TargetFacePoint{};
+    face_pt.face_point = ball_pos;
 
+    ptc.angle_override = face_pt;
+    ptc.ignore_ball = false;
+
+    intent.motion_command = ptc;
     return intent;
 }
 

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -14,26 +14,24 @@ std::optional<RobotIntent> Defense::derived_get_task(RobotIntent intent) {
     WorldState* world_state = this->world_state();
 
     // oscillate along horizontal line (temp)
-    auto ptc = planning::PathTargetCommand{};
     double x = -3.0;
     if (move_ct_ % 2 == 1) {
         x = 3.0;
     }
+    rj_geometry::Point target_pt{x, 3.0};
 
-    rj_geometry::Point pt{x, 3.0};
-    ptc.goal.position = pt;
+    // stop at end of path
+    rj_geometry::Point target_vel{0.0, 0.0};
 
-    rj_geometry::Point vel{0.0, 0.0};
-    ptc.goal.velocity = vel;
+    // face ball
+    planning::AngleOverride angle_override = planning::TargetFacePoint{world_state->ball.position};
 
-    rj_geometry::Point ball_pos = world_state->ball.position;
-    planning::TargetFacePoint face_pt = planning::TargetFacePoint{};
-    face_pt.face_point = ball_pos;
+    // avoid ball
+    bool ignore_ball = false;
 
-    ptc.angle_override = face_pt;
-    ptc.ignore_ball = false;
-
-    intent.motion_command = ptc;
+    planning::LinearMotionInstant goal{target_pt, target_vel};
+    intent.motion_command = planning::PathTargetCommand{goal, angle_override, ignore_ball};
+    intent.motion_command_name = "path_target";
     return intent;
 }
 

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -24,7 +24,7 @@ std::optional<RobotIntent> Defense::derived_get_task(RobotIntent intent) {
     rj_geometry::Point target_vel{0.0, 0.0};
 
     // face ball
-    planning::AngleOverride angle_override = planning::TargetFacePoint{world_state->ball.position};
+    planning::AngleOverride angle_override = planning::TargetFaceBall{};
 
     // avoid ball
     bool ignore_ball = false;

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -24,13 +24,13 @@ std::optional<RobotIntent> Defense::derived_get_task(RobotIntent intent) {
     rj_geometry::Point target_vel{0.0, 0.0};
 
     // face ball
-    planning::AngleOverride angle_override = planning::TargetFaceBall{};
+    planning::PathTargetFaceOption face_option = planning::FaceBall{};
 
     // avoid ball
     bool ignore_ball = false;
 
     planning::LinearMotionInstant goal{target_pt, target_vel};
-    intent.motion_command = planning::PathTargetMotionCommand{goal, angle_override, ignore_ball};
+    intent.motion_command = planning::PathTargetMotionCommand{goal, face_option, ignore_ball};
     intent.motion_command_name = "path_target";
     return intent;
 }

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -30,7 +30,7 @@ std::optional<RobotIntent> Defense::derived_get_task(RobotIntent intent) {
     bool ignore_ball = false;
 
     planning::LinearMotionInstant goal{target_pt, target_vel};
-    intent.motion_command = planning::PathTargetCommand{goal, angle_override, ignore_ball};
+    intent.motion_command = planning::PathTargetMotionCommand{goal, angle_override, ignore_ball};
     intent.motion_command_name = "path_target";
     return intent;
 }

--- a/soccer/src/soccer/strategy/agent/position/defense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.hpp
@@ -4,6 +4,7 @@
 
 #include <spdlog/spdlog.h>
 
+#include <planning/instant.hpp>
 #include <rj_common/time.hpp>
 #include <rj_geometry/geometry_conversions.hpp>
 #include <rj_geometry/point.hpp>

--- a/soccer/src/soccer/strategy/agent/position/defense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.hpp
@@ -2,18 +2,18 @@
 
 #include <cmath>
 
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
 #include <spdlog/spdlog.h>
 
-#include <planning/instant.hpp>
-#include <rj_common/time.hpp>
-#include <rj_geometry/geometry_conversions.hpp>
-#include <rj_geometry/point.hpp>
+#include <rj_msgs/action/robot_move.hpp>
 #include <rj_msgs/msg/empty_motion_command.hpp>
 
+#include "planning/instant.hpp"
 #include "position.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp_action/rclcpp_action.hpp"
-#include "rj_msgs/action/robot_move.hpp"
+#include "rj_common/time.hpp"
+#include "rj_geometry/geometry_conversions.hpp"
+#include "rj_geometry/point.hpp"
 
 namespace strategy {
 

--- a/soccer/src/soccer/strategy/agent/position/defense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.hpp
@@ -25,10 +25,10 @@ public:
     Defense(int r_id);
     ~Defense() override = default;
 
-    std::optional<rj_msgs::msg::RobotIntent> get_task() override;
-
 private:
     int move_ct_ = 0;
+
+    std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/defense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.hpp
@@ -25,7 +25,7 @@ public:
     Defense(int r_id);
     ~Defense() override = default;
 
-    rj_msgs::msg::RobotIntent get_task() override;
+    std::optional<rj_msgs::msg::RobotIntent> get_task() override;
 
 private:
     int move_ct_ = 0;

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -5,30 +5,20 @@ namespace strategy {
 // TODO(Kevin): lock Goalie id to id given by the ref
 Goalie::Goalie(int r_id) : Position(r_id) { position_name_ = "Goalie"; }
 
-std::optional<rj_msgs::msg::RobotIntent> Goalie::get_task() {
-    // init an intent with our robot id
-    rj_msgs::msg::RobotIntent intent;
-    intent.robot_id = robot_id_;
-
-    // if world_state invalid, return empty_intent
-    if (!assert_world_state_valid()) {
-        return get_empty_intent();
-    }
-
-    WorldState* world_state = this->world_state();  // thread-safe getter
+std::optional<RobotIntent> Goalie::derived_get_task(RobotIntent intent) {
+    WorldState* world_state = this->world_state();
     if (shot_on_goal_detected(world_state)) {
         // TODO(Kevin): fix intercept planner's is_done, then add in logic to
         // clear/pass ball once done intercepting
-        auto intercept_mc = rj_msgs::msg::InterceptMotionCommand{};
-        intercept_mc.target.x = 0.0;
-        intercept_mc.target.y = 0.1;
-        intent.motion_command.intercept_command = {intercept_mc};
-        intent.motion_command.name = "intercept";
+        auto intercept_cmd = planning::InterceptCommand{};
+        intercept_cmd.target = rj_geometry::Point{0.0, 0.1};
+        intent.motion_command = intercept_cmd;
+        /* intent.motion_command.name = "intercept"; */
         return intent;
     } else {
-        auto goalie_idle = rj_msgs::msg::GoalieIdleMotionCommand{};
-        intent.motion_command.goalie_idle_command = {goalie_idle};
-        intent.motion_command.name = "goalie_idle";
+        auto goalie_idle_cmd = planning::GoalieIdleCommand{};
+        intent.motion_command = goalie_idle_cmd;
+        /* intent.motion_command.name = "goalie_idle"; */
         return intent;
     }
 

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -5,7 +5,7 @@ namespace strategy {
 // TODO: lock Goalie id to id given by the ref
 Goalie::Goalie(int r_id) : Position(r_id) { position_name_ = "Goalie"; }
 
-rj_msgs::msg::RobotIntent Goalie::get_task() {
+std::optional<rj_msgs::msg::RobotIntent> Goalie::get_task() {
     // init an intent with our robot id
     rj_msgs::msg::RobotIntent intent;
     intent.robot_id = robot_id_;
@@ -16,11 +16,10 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
     }
 
     WorldState* world_state = this->world_state();  // thread-safe getter
-    bool needs_to_block = false;
-    auto block_pt = get_block_pt(world_state, needs_to_block);
-
-    if (needs_to_block) {
+    if (planning::InterceptPlanner::shot_on_goal_detected(world_state)) {
+        /* if (true) { */
         // create PathTargetMotionCommand, set goal position to block_pt
+        /*
         auto ptmc = rj_msgs::msg::PathTargetMotionCommand{};
         ptmc.target.position = rj_convert::convert_to_ros(block_pt);
 
@@ -34,6 +33,13 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
         // update intent
         intent.motion_command.path_target_command = {ptmc};
         intent.motion_command.name = "path_target";
+        return intent;
+        */
+
+        auto intercept_mc = rj_msgs::msg::InterceptMotionCommand{};
+        intent.motion_command.intercept_command = {intercept_mc};
+        intent.motion_command.name = "intercept";
+        return intent;
     } else {
         // send idle command a few times in case it doesn't get picked up on init
         /* if (send_idle_ct_ < 3) { */
@@ -42,46 +48,14 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
         intent.motion_command.name = "goalie_idle";
 
         /* send_idle_ct_++; */
-        /* return intent; */
+        return intent;
         /* } */
     }
 
     // TODO: capture ball if vel is slow & ball is inside box
     // (waiting on field pts to be given to world_state)
 
-    // TODO(Kevin): make this method std::optional, make AC send nothing on no intent
-    return intent;
-}
-
-rj_geometry::Point Goalie::get_block_pt(WorldState* world_state, bool& needs_to_block) {
-    // TODO: make intercept planner do what its header file does, so we don't need this
-    // also, fix the intercept planner so we don't have to pass in the ball
-    // point every tick
-    rj_geometry::Point ball_pos = world_state->ball.position;
-    rj_geometry::Point ball_vel = world_state->ball.velocity;
-
-    // if ball is slow, doesn't need to block
-    if (ball_vel.mag() < 0.1) {
-        needs_to_block = false;
-        return rj_geometry::Point{-1, -1};  // intentionally invalid
-    }
-
-    // find x-coord that the ball would cross on the goal line
-    // (0, 0) is our goal, +y points out of goal
-    // assume ball vel will remain constant
-    double time_to_cross = std::abs(ball_pos.y() / ball_vel.y());  // again, ball_vel is > 0
-    double cross_x = ball_pos.x() + ball_vel.x() * time_to_cross;
-
-    // if shot is going out of goal, ignore it
-    if (std::abs(cross_x) > 0.6) {  // TODO(Kevin): add field to world_state to avoid hardcoding
-        needs_to_block = false;
-        return rj_geometry::Point{-1, -1};  // intentionally invalid
-    }
-
-    // otherwise, return point needed to block shot
-    needs_to_block = true;
-    rj_geometry::Point block_pt{cross_x, 0.0};
-    return block_pt;
+    return std::nullopt;
 }
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -33,11 +33,13 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
 
         // update intent
         intent.motion_command.path_target_command = {ptmc};
+        intent.motion_command.name = "path_target";
     } else {
         // send idle command a few times in case it doesn't get picked up on init
         /* if (send_idle_ct_ < 3) { */
         auto goalie_idle = rj_msgs::msg::GoalieIdleMotionCommand{};
         intent.motion_command.goalie_idle_command = {goalie_idle};
+        intent.motion_command.name = "goalie_idle";
 
         /* send_idle_ct_++; */
         /* return intent; */

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -10,15 +10,14 @@ std::optional<RobotIntent> Goalie::derived_get_task(RobotIntent intent) {
     if (shot_on_goal_detected(world_state)) {
         // TODO(Kevin): fix intercept planner's is_done, then add in logic to
         // clear/pass ball once done intercepting
-        auto intercept_cmd = planning::InterceptCommand{};
-        intercept_cmd.target = rj_geometry::Point{0.0, 0.1};
+        auto intercept_cmd = planning::InterceptCommand{rj_geometry::Point{0.0, 0.1}};
         intent.motion_command = intercept_cmd;
-        /* intent.motion_command.name = "intercept"; */
+        intent.motion_command_name = "intercept";
         return intent;
     } else {
         auto goalie_idle_cmd = planning::GoalieIdleCommand{};
         intent.motion_command = goalie_idle_cmd;
-        /* intent.motion_command.name = "goalie_idle"; */
+        intent.motion_command_name = "goalie_idle";
         return intent;
     }
 

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -15,6 +15,16 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
         return get_empty_intent();
     }
 
+    // send idle command a few times in case it doesn't get picked up on init
+    if (send_idle_ct_ < 5) {
+        auto goalie_idle = rj_msgs::msg::GoalieIdleMotionCommand{};
+        intent.motion_command.goalie_idle_command = {goalie_idle};
+
+        send_idle_ct_++;
+        return intent;
+    }
+
+    /*
     if (check_is_done()) {
         move_ct++;
     }
@@ -40,6 +50,7 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
     // (waiting on field pts to be given to world_state)
 
     return intent;
+    */
 }
 
 rj_geometry::Point Goalie::get_block_pt(WorldState* world_state) const {

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -10,12 +10,12 @@ std::optional<RobotIntent> Goalie::derived_get_task(RobotIntent intent) {
     if (shot_on_goal_detected(world_state)) {
         // TODO(Kevin): fix intercept planner's is_done, then add in logic to
         // clear/pass ball once done intercepting
-        auto intercept_cmd = planning::InterceptCommand{rj_geometry::Point{0.0, 0.1}};
+        auto intercept_cmd = planning::InterceptMotionCommand{rj_geometry::Point{0.0, 0.1}};
         intent.motion_command = intercept_cmd;
         intent.motion_command_name = "intercept";
         return intent;
     } else {
-        auto goalie_idle_cmd = planning::GoalieIdleCommand{};
+        auto goalie_idle_cmd = planning::GoalieIdleMotionCommand{};
         intent.motion_command = goalie_idle_cmd;
         intent.motion_command_name = "goalie_idle";
         return intent;

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -2,7 +2,7 @@
 
 namespace strategy {
 
-// TODO: lock Goalie id to id given by the ref
+// TODO(Kevin): lock Goalie id to id given by the ref
 Goalie::Goalie(int r_id) : Position(r_id) { position_name_ = "Goalie"; }
 
 std::optional<rj_msgs::msg::RobotIntent> Goalie::get_task() {
@@ -17,25 +17,8 @@ std::optional<rj_msgs::msg::RobotIntent> Goalie::get_task() {
 
     WorldState* world_state = this->world_state();  // thread-safe getter
     if (shot_on_goal_detected(world_state)) {
-        /* if (world_state->ball.velocity.mag() > 1.0) { */
-        // create PathTargetMotionCommand, set goal position to block_pt
-        /*
-        auto ptmc = rj_msgs::msg::PathTargetMotionCommand{};
-        ptmc.target.position = rj_convert::convert_to_ros(block_pt);
-
-        // make goalie face the ball
-        rj_geometry::Point ball_pos = world_state->ball.position;
-        auto face_pt = ball_pos;
-        ptmc.override_face_point = {rj_convert::convert_to_ros(face_pt)};
-
-        ptmc.ignore_ball = true;  // allow goalie to intersect ball's path
-
-        // update intent
-        intent.motion_command.path_target_command = {ptmc};
-        intent.motion_command.name = "path_target";
-        return intent;
-        */
-
+        // TODO(Kevin): fix intercept planner's is_done, then add in logic to
+        // clear/pass ball once done intercepting
         auto intercept_mc = rj_msgs::msg::InterceptMotionCommand{};
         intercept_mc.target.x = 0.0;
         intercept_mc.target.y = 0.1;
@@ -43,19 +26,11 @@ std::optional<rj_msgs::msg::RobotIntent> Goalie::get_task() {
         intent.motion_command.name = "intercept";
         return intent;
     } else {
-        // send idle command a few times in case it doesn't get picked up on init
-        /* if (send_idle_ct_ < 3) { */
         auto goalie_idle = rj_msgs::msg::GoalieIdleMotionCommand{};
         intent.motion_command.goalie_idle_command = {goalie_idle};
         intent.motion_command.name = "goalie_idle";
-
-        /* send_idle_ct_++; */
         return intent;
-        /* } */
     }
-
-    // TODO: capture ball if vel is slow & ball is inside box
-    // (waiting on field pts to be given to world_state)
 
     return std::nullopt;
 }

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -51,7 +51,7 @@ rj_msgs::msg::RobotIntent Goalie::get_task() {
     return intent;
 }
 
-rj_geometry::Point Goalie::get_block_pt(WorldState* world_state, bool& needs_to_block) const {
+rj_geometry::Point Goalie::get_block_pt(WorldState* world_state, bool& needs_to_block) {
     // TODO: make intercept planner do what its header file does, so we don't need this
     // also, fix the intercept planner so we don't have to pass in the ball
     // point every tick
@@ -71,7 +71,7 @@ rj_geometry::Point Goalie::get_block_pt(WorldState* world_state, bool& needs_to_
     double cross_x = ball_pos.x() + ball_vel.x() * time_to_cross;
 
     // if shot is going out of goal, ignore it
-    if (std::abs(cross_x) > 0.6) {  // TODO: add field to world_state to avoid hardcoding
+    if (std::abs(cross_x) > 0.6) {  // TODO(Kevin): add field to world_state to avoid hardcoding
         needs_to_block = false;
         return rj_geometry::Point{-1, -1};  // intentionally invalid
     }

--- a/soccer/src/soccer/strategy/agent/position/goalie.hpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.hpp
@@ -29,11 +29,11 @@ public:
     Goalie(int r_id);
     ~Goalie() override = default;
 
-    std::optional<rj_msgs::msg::RobotIntent> get_task() override;
-
 private:
     // temp
     int send_idle_ct_ = 0;
+
+    std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
 
     /*
      * @return true if ball is heading towards goal at some minimum speed threshold

--- a/soccer/src/soccer/strategy/agent/position/goalie.hpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.hpp
@@ -38,7 +38,7 @@ private:
      *
      * Assumes ball is not slow.
      */
-    rj_geometry::Point get_block_pt(WorldState* world_state, bool& needs_to_block) const;
+    static rj_geometry::Point get_block_pt(WorldState* world_state, bool& needs_to_block);
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/goalie.hpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.hpp
@@ -34,6 +34,11 @@ public:
 private:
     // temp
     int send_idle_ct_ = 0;
+
+    /*
+     * @return true if ball is heading towards goal at some minimum speed threshold
+     */
+    bool shot_on_goal_detected(WorldState* world_state);
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/goalie.hpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.hpp
@@ -2,11 +2,11 @@
 
 #include <cmath>
 
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
 #include <spdlog/spdlog.h>
 
-#include <rj_common/time.hpp>
-#include <rj_geometry/geometry_conversions.hpp>
-#include <rj_geometry/point.hpp>
+#include <rj_msgs/action/robot_move.hpp>
 #include <rj_msgs/msg/empty_motion_command.hpp>
 #include <rj_msgs/msg/goalie_idle_motion_command.hpp>
 #include <rj_msgs/msg/intercept_motion_command.hpp>
@@ -14,9 +14,9 @@
 
 #include "planning/planner/intercept_planner.hpp"
 #include "position.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp_action/rclcpp_action.hpp"
-#include "rj_msgs/action/robot_move.hpp"
+#include "rj_common/time.hpp"
+#include "rj_geometry/geometry_conversions.hpp"
+#include "rj_geometry/point.hpp"
 
 namespace strategy {
 

--- a/soccer/src/soccer/strategy/agent/position/goalie.hpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.hpp
@@ -8,6 +8,8 @@
 #include <rj_geometry/geometry_conversions.hpp>
 #include <rj_geometry/point.hpp>
 #include <rj_msgs/msg/empty_motion_command.hpp>
+#include <rj_msgs/msg/goalie_idle_motion_command.hpp>
+#include <rj_msgs/msg/path_target_motion_command.hpp>
 
 #include "position.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -28,19 +30,15 @@ public:
     rj_msgs::msg::RobotIntent get_task() override;
 
 private:
-    // temp to move back and forth
-    int move_ct = 0;
+    // temp
+    int send_idle_ct_ = 0;
 
     /*
-     * @return Point for Goalie to block a shot. Calls get_idle_pt() if ball is
-     * slow or shot will miss the goal.
+     * @return Point for Goalie to block a shot.
+     *
+     * Assumes ball is not slow.
      */
     rj_geometry::Point get_block_pt(WorldState* world_state) const;
-
-    /*
-     * @return Point for Goalie to stand in when no shot is coming. Expects
-     * ball to be slow.
-     */
     rj_geometry::Point get_idle_pt(WorldState* world_state) const;
 };
 

--- a/soccer/src/soccer/strategy/agent/position/goalie.hpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.hpp
@@ -9,8 +9,10 @@
 #include <rj_geometry/point.hpp>
 #include <rj_msgs/msg/empty_motion_command.hpp>
 #include <rj_msgs/msg/goalie_idle_motion_command.hpp>
+#include <rj_msgs/msg/intercept_motion_command.hpp>
 #include <rj_msgs/msg/path_target_motion_command.hpp>
 
+#include "planning/planner/intercept_planner.hpp"
 #include "position.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
@@ -27,18 +29,11 @@ public:
     Goalie(int r_id);
     ~Goalie() override = default;
 
-    rj_msgs::msg::RobotIntent get_task() override;
+    std::optional<rj_msgs::msg::RobotIntent> get_task() override;
 
 private:
     // temp
     int send_idle_ct_ = 0;
-
-    /*
-     * @return Point for Goalie to block a shot.
-     *
-     * Assumes ball is not slow.
-     */
-    static rj_geometry::Point get_block_pt(WorldState* world_state, bool& needs_to_block);
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/goalie.hpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.hpp
@@ -38,8 +38,7 @@ private:
      *
      * Assumes ball is not slow.
      */
-    rj_geometry::Point get_block_pt(WorldState* world_state) const;
-    rj_geometry::Point get_idle_pt(WorldState* world_state) const;
+    rj_geometry::Point get_block_pt(WorldState* world_state, bool& needs_to_block) const;
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -25,16 +25,16 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
     rj_geometry::Point target_vel{0.0, 0.0};
 
     // face ball on way up, face path on way down
-    planning::AngleOverride angle_override = planning::TargetFaceBall{};
+    planning::PathTargetFaceOption face_option = planning::FaceBall{};
     if (kicking_) {
-        angle_override = planning::TargetFaceTangent{};
+        face_option = planning::FaceTarget{};
     }
 
     // avoid ball
     bool ignore_ball = false;
 
     planning::LinearMotionInstant goal{target_pt, target_vel};
-    intent.motion_command = planning::PathTargetMotionCommand{goal, angle_override, ignore_ball};
+    intent.motion_command = planning::PathTargetMotionCommand{goal, face_option, ignore_ball};
     intent.motion_command_name = "path_target";
     return intent;
 }

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -4,7 +4,7 @@ namespace strategy {
 
 Offense::Offense(int r_id) : Position(r_id) { position_name_ = "Offense"; }
 
-rj_msgs::msg::RobotIntent Offense::get_task() {
+std::optional<rj_msgs::msg::RobotIntent> Offense::get_task() {
     // init an intent with our robot id
     rj_msgs::msg::RobotIntent intent;
     intent.robot_id = robot_id_;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -4,16 +4,7 @@ namespace strategy {
 
 Offense::Offense(int r_id) : Position(r_id) { position_name_ = "Offense"; }
 
-std::optional<rj_msgs::msg::RobotIntent> Offense::get_task() {
-    // init an intent with our robot id
-    rj_msgs::msg::RobotIntent intent;
-    intent.robot_id = robot_id_;
-
-    // if world_state invalid, return empty_intent
-    if (!assert_world_state_valid()) {
-        return get_empty_intent();
-    }
-
+std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
     // FSM: kick -> move away -> repeat
     if (check_is_done()) {
         // switch from kicking -> not kicking or vice versa
@@ -24,49 +15,25 @@ std::optional<rj_msgs::msg::RobotIntent> Offense::get_task() {
     WorldState* world_state = this->world_state();  // thread-safe getter
 
     // oscillate along vertical line (temp)
-    auto ptmc = rj_msgs::msg::PathTargetMotionCommand{};
+    auto ptc = planning::PathTargetCommand{};
     double y = 6.0;
     if (!kicking_) {
         y = 1.0;
     }
     rj_geometry::Point back_pt{(6.0 * (robot_id_ * 0.1) - 2.0), y};
-    ptmc.target.position = rj_convert::convert_to_ros(back_pt);
+    ptc.goal.position = back_pt;
+
+    rj_geometry::Point vel{0.0, 0.0};
+    ptc.goal.velocity = vel;
 
     rj_geometry::Point ball_pos = world_state->ball.position;
-    auto face_pt = ball_pos;
-    ptmc.override_face_point = {rj_convert::convert_to_ros(face_pt)};
-    ptmc.ignore_ball = true;  // don't try to avoid ball
-    intent.motion_command.path_target_command = {ptmc};
+    planning::TargetFacePoint face_pt = planning::TargetFacePoint{};
+    face_pt.face_point = ball_pos;
 
-    /*
-    // TODO(Kevin): line kick is broken, fix it
-    if (kicking_) {
-        auto lkmc = rj_msgs::msg::LineKickMotionCommand{};
-        rj_geometry::Point ball_pos = world_state->ball.position;
-        lkmc.target = rj_convert::convert_to_ros(ball_pos);
-        intent.motion_command.line_kick_command = {lkmc};
+    ptc.angle_override = face_pt;
+    ptc.ignore_ball = false;
 
-        // TODO(Kevin): this is still tick based, not event-driven, fix? or clarify somewhere
-        // event driven would only get this ball pos once, but this is tick that we pretend is
-        // event driven there should be a task for facing the ball always
-        rj_geometry::Point ball_pos = world_state->ball.position;
-        auto face_pt = ball_pos;
-        ptmc.override_face_point = {rj_convert::convert_to_ros(face_pt)};
-        ptmc.ignore_ball = true;  // don't try to avoid ball
-        intent.motion_command.path_target_command = {ptmc};
-    } else {
-        auto ptmc = rj_msgs::msg::PathTargetMotionCommand{};
-        rj_geometry::Point back_pt{(8.0 * (robot_id_ * 0.1) - 4.0), 2.0};
-        ptmc.target.position = rj_convert::convert_to_ros(back_pt);
-
-        rj_geometry::Point ball_pos = world_state->ball.position;
-        auto face_pt = ball_pos;
-        ptmc.override_face_point = {rj_convert::convert_to_ros(face_pt)};
-        ptmc.ignore_ball = false;  // try to avoid ball
-        intent.motion_command.path_target_command = {ptmc};
-    }
-    */
-
+    intent.motion_command = ptc;
     return intent;
 }
 

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -25,7 +25,7 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
     rj_geometry::Point target_vel{0.0, 0.0};
 
     // face ball on way up, face path on way down
-    planning::AngleOverride angle_override = planning::TargetFacePoint{world_state->ball.position};
+    planning::AngleOverride angle_override = planning::TargetFaceBall{};
     if (kicking_) {
         angle_override = planning::TargetFaceTangent{};
     }

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -34,7 +34,7 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
     bool ignore_ball = false;
 
     planning::LinearMotionInstant goal{target_pt, target_vel};
-    intent.motion_command = planning::PathTargetCommand{goal, angle_override, ignore_ball};
+    intent.motion_command = planning::PathTargetMotionCommand{goal, angle_override, ignore_ball};
     intent.motion_command_name = "path_target";
     return intent;
 }

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -30,7 +30,11 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
     planning::TargetFacePoint face_pt = planning::TargetFacePoint{};
     face_pt.face_point = ball_pos;
 
-    ptc.angle_override = face_pt;
+    if (!kicking_) {
+        ptc.angle_override = face_pt;
+    } else {
+        ptc.angle_override = planning::TargetFaceTangent{};
+    }
     ptc.ignore_ball = false;
 
     intent.motion_command = ptc;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -15,29 +15,27 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
     WorldState* world_state = this->world_state();  // thread-safe getter
 
     // oscillate along vertical line (temp)
-    auto ptc = planning::PathTargetCommand{};
     double y = 6.0;
     if (!kicking_) {
         y = 1.0;
     }
-    rj_geometry::Point back_pt{(6.0 * (robot_id_ * 0.1) - 2.0), y};
-    ptc.goal.position = back_pt;
+    rj_geometry::Point target_pt{(6.0 * (robot_id_ * 0.1) - 2.0), y};
 
-    rj_geometry::Point vel{0.0, 0.0};
-    ptc.goal.velocity = vel;
+    // stop at end of path
+    rj_geometry::Point target_vel{0.0, 0.0};
 
-    rj_geometry::Point ball_pos = world_state->ball.position;
-    planning::TargetFacePoint face_pt = planning::TargetFacePoint{};
-    face_pt.face_point = ball_pos;
-
-    if (!kicking_) {
-        ptc.angle_override = face_pt;
-    } else {
-        ptc.angle_override = planning::TargetFaceTangent{};
+    // face ball on way up, face path on way down
+    planning::AngleOverride angle_override = planning::TargetFacePoint{world_state->ball.position};
+    if (kicking_) {
+        angle_override = planning::TargetFaceTangent{};
     }
-    ptc.ignore_ball = false;
 
-    intent.motion_command = ptc;
+    // avoid ball
+    bool ignore_ball = false;
+
+    planning::LinearMotionInstant goal{target_pt, target_vel};
+    intent.motion_command = planning::PathTargetCommand{goal, angle_override, ignore_ball};
+    intent.motion_command_name = "path_target";
     return intent;
 }
 

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -4,6 +4,7 @@
 
 #include <spdlog/spdlog.h>
 
+#include <planning/instant.hpp>
 #include <rj_common/time.hpp>
 #include <rj_geometry/geometry_conversions.hpp>
 #include <rj_geometry/point.hpp>

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -2,18 +2,18 @@
 
 #include <cmath>
 
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
 #include <spdlog/spdlog.h>
 
-#include <planning/instant.hpp>
-#include <rj_common/time.hpp>
-#include <rj_geometry/geometry_conversions.hpp>
-#include <rj_geometry/point.hpp>
+#include <rj_msgs/action/robot_move.hpp>
 #include <rj_msgs/msg/empty_motion_command.hpp>
 
+#include "planning/instant.hpp"
 #include "position.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp_action/rclcpp_action.hpp"
-#include "rj_msgs/action/robot_move.hpp"
+#include "rj_common/time.hpp"
+#include "rj_geometry/geometry_conversions.hpp"
+#include "rj_geometry/point.hpp"
 
 namespace strategy {
 

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -25,7 +25,7 @@ public:
     Offense(int r_id);
     ~Offense() override = default;
 
-    rj_msgs::msg::RobotIntent get_task() override;
+    std::optional<rj_msgs::msg::RobotIntent> get_task() override;
 
 private:
     bool kicking_{true};

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -25,11 +25,11 @@ public:
     Offense(int r_id);
     ~Offense() override = default;
 
-    std::optional<rj_msgs::msg::RobotIntent> get_task() override;
-
 private:
     bool kicking_{true};
     // TODO: strategy design pattern for BallHandler/Receiver
+
+    std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/position.cpp
@@ -11,7 +11,7 @@ std::optional<RobotIntent> Position::get_task() {
 
     // if world_state invalid, return empty_intent
     if (!assert_world_state_valid()) {
-        intent.motion_command = planning::EmptyCommand{};
+        intent.motion_command = planning::EmptyMotionCommand{};
         return intent;
     }
 

--- a/soccer/src/soccer/strategy/agent/position/position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/position.cpp
@@ -19,6 +19,12 @@ std::optional<RobotIntent> Position::get_task() {
     return derived_get_task(intent);
 }
 
+void Position::set_time_left(double time_left) { time_left_ = time_left; }
+
+void Position::set_is_done() { is_done_ = true; }
+
+void Position::set_goal_canceled() { goal_canceled_ = true; }
+
 bool Position::check_is_done() {
     if (is_done_) {
         is_done_ = false;

--- a/soccer/src/soccer/strategy/agent/position/position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/position.cpp
@@ -4,6 +4,21 @@ namespace strategy {
 
 Position::Position(int r_id) : robot_id_(r_id) {}
 
+std::optional<RobotIntent> Position::get_task() {
+    // init an intent with our robot id
+    RobotIntent intent = RobotIntent{};
+    intent.robot_id = robot_id_;
+
+    // if world_state invalid, return empty_intent
+    if (!assert_world_state_valid()) {
+        intent.motion_command = planning::EmptyCommand{};
+        return intent;
+    }
+
+    // delegate to derived class to complete behavior
+    return derived_get_task(intent);
+}
+
 bool Position::check_is_done() {
     if (is_done_) {
         is_done_ = false;
@@ -48,13 +63,6 @@ bool Position::assert_world_state_valid() {
         return false;
     }
     return true;
-}
-
-rj_msgs::msg::RobotIntent Position::get_empty_intent() const {
-    rj_msgs::msg::RobotIntent intent{};
-    auto empty = rj_msgs::msg::EmptyMotionCommand{};
-    intent.motion_command.empty_command = {empty};
-    return intent;
 }
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -105,7 +105,7 @@ protected:
 
 private:
     // private to avoid allowing WorldState to be accessed directly by derived
-    // classes
+    // classes (must use thread-safe getter)
     WorldState last_world_state_;
     mutable std::mutex world_state_mutex_;
 

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
 #include <spdlog/spdlog.h>
 
-#include <rj_common/time.hpp>
-#include <rj_geometry/geometry_conversions.hpp>
-#include <rj_geometry/point.hpp>
+#include <rj_msgs/action/robot_move.hpp>
 #include <rj_msgs/msg/coach_state.hpp>
 #include <rj_msgs/msg/empty_motion_command.hpp>
 #include <rj_msgs/msg/global_override.hpp>
 
 #include "planning/planner/motion_command.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp_action/rclcpp_action.hpp"
-#include "rj_msgs/action/robot_move.hpp"
+#include "rj_common/time.hpp"
+#include "rj_geometry/geometry_conversions.hpp"
+#include "rj_geometry/point.hpp"
 #include "robot_intent.hpp"
 #include "world_state.hpp"
 

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -37,7 +37,7 @@ public:
      * @brief return a RobotIntent to be sent to PlannerNode by AC; nullopt
      * means no new task requested.
      *
-     * Creates a RobotIntent with the right robot ID, then returns EmptyCommand
+     * Creates a RobotIntent with the right robot ID, then returns EmptyMotionCommand
      * if world_state is invalid, then delegates to derived classes.
      *
      * Uses the Template Method + non-virtual interface:

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -38,7 +38,11 @@ public:
     void update_world_state(WorldState world_state);
     void update_coach_state(rj_msgs::msg::CoachState coach_state);
 
-    virtual rj_msgs::msg::RobotIntent get_task() = 0;
+    /*
+     * @brief return a RobotIntent to be sent to PlannerNode; nullopt means no
+     * new task requested
+     */
+    virtual std::optional<rj_msgs::msg::RobotIntent> get_task() = 0;
 
     // this allows AgentActionClient to change private/protected members of this class
     friend class AgentActionClient;


### PR DESCRIPTION
## Description

A refactoring PR to make it easier to add more complex strategy later. No visible on-field changes. Firmly establishes tasks/RobotIntents as long-running actions, as the ROS Action model requires. 

Big changes:
 * Add FaceBall option for PathTargetMotionCommand, instead of having to pass in an updated ball position to FacePoint. This makes the task "move here and face the ball" consistent in the eyes of the ActionClient, unlike before.
 * Confines use of ROS msg types to the ROS nodes they are sent/received from, to alleviate confusion over when our classes vs. ROS' autogenerated classes are used (see PR #1980 )
 * Uses the [Template Method + non-virtual interface](https://www.sandordargo.com/blog/2022/08/24/tmp-and-nvi) pattern to simplify get_task() in Position.
 * Moves the comparison operator overloads from `conversion_tests.cpp` (??) to `motion_command.cpp`, so they're next to their class definitions.
 * Debug drawer will now draw robot endpoint for all planner types (not just PathTargetPlanner)
 * RobotIntent.msg and RobotIntent struct now have a `motion_command_name` string for ease of introspection (warning: not enforced internally)
 * Standardize naming across ROS/motion_command.hpp

## Steps to Test
### Test Case 1
1. Run sim
2. Compare with #1987 

**Expected result:** Should look identical, except now intercept planner should draw a black circle too (not true in #1987 ).

Again (like #1811 ) my main goal was to ease future development, not introduce new changes, so review the code (especially the subclasses of Position).

## Key Files to Review
Reviewing by commit should be easiest here, I did a fairly good job of giving meaningful commit msgs. 

(**Except** in "use aggregate initialization for MotionCommands to be concise" I also gave RobotIntent.msg a motion_command_name field, which I forgot about when committing.)

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack

