### PR TITLE
Hotfix: Make ROS2 run again (far trajectory bug)

### DIFF
--- a/soccer/src/soccer/planning/primitives/velocity_profiling.cpp
+++ b/soccer/src/soccer/planning/primitives/velocity_profiling.cpp
@@ -161,6 +161,14 @@ Trajectory profile_velocity(const BezierPath& path, double initial_speed, double
         Pose pose{points[n], 0};
         Twist twist{derivs1[n].normalized(speed[n]), 0};
 
+        // TODO (someone): Make sure destination points sent to planner are within the field radius
+        // A bug exists where a point incredibly far from the field is targetted as the next location for the robot.
+        // In this case it will take the robot an incredibly long time to get there and the trajectory after will have the same
+        // destination time for some reason.
+        if (interval_time > 1e15) {
+            continue;
+        }
+
         // Add point n in
         trajectory.append_instant(RobotInstant{pose, twist, current_time});
     }

--- a/soccer/src/soccer/planning/primitives/velocity_profiling.cpp
+++ b/soccer/src/soccer/planning/primitives/velocity_profiling.cpp
@@ -162,9 +162,10 @@ Trajectory profile_velocity(const BezierPath& path, double initial_speed, double
         Twist twist{derivs1[n].normalized(speed[n]), 0};
 
         // TODO (someone): Make sure destination points sent to planner are within the field radius
-        // A bug exists where a point incredibly far from the field is targetted as the next location for the robot.
-        // In this case it will take the robot an incredibly long time to get there and the trajectory after will have the same
-        // destination time for some reason.
+        // A bug exists where a point incredibly far from the field is targetted
+        // as the next location for the robot.
+        // In this case it will take the robot an incredibly long time to get there
+        // and the trajectory after will have the same destination time for some reason.
         if (interval_time > 1e15) {
             continue;
         }


### PR DESCRIPTION
## Description
ros2 was broken because the velocity_profiling.cpp file had a line that was adding incredibly far away points to the trajectory (points with x and y in the magnitude of 10^17).  This caused the time to get to the point to be incredibly high, so high in fact that it seems that all of the times were approximately equal.  This change makes the planner ignore points that would take an extreme amount of time to reach.

I created a clickup card for stopping the out-of-bounds paths from being planned in the first place (https://app.clickup.com/t/86773tf5n)
