### PR TITLE
Fix Framework Script 

### DIFF
--- a/launch/framework.bash
+++ b/launch/framework.bash
@@ -6,6 +6,6 @@ echo "launching ER-Force framework and our UI"
 # first trap SIGINT to kill the entire subshell
 # then find the location of simulator-cli in the home directory and run it with args -g 2020B (in background)
 # then run sim through makefile shortcut (in background)
-# finally wait, so that the simulator-cli process isn't lost/disowned when run-sim-only dies before it does.
-(trap 'kill 0' SIGINT; find ~ -name 'simulator-cli' -type f -exec '{}' -g 2020B ';' & make run-our-stack & wait)
-
+# finally wait, so that the simulator-cli process isn't lost/disowned when run-our-stack dies before it does.
+pkill .*simulator-cli
+(trap 'exit' SIGINT SIGTERM; trap 'pkill .*simulator-cli; kill 0' EXIT; find ~ -name 'simulator-cli' -type f -exec '{}' -g 2020B ';' & make run-our-stack & wait)

--- a/launch/framework.bash
+++ b/launch/framework.bash
@@ -2,10 +2,12 @@
 # this script launches the ER-force framework and our simulator UI simultaneously and allows you to kill both at once using ctrl-c
 # you may need to press ctrl-c twice
 echo "launching ER-Force framework and our UI"
+# kill existing ER-Force simulator instances
+pkill .*simulator-cli
 # in a subshell: 
 # first trap SIGINT to kill the entire subshell
 # then find the location of simulator-cli in the home directory and run it with args -g 2020B (in background)
 # then run sim through makefile shortcut (in background)
 # finally wait, so that the simulator-cli process isn't lost/disowned when run-our-stack dies before it does.
+(trap 'exit' SIGINT SIGTERM; trap 'kill 0' EXIT; find ~ -name 'simulator-cli' -type f -exec '{}' -g 2020B ';' & make run-our-stack & wait)
 pkill .*simulator-cli
-(trap 'exit' SIGINT SIGTERM; trap 'pkill .*simulator-cli; kill 0' EXIT; find ~ -name 'simulator-cli' -type f -exec '{}' -g 2020B ';' & make run-our-stack & wait)


### PR DESCRIPTION
## Description
The `make run-sim` script was sometimes leaving the ER-Force simulator running. When the script was later run again, this would result in two instances of ER-Force and create strange issues.
This PR attempts to correct this problem by manually killing `simulator-cli` instances before and after the script runs.

## Associated / Resolved Issue
Resolves [ClickUp card](https://app.clickup.com/t/86776zrap)

## Steps to Test
### Test Case 1
1. Run `simulator-cli` manually
2. Run framework.bash in a separate shell.

**Expected result:** the original `simulator-cli` should be terminated and a new one will be created. one way to check is the PID should change. 

## Key Files to Review
 * framework.bash

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack
