### PR TITLE
Robots respect max speed overrides

### DIFF
--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -244,6 +244,8 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     const auto play_state = shared_state_->play_state();
     const bool is_goalie = goalie_id == robot_id_;
     const auto min_dist_from_ball = shared_state_->min_dist_from_ball();
+    const auto max_robot_speed = shared_state_->max_robot_speed();
+    
 
     const auto& robot = world_state->our_robots.at(robot_id_);
     const auto start = RobotInstant{robot.pose, robot.velocity, robot.timestamp};
@@ -274,11 +276,8 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     }
     */
 
-    // TODO(Kyle): Send constraints from gameplay
     RobotConstraints constraints;
-    if (play_state.is_stop()) {
-        constraints.mot.max_speed = 0.8;
-    }
+    constraints.mot.max_speed = max_robot_speed;
 
     return PlanRequest{start,
                        intent.motion_command,

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -283,19 +283,15 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
         // If coach node has speed set to 0,
         // choose not to move by replacing the MotionCommand with an empty one.
         motion_command = EmptyMotionCommand{};
-    }
-    else if (max_robot_speed < 0.0f) {
+    } else if (max_robot_speed < 0.0f) {
         // If coach node has speed set to negative, assume infinity.
         // Negative numbers cause crashes, but 10 is an effectively infinite limit.
         motion_command = intent.motion_command;
         constraints.mot.max_speed = 10.0f;
-    }
-    else {
+    } else {
         motion_command = intent.motion_command;
         constraints.mot.max_speed = max_robot_speed;
     }
-
-    SPDLOG_INFO("Max robot speed: {}", max_robot_speed);
 
     return PlanRequest{start,
                        motion_command,

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -275,13 +275,19 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     }
     */
 
-    RobotConstraints constraints;
-    if (max_robot_speed > 0.0f) {
+    RobotConstraints constraints {};
+    MotionCommand motion_command;
+    // If max robot speed is 0, replace the motion command with an empty one. 
+    // Simply passing 0 in as the max speed crashes the planner; an EmptyMotionCommand results in the expected no movement.
+    if (max_robot_speed == 0.0f) {
+        motion_command = EmptyMotionCommand {};
+    } else {
+        motion_command = intent.motion_command;
         constraints.mot.max_speed = max_robot_speed;
     }
 
     return PlanRequest{start,
-                       intent.motion_command,
+                       motion_command,
                        constraints,
                        std::move(real_obstacles),
                        std::move(virtual_obstacles),

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -243,8 +243,8 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     const auto goalie_id = shared_state_->goalie_id();
     const auto play_state = shared_state_->play_state();
     const bool is_goalie = goalie_id == robot_id_;
-    const auto min_dist_from_ball = shared_state_->min_dist_from_ball();
-    const auto max_robot_speed = shared_state_->max_robot_speed();
+    const auto min_dist_from_ball = shared_state_->coach_state().global_override.min_dist_from_ball;
+    const auto max_robot_speed = shared_state_->coach_state().global_override.min_dist_from_ball;
 
     const auto& robot = world_state->our_robots.at(robot_id_);
     const auto start = RobotInstant{robot.pose, robot.velocity, robot.timestamp};

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -245,7 +245,6 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     const bool is_goalie = goalie_id == robot_id_;
     const auto min_dist_from_ball = shared_state_->min_dist_from_ball();
     const auto max_robot_speed = shared_state_->max_robot_speed();
-    
 
     const auto& robot = world_state->our_robots.at(robot_id_);
     const auto start = RobotInstant{robot.pose, robot.velocity, robot.timestamp};
@@ -277,7 +276,9 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     */
 
     RobotConstraints constraints;
-    constraints.mot.max_speed = max_robot_speed;
+    if (max_robot_speed > 0.0f) {
+        constraints.mot.max_speed = max_robot_speed;
+    }
 
     return PlanRequest{start,
                        intent.motion_command,

--- a/soccer/src/soccer/planning/planner_node.hpp
+++ b/soccer/src/soccer/planning/planner_node.hpp
@@ -103,7 +103,6 @@ public:
         auto lock = std::lock_guard(mutex_);
         return last_coach_state_;
     }
-    
 
 private:
     rclcpp::Subscription<rj_msgs::msg::PlayState>::SharedPtr play_state_sub_;

--- a/soccer/src/soccer/planning/planner_node.hpp
+++ b/soccer/src/soccer/planning/planner_node.hpp
@@ -71,8 +71,7 @@ public:
             "/strategy/coach_state", rclcpp::QoS(1),
             [this](rj_msgs::msg::CoachState::SharedPtr coach_state) {  // NOLINT
                 auto lock = std::lock_guard(mutex_);
-                last_min_dist_from_ball_ = coach_state->global_override.min_dist_from_ball;
-                last_robot_max_speed_ = coach_state->global_override.max_speed;
+                last_coach_state_ = *coach_state;
             });
     }
 
@@ -100,14 +99,11 @@ public:
         auto lock = std::lock_guard(mutex_);
         return &last_world_state_;
     }
-    [[nodiscard]] float min_dist_from_ball() const {
+    [[nodiscard]] const rj_msgs::msg::CoachState coach_state() const {
         auto lock = std::lock_guard(mutex_);
-        return last_min_dist_from_ball_;
+        return last_coach_state_;
     }
-    [[nodiscard]] float max_robot_speed() const {
-        auto lock = std::lock_guard(mutex_);
-        return last_robot_max_speed_;
-    }
+    
 
 private:
     rclcpp::Subscription<rj_msgs::msg::PlayState>::SharedPtr play_state_sub_;
@@ -125,8 +121,7 @@ private:
     rj_geometry::ShapeSet last_global_obstacles_;
     rj_geometry::ShapeSet last_def_area_obstacles_;
     WorldState last_world_state_;
-    float last_min_dist_from_ball_;
-    float last_robot_max_speed_;
+    rj_msgs::msg::CoachState last_coach_state_;
 };
 
 /**

--- a/soccer/src/soccer/planning/planner_node.hpp
+++ b/soccer/src/soccer/planning/planner_node.hpp
@@ -72,6 +72,7 @@ public:
             [this](rj_msgs::msg::CoachState::SharedPtr coach_state) {  // NOLINT
                 auto lock = std::lock_guard(mutex_);
                 last_min_dist_from_ball_ = coach_state->global_override.min_dist_from_ball;
+                last_robot_max_speed_ = coach_state->global_override.max_speed;
             });
     }
 
@@ -103,6 +104,10 @@ public:
         auto lock = std::lock_guard(mutex_);
         return last_min_dist_from_ball_;
     }
+    [[nodiscard]] float max_robot_speed() const {
+        auto lock = std::lock_guard(mutex_);
+        return last_robot_max_speed_;
+    }
 
 private:
     rclcpp::Subscription<rj_msgs::msg::PlayState>::SharedPtr play_state_sub_;
@@ -121,6 +126,7 @@ private:
     rj_geometry::ShapeSet last_def_area_obstacles_;
     WorldState last_world_state_;
     float last_min_dist_from_ball_;
+    float last_robot_max_speed_;
 };
 
 /**

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -123,7 +123,8 @@ void CoachNode::check_for_play_state_change() {
                 global_override.min_dist_from_ball = 0.5;
                 break;
             case PlayState::State::Playing:
-                global_override.max_speed = -1;
+                // Unbounded speed. Setting to -1 or 0 crashes planner, so use large number instead.
+                global_override.max_speed = 10.0;
                 global_override.min_dist_from_ball = 0;
         }
 


### PR DESCRIPTION
## Description
Describe your pull request.

## Associated / Resolved Issue
Resolves [ClickUp card](https://app.clickup.com/t/86777u5pt)

## Steps to Test
### Test Case 1
1. run sim
2. switch between stop and playing
3. use rqt to change coach_state, limiting speed to a small number (e.g. 0.5)

**Expected result:** Robots slow down when their speed is limited, and speed back up (to a point) when the limit is removed

## Key Files to Review
Planner
 * `planner_node.hpp`
 * `planner_node.cpp`

Coach
 * Changed negative "infinite" speed to 10

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack
