### PR TITLE
Add back UI/referee control over goalie

### DIFF
--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -110,12 +110,11 @@ void AgentActionClient::update_position(const rj_msgs::msg::PositionAssignment::
     /*     SPDLOG_INFO("position at {}: {}", i, msg->client_positions.at(i)); */
     /* } */
     // SPDLOG_INFO("{}'s position : {}", robot_id_, msg->client_positions[robot_id_]);
-    if (robot_id_ == 0) {
-        return;
-    }
-
     std::unique_ptr<Position> next_position_;
     switch (msg->client_positions[robot_id_]) {
+        case 0:
+            next_position_ = std::make_unique<Goalie>(robot_id_);
+            break;
         case 1:
             next_position_ = std::make_unique<Defense>(robot_id_);
             break;

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -24,7 +24,7 @@ CoachNode::CoachNode(const rclcpp::NodeOptions& options) : Node("coach_node", op
         [this](const rj_msgs::msg::WorldState::SharedPtr msg) { world_state_callback(msg); });
 
     goalie_sub_ = this->create_subscription<rj_msgs::msg::Goalie>(
-        "/referee/goalie", 10,
+        "/referee/our_goalie", 10,
         [this](const rj_msgs::msg::Goalie::SharedPtr msg) { goalie_callback(msg); });
 
     // TODO: (https://app.clickup.com/t/867796fh2)sub to acknowledgement topic from AC

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -23,6 +23,10 @@ CoachNode::CoachNode(const rclcpp::NodeOptions& options) : Node("coach_node", op
         "/vision_filter/world_state", 10,
         [this](const rj_msgs::msg::WorldState::SharedPtr msg) { world_state_callback(msg); });
 
+    goalie_sub_ = this->create_subscription<rj_msgs::msg::Goalie>(
+        "/referee/goalie", 10,
+        [this](const rj_msgs::msg::Goalie::SharedPtr msg) { goalie_callback(msg); });
+
     // TODO: (https://app.clickup.com/t/867796fh2)sub to acknowledgement topic from AC
     // save state of acknowledgements, only spam until some long time has passed, or ack received
     /* ack_array[msg->ID] = true; */
@@ -163,6 +167,10 @@ void CoachNode::assign_positions() {
 void CoachNode::field_dimensions_callback(const rj_msgs::msg::FieldDimensions::SharedPtr& msg) {
     current_field_dimensions_ = *msg;
     have_field_dimensions_ = true;
+}
+
+void CoachNode::goalie_callback(const rj_msgs::msg::Goalie::SharedPtr& msg) {
+    goalie_id_ = msg->goalie_id;
 }
 
 void CoachNode::publish_static_obstacles() {

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -148,16 +148,32 @@ void CoachNode::check_for_play_state_change() {
 void CoachNode::assign_positions() {
     rj_msgs::msg::PositionAssignment positions_message;
     std::array<uint32_t, kNumShells> positions{};
-    positions[0] = Positions::Goalie;
+    positions[goalie_id_] = Positions::Goalie;
     if (!possessing_) {
-        positions[1] = Positions::Offense;
-        for (int i = 2; i < kNumShells; i++) {
-            positions[i] = Positions::Defense;
+        // All robots set to defense
+        for (int i = 0; i < kNumShells; i++) {
+            if (i != goalie_id_) {
+                positions[i] = Positions::Defense;
+            }
+        }
+        // Lowest non-goalie robot set to offense
+        if (goalie_id_ == 0) {
+            positions[1] = Positions::Offense;
+        } else {
+            positions[0] = Positions::Offense;
         }
     } else {
-        positions[1] = Positions::Defense;
-        for (int i = 2; i < kNumShells; i++) {
-            positions[i] = Positions::Offense;
+        // All robots set to offense
+        for (int i = 0; i < kNumShells; i++) {
+            if (i != goalie_id_) {
+                positions[i] = Positions::Offense;
+            }
+        }
+        // Lowest non-goalie robot set to defense
+        if (goalie_id_ == 0) {
+            positions[1] = Positions::Defense;
+        } else {
+            positions[0] = Positions::Defense;
         }
     }
     positions_message.client_positions = positions;

--- a/soccer/src/soccer/strategy/coach/coach_node.hpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.hpp
@@ -83,7 +83,7 @@ private:
     rj_msgs::msg::FieldDimensions current_field_dimensions_;
     bool have_field_dimensions_ = false;
 
-    int goalie_id_ = 0;  // sensible default?
+    int goalie_id_{0};
 
     void play_state_callback(const rj_msgs::msg::PlayState::SharedPtr msg);
     void world_state_callback(const rj_msgs::msg::WorldState::SharedPtr msg);

--- a/soccer/src/soccer/strategy/coach/coach_node.hpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.hpp
@@ -9,6 +9,7 @@
 #include <rj_geometry_msgs/msg/point.hpp>
 #include <rj_msgs/msg/coach_state.hpp>
 #include <rj_msgs/msg/global_override.hpp>
+#include <rj_msgs/msg/goalie.hpp>
 #include <rj_msgs/msg/play_state.hpp>
 #include <rj_msgs/msg/position_assignment.hpp>
 #include <rj_msgs/msg/robot_state.hpp>
@@ -64,6 +65,11 @@ private:
      */
     rclcpp::Subscription<rj_msgs::msg::FieldDimensions>::SharedPtr field_dimensions_sub_;
 
+    /*
+     * Let the referee determine which robot is the goalie.
+     */
+    rclcpp::Subscription<rj_msgs::msg::Goalie>::SharedPtr goalie_sub_;
+
     rclcpp::Publisher<rj_msgs::msg::PositionAssignment>::SharedPtr positions_pub_;
     rclcpp::Subscription<rj_msgs::msg::PlayState>::SharedPtr play_state_sub_;
     rclcpp::Subscription<rj_msgs::msg::WorldState>::SharedPtr world_state_sub_;
@@ -77,10 +83,13 @@ private:
     rj_msgs::msg::FieldDimensions current_field_dimensions_;
     bool have_field_dimensions_ = false;
 
+    int goalie_id_ = 0;  // sensible default?
+
     void play_state_callback(const rj_msgs::msg::PlayState::SharedPtr msg);
     void world_state_callback(const rj_msgs::msg::WorldState::SharedPtr msg);
     void ball_sense_callback(const rj_msgs::msg::RobotStatus::SharedPtr msg, bool our_team);
     void field_dimensions_callback(const rj_msgs::msg::FieldDimensions::SharedPtr& msg);
+    void goalie_callback(const rj_msgs::msg::Goalie::SharedPtr& msg);
     void check_for_play_state_change();
     /*
      * Handles actions the Coach does every tick. Currently calls assign_positions and


### PR DESCRIPTION
## Description
The referee should decide who the goalie is, instead of hard-coding 0. Coach and Agent-action-client updated to match.

## Associated / Resolved Issue

## Steps to Test
### Run Sim
1. Change goalie dropdown in top-right as you please

**Expected result:** You can set yellow/our goalie to any robot. The lowest numbered remaining robot is either offense or defense, the rest are the opposite (depending on possession). 

## Review Checklist

- [ ] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [ ] **Remove extra print statements**: Any print statements used for debugging should be removed
- [ ] **Tag reviewers**: Tag some people for review and ping them on Slack

