### PR TITLE
Strategy system uses real field dimensions

### DIFF
--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -27,6 +27,12 @@ AgentActionClient::AgentActionClient(int r_id)
         "strategy/coach_state", 1,
         [this](rj_msgs::msg::CoachState::SharedPtr msg) { coach_state_callback(msg); });
 
+    field_dimensions_sub_ = create_subscription<rj_msgs::msg::FieldDimensions>(
+        "config/field_dimensions", 1,
+        [this](rj_msgs::msg::FieldDimensions::SharedPtr msg) {
+            field_dimensions_callback(msg);
+        });
+
     robot_communication_srv_ = create_service<rj_msgs::srv::AgentCommunication>(
         fmt::format("agent_{}_incoming", r_id),
         [this](const std::shared_ptr<rj_msgs::srv::AgentCommunication::Request> request,
@@ -77,6 +83,15 @@ void AgentActionClient::coach_state_callback(const rj_msgs::msg::CoachState::Sha
     }
 
     current_position_->update_coach_state(*msg);
+}
+
+void AgentActionClient::field_dimensions_callback(
+    const rj_msgs::msg::FieldDimensions::SharedPtr& msg) {
+    if (current_position_ == nullptr) {
+        return;
+    }
+
+    current_position_->update_field_dimensions(rj_convert::convert_from_ros(*msg));
 }
 
 void AgentActionClient::get_task() {

--- a/soccer/src/soccer/strategy/agent/agent_action_client.hpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.hpp
@@ -53,11 +53,13 @@ private:
     rclcpp::Subscription<rj_msgs::msg::WorldState>::SharedPtr world_state_sub_;
     rclcpp::Subscription<rj_msgs::msg::CoachState>::SharedPtr coach_state_sub_;
     rclcpp::Subscription<rj_msgs::msg::PositionAssignment>::SharedPtr positions_sub_;
+    rclcpp::Subscription<rj_msgs::msg::FieldDimensions>::SharedPtr field_dimensions_sub_;
     // TODO(Kevin): communication module pub/sub here (e.g. passing)
 
     // callbacks for subs
     void world_state_callback(const rj_msgs::msg::WorldState::SharedPtr& msg);
     void coach_state_callback(const rj_msgs::msg::CoachState::SharedPtr& msg);
+    void field_dimensions_callback(const rj_msgs::msg::FieldDimensions::SharedPtr& msg);
 
     std::unique_ptr<Position> current_position_;
 

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -11,7 +11,7 @@ std::optional<RobotIntent> Defense::derived_get_task(RobotIntent intent) {
 
     // Create Waller
     Waller waller{0};
-    return waller.get_task(intent, world_state);
+    return waller.get_task(intent, world_state, this->field_dimensions_);
 }
 
 void Defense::receive_communication_response(communication::AgentPosResponseWrapper response) {

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -64,7 +64,7 @@ std::optional<RobotIntent> Goalie::state_to_task(RobotIntent intent) {
         return intent;
     } else if (latest_state_ == BALL_NOT_FOUND) {
         // TODO: make point dependent on team
-        rj_geometry::Point target_pt{0, 0.5};
+        rj_geometry::Point target_pt = this->field_dimensions_.our_defense_area().center();
         rj_geometry::Point target_vel{0.0, 0.0};
 
         planning::PathTargetFaceOption face_option = planning::FaceTarget{};
@@ -98,8 +98,8 @@ bool Goalie::shot_on_goal_detected(WorldState* world_state) {
     double time_to_cross = std::abs(ball_pos.y() / ball_vel.y());
     double cross_x = ball_pos.x() + ball_vel.x() * time_to_cross;
 
-    bool shot_on_target =
-        std::abs(cross_x) < 0.5;  // TODO(Kevin): add field to world_state to avoid hardcoding this
+    bool shot_on_target = std::abs(cross_x) < this->field_dimensions_.goal_width() / 2.0;
+
     bool ball_is_fast = ball_vel.mag() > 1.0;
     return ball_is_fast && shot_on_target;
 }

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -27,9 +27,8 @@ Goalie::State Goalie::update_state() {
     bool ball_is_slow = world_state->ball.velocity.mag() < 0.5;  // m/s
 
     rj_geometry::Point ball_pt = world_state->ball.position;
-    // TODO(Kevin): account for field direction when field coords
-    // added in
-    bool ball_in_box = ball_pt.y() < 1.0 && fabs(ball_pt.x()) < 1.0;  // m
+
+    bool ball_in_box = this->field_dimensions_.our_defense_area().contains_point(ball_pt);
     if (ball_is_slow && ball_in_box) {
         return CLEARING;
     }

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -2,7 +2,6 @@
 
 namespace strategy {
 
-// TODO(Kevin): lock Goalie id to id given by the ref
 Goalie::Goalie(int r_id) : Position(r_id) { position_name_ = "Goalie"; }
 
 std::optional<RobotIntent> Goalie::derived_get_task(RobotIntent intent) {

--- a/soccer/src/soccer/strategy/agent/position/position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/position.cpp
@@ -56,6 +56,10 @@ void Position::update_coach_state(rj_msgs::msg::CoachState msg) {
     /* SPDLOG_INFO("match_situation {}, our_possession {}", match_situation_, our_possession_); */
 }
 
+void Position::update_field_dimensions(FieldDimensions field_dims) {
+    field_dimensions_ = std::move(field_dims);
+}
+
 [[nodiscard]] WorldState* Position::world_state() {
     // thread-safe getter for world_state (see update_world_state())
     auto lock = std::lock_guard(world_state_mutex_);

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -10,6 +10,7 @@
 #include <rj_msgs/msg/coach_state.hpp>
 #include <rj_msgs/msg/empty_motion_command.hpp>
 #include <rj_msgs/msg/global_override.hpp>
+#include <rj_common/field_dimensions.hpp>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
@@ -66,6 +67,7 @@ public:
     // communication with AC
     void update_world_state(WorldState world_state);
     void update_coach_state(rj_msgs::msg::CoachState coach_state);
+    void update_field_dimensions(FieldDimensions field_dimensions);
     const std::string get_name();
 
     /**
@@ -130,6 +132,8 @@ protected:
     int match_situation_{};  // TODO: this is an enum, get from coach_node
     bool our_possession_{};
     rj_msgs::msg::GlobalOverride global_override_{};
+
+    FieldDimensions field_dimensions_ = FieldDimensions::kDefaultDimensions;
 
     /*
      * @return thread-safe ptr to most recent world_state

--- a/soccer/src/soccer/strategy/agent/position/role_interface.hpp
+++ b/soccer/src/soccer/strategy/agent/position/role_interface.hpp
@@ -41,8 +41,8 @@ public:
      * @param [RobotIntent intent] [RobotIntent of the Robot]
      * @return [RobotIntent with next target point for the robot]
      */
-    virtual std::optional<RobotIntent> get_task(RobotIntent intent,
-                                                const WorldState* world_state, FieldDimensions field_dimensions) = 0;
+    virtual std::optional<RobotIntent> get_task(RobotIntent intent, const WorldState* world_state,
+                                                FieldDimensions field_dimensions) = 0;
 
 private:
 };

--- a/soccer/src/soccer/strategy/agent/position/role_interface.hpp
+++ b/soccer/src/soccer/strategy/agent/position/role_interface.hpp
@@ -42,7 +42,7 @@ public:
      * @return [RobotIntent with next target point for the robot]
      */
     virtual std::optional<RobotIntent> get_task(RobotIntent intent,
-                                                const WorldState* world_state) = 0;
+                                                const WorldState* world_state, FieldDimensions field_dimensions) = 0;
 
 private:
 };

--- a/soccer/src/soccer/strategy/agent/position/waller.cpp
+++ b/soccer/src/soccer/strategy/agent/position/waller.cpp
@@ -7,7 +7,7 @@ Waller::Waller(int waller_num) {
     waller_pos_ = waller_num;
 }
 
-std::optional<RobotIntent> Waller::get_task(RobotIntent intent, const WorldState* world_state) {
+std::optional<RobotIntent> Waller::get_task(RobotIntent intent, const WorldState* world_state, FieldDimensions field_dimensions) {
     rj_geometry::Point ball_location{world_state->ball.position};
 
     // Get Goal Location (Always (0,0)) as of creation

--- a/soccer/src/soccer/strategy/agent/position/waller.cpp
+++ b/soccer/src/soccer/strategy/agent/position/waller.cpp
@@ -7,7 +7,8 @@ Waller::Waller(int waller_num) {
     waller_pos_ = waller_num;
 }
 
-std::optional<RobotIntent> Waller::get_task(RobotIntent intent, const WorldState* world_state, FieldDimensions field_dimensions) {
+std::optional<RobotIntent> Waller::get_task(RobotIntent intent, const WorldState* world_state,
+                                            FieldDimensions field_dimensions) {
     rj_geometry::Point ball_location{world_state->ball.position};
 
     // Get Goal Location (Always (0,0)) as of creation

--- a/soccer/src/soccer/strategy/agent/position/waller.cpp
+++ b/soccer/src/soccer/strategy/agent/position/waller.cpp
@@ -16,9 +16,9 @@ std::optional<RobotIntent> Waller::get_task(RobotIntent intent, const WorldState
     // Creates Minimum wall radius is slightly greater than  box bounds
     // Dimension accessors should be edited when we figure out how we are doing dimensions realtime
     // from vision
-    float box_w{FieldDimensions::kDefaultDimensions.penalty_long_dist()};
-    float box_h{FieldDimensions::kDefaultDimensions.penalty_short_dist()};
-    float line_w{FieldDimensions::kDefaultDimensions.line_width()};
+    float box_w{field_dimensions.penalty_long_dist()};
+    float box_h{field_dimensions.penalty_short_dist()};
+    float line_w{field_dimensions.line_width()};
     double min_wall_rad{(kRobotRadius * 4.0f) + line_w +
                         hypot(static_cast<double>(box_w) / 2, static_cast<double>((box_h)))};
 

--- a/soccer/src/soccer/strategy/agent/position/waller.hpp
+++ b/soccer/src/soccer/strategy/agent/position/waller.hpp
@@ -37,7 +37,7 @@ public:
      * @param [RobotIntent intent] [RobotIntent of the Defensive Robot]
      * @return [RobotIntent with next target point for the robot]
      */
-    std::optional<RobotIntent> get_task(RobotIntent intent, const WorldState* world_state) override;
+    std::optional<RobotIntent> get_task(RobotIntent intent, const WorldState* world_state, FieldDimensions field_dimensions) override;
 
 private:
     std::string defense_type_;

--- a/soccer/src/soccer/strategy/agent/position/waller.hpp
+++ b/soccer/src/soccer/strategy/agent/position/waller.hpp
@@ -37,7 +37,8 @@ public:
      * @param [RobotIntent intent] [RobotIntent of the Defensive Robot]
      * @return [RobotIntent with next target point for the robot]
      */
-    std::optional<RobotIntent> get_task(RobotIntent intent, const WorldState* world_state, FieldDimensions field_dimensions) override;
+    std::optional<RobotIntent> get_task(RobotIntent intent, const WorldState* world_state,
+                                        FieldDimensions field_dimensions) override;
 
 private:
     std::string defense_type_;

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -238,8 +238,9 @@ rj_geometry::ShapeSet CoachNode::create_defense_area_obstacles() {
     auto their_defense_area =
         is_extra_dist_necessary
             ? std::make_shared<rj_geometry::Rect>(
-                  current_field_dimensions_.their_defense_area_padded(slack_around_box))
-            : std::make_shared<rj_geometry::Rect>(current_field_dimensions_.their_defense_area());
+                  std::move(current_field_dimensions_.their_defense_area_padded(slack_around_box)))
+            : std::make_shared<rj_geometry::Rect>(
+                  std::move(current_field_dimensions_.their_defense_area()));
 
     // Combine both defense areas into ShapeSet
     rj_geometry::ShapeSet def_area_obstacles{};

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -221,8 +221,8 @@ void CoachNode::publish_static_obstacles() {
 
 rj_geometry::ShapeSet CoachNode::create_defense_area_obstacles() {
     // Create defense areas as rectangular area obstacles
-    auto our_defense_area{
-        std::make_shared<rj_geometry::Rect>(current_field_dimensions_.our_defense_area())};
+    auto our_defense_area{std::make_shared<rj_geometry::Rect>(
+        std::move(current_field_dimensions_.our_defense_area()))};
 
     // Sometimes there is a greater distance we need to keep:
     // https://robocup-ssl.github.io/ssl-rules/sslrules.html#_robot_too_close_to_opponent_defense_area

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -201,7 +201,7 @@ void CoachNode::overrides_callback(const rj_msgs::msg::PositionAssignment::Share
 }
 
 void CoachNode::field_dimensions_callback(const rj_msgs::msg::FieldDimensions::SharedPtr& msg) {
-    current_field_dimensions_ = *msg;
+    current_field_dimensions_ = rj_convert::convert_from_ros(*msg);
     have_field_dimensions_ = true;
 }
 
@@ -221,20 +221,8 @@ void CoachNode::publish_static_obstacles() {
 
 rj_geometry::ShapeSet CoachNode::create_defense_area_obstacles() {
     // Create defense areas as rectangular area obstacles
-
-    // Create our defense area using field dimensions
-    float def_long_dist = current_field_dimensions_.penalty_long_dist / 2.0f;
-    float def_short_dist = current_field_dimensions_.penalty_short_dist;
-    float line_width = current_field_dimensions_.line_width;
-    float field_length = current_field_dimensions_.length;
-
-    rj_geometry::Point o_top_left{def_long_dist + line_width, 0.0};
-
-    rj_geometry::Point o_bot_right{-def_long_dist - line_width, def_short_dist};
-
-    auto our_defense_area{std::make_shared<rj_geometry::Rect>(o_top_left, o_bot_right)};
-
-    // Create opponent defense area using field dimensions
+    auto our_defense_area{
+        std::make_shared<rj_geometry::Rect>(current_field_dimensions_.our_defense_area())};
 
     // Sometimes there is a greater distance we need to keep:
     // https://robocup-ssl.github.io/ssl-rules/sslrules.html#_robot_too_close_to_opponent_defense_area
@@ -245,16 +233,13 @@ rj_geometry::ShapeSet CoachNode::create_defense_area_obstacles() {
                                     current_play_state_.restart == PlayState::Restart::Indirect);
 
     // Also add a slack around the box
-    double slack_around_box = 0.1;
-    double extra_dist = is_extra_dist_necessary ? 0.2 + slack_around_box : 0;
-    double left_x = def_long_dist + line_width + extra_dist;
+    float slack_around_box{0.3f};
 
-    rj_geometry::Point t_bot_left{left_x, field_length};
-
-    rj_geometry::Point t_top_right{-left_x,
-                                   field_length - (def_short_dist + line_width + extra_dist)};
-
-    auto their_defense_area{std::make_shared<rj_geometry::Rect>(t_bot_left, t_top_right)};
+    auto their_defense_area =
+        is_extra_dist_necessary
+            ? std::make_shared<rj_geometry::Rect>(
+                  current_field_dimensions_.their_defense_area_padded(slack_around_box))
+            : std::make_shared<rj_geometry::Rect>(current_field_dimensions_.their_defense_area());
 
     // Combine both defense areas into ShapeSet
     rj_geometry::ShapeSet def_area_obstacles{};
@@ -267,9 +252,9 @@ rj_geometry::ShapeSet CoachNode::create_defense_area_obstacles() {
 rj_geometry::ShapeSet CoachNode::create_goal_wall_obstacles() {
     // Create physical walls of the goals as static obstacles
     double physical_goal_board_width = 0.1;
-    float goal_width = current_field_dimensions_.goal_width;
-    float goal_depth = current_field_dimensions_.goal_depth;
-    float field_length = current_field_dimensions_.length;
+    float goal_width = current_field_dimensions_.goal_width();
+    float goal_depth = current_field_dimensions_.goal_depth();
+    float field_length = current_field_dimensions_.length();
 
     // Each goal is three rectangles
     rj_geometry::Point og1_1{goal_width / 2, -goal_depth};

--- a/soccer/src/soccer/strategy/coach/coach_node.hpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.hpp
@@ -87,7 +87,7 @@ private:
     bool possessing_ = false;
     bool play_state_has_changed_ = true;
 
-    rj_msgs::msg::FieldDimensions current_field_dimensions_;
+    FieldDimensions current_field_dimensions_;
     bool have_field_dimensions_ = false;
 
     /*


### PR DESCRIPTION
## Description
- Update Field Dimensions to calculate the obstacle dimensions that coach needs.
- Coach uses obstacle dimensions from FieldDimensions
- Position and Role interfaces are updated to accept field dimensions
- Goalie and Waller are updated to use field dimensions
## Associated / Resolved Issue
[ClickUp card](https://app.clickup.com/t/8677mfmhm)

## Steps to Test
### Test Case 1
Nothing should really change visually, but theoretically if we had field dimensions that were non-default then everything should update

## Key Files to Review
FieldDimensions
 * `field_dimensions.hpp`

Coach
 * `coach_node.hpp`
 * `coach_node.cpp`

Position and Role
 * `agent_action_client`
 * `position`
 * `waller`
 * `defense`
 * `goalie`

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack
