### PR TITLE
Update to CoachState.msg

### DIFF
--- a/rj_msgs/msg/CoachState.msg
+++ b/rj_msgs/msg/CoachState.msg
@@ -1,4 +1,4 @@
-# match_situation is an enum defined in soccer/src/soccer/coach/coach_node.hpp
-uint8 match_situation
+# state and restart are an enum defined in soccer/src/soccer/.hpp
+PlayState play_state
 bool our_possession
 GlobalOverride global_override

--- a/soccer/src/soccer/strategy/agent/position/position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/position.cpp
@@ -49,11 +49,12 @@ void Position::update_world_state(WorldState world_state) {
 }
 
 void Position::update_coach_state(rj_msgs::msg::CoachState msg) {
-    match_situation_ = msg.match_situation;
+    match_state_ = msg.play_state.state;
+    match_restart_ = msg.play_state.restart;
     our_possession_ = msg.our_possession;
     // TODO: how is planner supposed to get this global override info?
     global_override_ = msg.global_override;
-    /* SPDLOG_INFO("match_situation {}, our_possession {}", match_situation_, our_possession_); */
+    /* SPDLOG_INFO("match_restart {}, match_state {}, our_possession {}", match_restart_, match_state_, our_possession_); */
 }
 
 [[nodiscard]] WorldState* Position::world_state() {

--- a/soccer/src/soccer/strategy/agent/position/position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/position.cpp
@@ -54,7 +54,8 @@ void Position::update_coach_state(rj_msgs::msg::CoachState msg) {
     our_possession_ = msg.our_possession;
     // TODO: how is planner supposed to get this global override info?
     global_override_ = msg.global_override;
-    /* SPDLOG_INFO("match_restart {}, match_state {}, our_possession {}", match_restart_, match_state_, our_possession_); */
+    /* SPDLOG_INFO("match_restart {}, match_state {}, our_possession {}", match_restart_,
+     * match_state_, our_possession_); */
 }
 
 [[nodiscard]] WorldState* Position::world_state() {

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -126,7 +126,7 @@ protected:
     // fields for coach_state
     // TODO: this is not thread-safe, does it need to be?
     // (if so match world_state below)
-    int match_state_{};  // TODO: this is an enum, get from PlayState
+    int match_state_{};    // TODO: this is an enum, get from PlayState
     int match_restart_{};  // TODO: this is an enum, get from PlayState
     bool our_possession_{};
     rj_msgs::msg::GlobalOverride global_override_{};

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -126,7 +126,8 @@ protected:
     // fields for coach_state
     // TODO: this is not thread-safe, does it need to be?
     // (if so match world_state below)
-    int match_situation_{};  // TODO: this is an enum, get from coach_node
+    int match_state_{};  // TODO: this is an enum, get from PlayState
+    int match_restart_{};  // TODO: this is an enum, get from PlayState
     bool our_possession_{};
     rj_msgs::msg::GlobalOverride global_override_{};
 

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -98,26 +98,7 @@ void CoachNode::coach_ticker() {
 void CoachNode::check_for_play_state_change() {
     if (play_state_has_changed_) {
         rj_msgs::msg::CoachState coach_message;
-
-        switch (current_play_state_.restart) {
-            case PlayState::Restart::Placement:
-                coach_message.match_situation = MatchSituation::ball_placement;
-                break;
-            case PlayState::Restart::Kickoff:
-                coach_message.match_situation = MatchSituation::kickoff;
-                break;
-            case PlayState::Restart::Free:
-                coach_message.match_situation = MatchSituation::free_kick;
-                break;
-            case PlayState::Restart::Penalty:
-                coach_message.match_situation = MatchSituation::penalty_kick;
-                break;
-        }
-
-        if (current_play_state_.state == PlayState::State::Playing) {
-            coach_message.match_situation = MatchSituation::in_play;
-        }
-
+        coach_message.play_state = current_play_state_;
         rj_msgs::msg::GlobalOverride global_override;
 
         switch (current_play_state_.state) {
@@ -134,6 +115,7 @@ void CoachNode::check_for_play_state_change() {
                 // instead.
                 global_override.max_speed = 10.0;
                 global_override.min_dist_from_ball = 0;
+                break;
         }
 
         // publish new necessary information

--- a/util/clang-tidy-to-junit.py
+++ b/util/clang-tidy-to-junit.py
@@ -35,10 +35,8 @@ class ClangTidyConverter:
 
     def print_junit_file(self, output_file):
         # Write the header.
-        output_file.write(
-            """<?xml version="1.0" encoding="UTF-8" ?>
-<testsuites>"""
-        )
+        output_file.write("""<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites>""")
 
         sorted_errors = sorted(self.errors, key=lambda x: x.file)
 


### PR DESCRIPTION
## Description
Passed in the PlayState into the CoachState rather than converge into one match_situation. Will be useful to create new positions based on external ref.

## Associated / Resolved Issue
[ClickUp card](https://app.clickup.com/t/8677t958u)

## Steps to Test
### Test Case 1
1. Start up external ref and run-sim-external
2. echo topic strategy/coach_state

**Expected result:** play state message should change with the different states in the external ref

## Key Files to Review
Group 1
 * coach_node.cpp
 * position.cpp

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack
