### PR TITLE
Simplify networking

### DIFF
--- a/rj_common/include/rj_common/network.hpp
+++ b/rj_common/include/rj_common/network.hpp
@@ -30,8 +30,32 @@
 // channel is given on the command line, the first available one is picked based
 // on which soccer-side port can be bound.
 
-static const std::string kRefereeAddress = "224.5.23.1";
-static const std::string kSharedVisionAddress = "224.5.23.2";
+/*
+ * These IP addresses are the multicast addresses we expect referee and vision
+ * data to come from, respectively. These are given by the league.
+ *
+ * In networking terms, the referee packets' source address should match
+ * kRefereeSourceAddress, and same thing for SharedVisionAddress.
+ *
+ * The physical interface we expect to receive these packets from is defined
+ * below.
+ */
+static const std::string kRefereeSourceAddress = "224.5.23.1";
+static const std::string kSharedVisionSourceAddress = "224.5.23.2";
+
+/* These IP addresses are the interfaces (e.g. Ethernet plugged into this
+ * laptop) where we expect ref/vision data to come from. They are (likely)
+ * physical Ethernet links to the network, so this address won't show up in
+ * Wireshark.
+ *
+ * When running sim, this should be localhost = 127.0.0.1.
+ *
+ * Run ifconfig to see list of interfaces on this computer, and pick the right
+ * one (or try them all in worst-case).
+ */
+static const std::string kRefereeInterface = "127.0.0.1";
+// In all but rare cirucmstances, this should match kRefereeInterface.
+static const std::string kVisionInterface = kRefereeInterface;
 
 static const int kSimVisionPort = 10020;  // was 10020 before 1-30-2022
 static const int kSimBlueStatusPort = 30011;

--- a/rj_common/include/rj_common/network.hpp
+++ b/rj_common/include/rj_common/network.hpp
@@ -43,7 +43,12 @@
 static const std::string kRefereeSourceAddress = "224.5.23.1";
 static const std::string kSharedVisionSourceAddress = "224.5.23.2";
 
-/* These IP addresses are the interfaces (e.g. Ethernet plugged into this
+/*
+ * UPDATE (4/9/2023): these are no longer necessary. Both VisionReceiver and
+ * ExternalReferee now simply join the multicast group and listen for their
+ * respective source addresses above.
+ *
+ * These IP addresses are the interfaces (e.g. Ethernet plugged into this
  * laptop) where we expect ref/vision data to come from. They are (likely)
  * physical Ethernet links to the network, so this address won't show up in
  * Wireshark.
@@ -54,8 +59,8 @@ static const std::string kSharedVisionSourceAddress = "224.5.23.2";
  * one (or try them all in worst-case).
  */
 static const std::string kRefereeInterface = "127.0.0.1";
-// In all but rare cirucmstances, this should match kRefereeInterface.
-static const std::string kVisionInterface = kRefereeInterface;
+static const std::string kVisionInterface =
+    kRefereeInterface;  // In all but rare cirucmstances, this should match kRefereeInterface.
 
 static const int kSimVisionPort = 10020;  // was 10020 before 1-30-2022
 static const int kSimBlueStatusPort = 30011;

--- a/rj_vision_receiver/src/vision_receiver.cpp
+++ b/rj_vision_receiver/src/vision_receiver.cpp
@@ -101,8 +101,9 @@ void VisionReceiver::set_port(const std::string& interface, int port) {
     // take them
     SPDLOG_INFO("VisionReceiver joining kSharedVisionSourceAddress: {}",
                 kSharedVisionSourceAddress);
-    socket_.set_option(boost::asio::ip::multicast::join_group(
-        boost::asio::ip::address::from_string(kSharedVisionSourceAddress).to_v4()));
+    const boost::asio::ip::address_v4 multicast_address =
+        boost::asio::ip::address::from_string(kSharedVisionSourceAddress).to_v4();
+    socket_.set_option(boost::asio::ip::multicast::join_group(multicast_address));
 
     // Bind the socket.
     boost::system::error_code bind_error;

--- a/rj_vision_receiver/src/vision_receiver.cpp
+++ b/rj_vision_receiver/src/vision_receiver.cpp
@@ -97,15 +97,12 @@ void VisionReceiver::set_port(const std::string& interface, int port) {
     socket_.open(udp::v4());
     socket_.set_option(udp::socket::reuse_address(true));
 
-    if (!interface.empty()) {
-        socket_.set_option(boost::asio::ip::multicast::join_group(
-            boost::asio::ip::address::from_string(kSharedVisionAddress).to_v4(),
-            boost::asio::ip::address::from_string(interface).to_v4()));
-    } else {
-        SPDLOG_INFO("VisionReceiver joining kSharedVisionAddress: {}", kSharedVisionAddress);
-        socket_.set_option(boost::asio::ip::multicast::join_group(
-            boost::asio::ip::address::from_string(kSharedVisionAddress).to_v4()));
-    }
+    // VisionReceiver will find any packets from kSharedVisionSourceAddressand
+    // take them
+    SPDLOG_INFO("VisionReceiver joining kSharedVisionSourceAddress: {}",
+                kSharedVisionSourceAddress);
+    socket_.set_option(boost::asio::ip::multicast::join_group(
+        boost::asio::ip::address::from_string(kSharedVisionSourceAddress).to_v4()));
 
     // Bind the socket.
     boost::system::error_code bind_error;

--- a/soccer/src/soccer/referee/external_referee.cpp
+++ b/soccer/src/soccer/referee/external_referee.cpp
@@ -36,11 +36,6 @@ static const int kKickVerifyTimeMs = 250;
 // the ref halts/stops, make this false
 static const bool kCancelBallPlaceOnHalt = true;
 
-// this IP addr should be where the external ref sends messages
-// see PR #1887 for last time this file was used w/ external interface
-// run ifconfig to see list of interfaces on this computer
-DEFINE_STRING(kRefereeParamModule, interface, "127.0.0.1", "The interface for referee operation");
-
 ExternalReferee::ExternalReferee() : RefereeBase{"external_referee"}, asio_socket_{io_service_} {
     this->get_parameter("team_name", param_team_name_);
     SPDLOG_INFO("ExternalReferee team_name: {}", param_team_name_);
@@ -74,7 +69,7 @@ void ExternalReferee::receive_packet(const boost::system::error_code& error, siz
     SSL_Referee ref_packet;
     if (!ref_packet.ParseFromArray(recv_buffer_.data(), num_bytes)) {
         SPDLOG_ERROR("Got bad packet of {} bytes from {}", num_bytes, sender_endpoint_);
-        SPDLOG_ERROR("Address: {}", fmt::ptr(&kRefereeAddress));
+        SPDLOG_ERROR("Address: {}", fmt::ptr(&kRefereeSourceAddress));
         return;
     }
 
@@ -119,9 +114,9 @@ void ExternalReferee::setup_referee_multicast() {
     }
     // Join multicast group
     const boost::asio::ip::address_v4 multicast_address =
-        boost::asio::ip::address::from_string(kRefereeAddress).to_v4();
+        boost::asio::ip::address::from_string(kRefereeSourceAddress).to_v4();
     const boost::asio::ip::address_v4 multicast_interface =
-        boost::asio::ip::address::from_string(PARAM_interface).to_v4();
+        boost::asio::ip::address::from_string(kRefereeInterface).to_v4();
     asio_socket_.set_option(
         boost::asio::ip::multicast::join_group(multicast_address, multicast_interface));
 }

--- a/soccer/src/soccer/referee/external_referee.cpp
+++ b/soccer/src/soccer/referee/external_referee.cpp
@@ -115,6 +115,7 @@ void ExternalReferee::setup_referee_multicast() {
 
     // ExternalReferee will find any packets from kRefereeSourceAddress take
     // them
+    SPDLOG_INFO("ExternalReferee joining kRefereeSourceAddress: {}", kRefereeSourceAddress);
     const boost::asio::ip::address_v4 multicast_address =
         boost::asio::ip::address::from_string(kRefereeSourceAddress).to_v4();
     asio_socket_.set_option(boost::asio::ip::multicast::join_group(multicast_address));

--- a/soccer/src/soccer/referee/external_referee.cpp
+++ b/soccer/src/soccer/referee/external_referee.cpp
@@ -112,13 +112,12 @@ void ExternalReferee::setup_referee_multicast() {
     } catch (const boost::system::system_error& e) {
         throw std::runtime_error("Failed to bind to shared referee port");
     }
-    // Join multicast group
+
+    // ExternalReferee will find any packets from kRefereeSourceAddress take
+    // them
     const boost::asio::ip::address_v4 multicast_address =
         boost::asio::ip::address::from_string(kRefereeSourceAddress).to_v4();
-    const boost::asio::ip::address_v4 multicast_interface =
-        boost::asio::ip::address::from_string(kRefereeInterface).to_v4();
-    asio_socket_.set_option(
-        boost::asio::ip::multicast::join_group(multicast_address, multicast_interface));
+    asio_socket_.set_option(boost::asio::ip::multicast::join_group(multicast_address));
 }
 
 void ExternalReferee::update() { io_service_.poll(); }


### PR DESCRIPTION
## Description
Previously, correcting the interfaces we receive ref/vision data from required a lot of hardcoding in two separate files. Now it should not require any knowledge of interfaces or networking at all!

## Design Documents
![IMG_4585](https://user-images.githubusercontent.com/30275369/230816390-ac40df3f-b685-4d37-bef2-0c8cc8215dd8.jpg)

## Steps to Test
### Test Case 1

1. Build and run `run-sim-ex` (**NOT `run-sim`**)
2. Launch external referee (ssl-game-controller)
3. Launch ER-Force sim manually (cd to framework, then `./build/bin/simulator-cli -g 2020B`)

**Expected result:** Works the same as ROS2 (robot 2 struggles to pass)

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack
