### PR TITLE
Waller Communication Trimmed

### DIFF
--- a/rj_msgs/CMakeLists.txt
+++ b/rj_msgs/CMakeLists.txt
@@ -24,6 +24,7 @@ rosidl_generate_interfaces(
 
   # Messages
   msg/AgentState.msg
+  msg/AliveRobots.msg
   msg/BallState.msg
   msg/BallPlacement.msg
   msg/CoachState.msg
@@ -66,12 +67,16 @@ rosidl_generate_interfaces(
   request/TestRequest.msg
   request/IncomingBallRequest.msg
   request/BallInTransitRequest.msg
+  request/JoinWallRequest.msg
+  request/LeaveWallRequest.msg
 
   # Agent Response Messages
   response/Acknowledge.msg
   response/PassResponse.msg
   response/PositionResponse.msg
   response/TestResponse.msg
+  response/JoinWallResponse.msg
+  response/LeaveWallResponse.msg
 
   # Services
   srv/AgentCommunication.srv

--- a/rj_msgs/msg/AgentRequest.msg
+++ b/rj_msgs/msg/AgentRequest.msg
@@ -8,3 +8,5 @@ PositionRequest[<=1] position_request
 PassRequest[<=1] pass_request
 IncomingBallRequest[<=1] incoming_ball_request
 BallInTransitRequest[<=1] ball_in_transit_request
+JoinWallRequest[<=1] join_wall_request
+LeaveWallRequest[<=1] leave_wall_request

--- a/rj_msgs/msg/AgentResponseVariant.msg
+++ b/rj_msgs/msg/AgentResponseVariant.msg
@@ -2,3 +2,5 @@ Acknowledge[<=1] acknowledge_response
 TestResponse[<=1] test_response
 PositionResponse[<=1] position_response
 PassResponse[<=1] pass_response
+JoinWallResponse[<=1] join_wall_response
+LeaveWallResponse[<=1] leave_wall_response

--- a/rj_msgs/msg/AliveRobots.msg
+++ b/rj_msgs/msg/AliveRobots.msg
@@ -1,0 +1,1 @@
+uint8[] alive_robots

--- a/rj_msgs/request/JoinWallRequest.msg
+++ b/rj_msgs/request/JoinWallRequest.msg
@@ -1,0 +1,2 @@
+uint32 request_uid
+uint8 robot_id

--- a/rj_msgs/request/LeaveWallRequest.msg
+++ b/rj_msgs/request/LeaveWallRequest.msg
@@ -1,0 +1,2 @@
+uint32 request_uid
+uint8 robot_id

--- a/rj_msgs/response/JoinWallResponse.msg
+++ b/rj_msgs/response/JoinWallResponse.msg
@@ -1,0 +1,2 @@
+uint32 response_uid
+uint8 robot_id

--- a/rj_msgs/response/LeaveWallResponse.msg
+++ b/rj_msgs/response/LeaveWallResponse.msg
@@ -1,0 +1,2 @@
+uin32 response_uid
+uint8 robot_id

--- a/rj_msgs/response/LeaveWallResponse.msg
+++ b/rj_msgs/response/LeaveWallResponse.msg
@@ -1,2 +1,2 @@
-uin32 response_uid
+uint32 response_uid
 uint8 robot_id

--- a/soccer/src/soccer/radio/network_radio.cpp
+++ b/soccer/src/soccer/radio/network_radio.cpp
@@ -6,6 +6,7 @@
 
 #include <rj_common/network.hpp>
 #include <rj_common/status.hpp>
+#include <rj_msgs/msg/alive_robots.hpp>
 
 #include "packet_convert.hpp"
 #include "rj_geometry/util.hpp"
@@ -30,6 +31,12 @@ NetworkRadio::NetworkRadio() : socket_(io_service_), recv_buffer_{}, send_buffer
     socket_.bind(udp::endpoint(udp::v4(), param_server_port_));
 
     start_receive();
+
+    alive_robots_pub_ =
+        this->create_publisher<rj_msgs::msg::AliveRobots>("strategy/alive_robots", rclcpp::QoS(1));
+
+    alive_robots_timer_ =
+        create_wall_timer(std::chrono::milliseconds(16), [this]() { publish_alive_robots(); });
 }
 
 void NetworkRadio::start_receive() {
@@ -135,5 +142,20 @@ void NetworkRadio::receive_packet(const boost::system::error_code& error, std::s
 }
 
 void NetworkRadio::switch_team(bool /*blue_team*/) {}
+
+void NetworkRadio::publish_alive_robots() {
+    // copy the values from robot_ip_map_ into a vector
+    std::vector<u_int8_t> alive_robots;
+    alive_robots.reserve(robot_ip_map_.size());
+    std::transform(robot_ip_map_.begin(), robot_ip_map_.end(), back_inserter(alive_robots),
+                   [](std::pair<boost::asio::ip::udp::endpoint, int> const& pair) {
+                       return (u_int8_t)pair.second;
+                   });
+
+    // publish a message containing the alive robots
+    rj_msgs::msg::AliveRobots alive_message{};
+    alive_message.alive_robots = alive_robots;
+    alive_robots_pub_->publish(alive_message);
+}
 
 }  // namespace radio

--- a/soccer/src/soccer/radio/network_radio.hpp
+++ b/soccer/src/soccer/radio/network_radio.hpp
@@ -7,6 +7,7 @@
 #include <boost/bimap/multiset_of.hpp>
 #include <boost/config.hpp>
 
+#include <rj_msgs/msg/alive_robots.hpp>
 #include <robot_intent.hpp>
 
 #include "radio.hpp"
@@ -59,6 +60,15 @@ protected:
     std::vector<std::array<uint8_t, rtp::HeaderSize + sizeof(rtp::RobotTxMessage)>> send_buffers_{};
 
     constexpr static std::chrono::duration kTimeout = std::chrono::milliseconds(250);
+
+    rclcpp::Publisher<rj_msgs::msg::AliveRobots>::SharedPtr alive_robots_pub_;
+    rclcpp::TimerBase::SharedPtr alive_robots_timer_;
+
+    /**
+     * @brief Publish a vector of alive robots to the "strategy/alive_robots" endpoint
+     *
+     */
+    void publish_alive_robots();
 };
 
 }  // namespace radio

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -117,14 +117,10 @@ void AgentActionClient::field_dimensions_callback(
 
 void AgentActionClient::alive_robots_callback(const rj_msgs::msg::AliveRobots::SharedPtr& msg) {
     alive_robots_ = msg->alive_robots;
-    for (u_int8_t alive_robot_id : alive_robots_) {
-        SPDLOG_INFO("\022[92mRobot {} is Alive\033[0m", alive_robot_id);
-    }
 }
 
 void AgentActionClient::game_settings_callback(const rj_msgs::msg::GameSettings::SharedPtr& msg) {
     is_simulated_ = msg->simulation;
-    SPDLOG_INFO("\033[92mIs Simulated: {}\033[0m", is_simulated_);
 }
 
 bool AgentActionClient::check_robot_alive(u_int8_t robot_id) {
@@ -182,8 +178,13 @@ void AgentActionClient::update_position(const rj_msgs::msg::PositionAssignment::
             break;
     };
 
-    if (current_position_ == nullptr ||
-        next_position_->get_name() != current_position_->get_name()) {
+    if (current_position_ == nullptr) {
+        current_position_ = std::move(next_position_);
+    } else if (next_position_->get_name() != current_position_->get_name()) {
+        // Call robot's die functionality
+        current_position_->die();
+        // Send any final death communications from robot
+        get_communication();
         current_position_ = std::move(next_position_);
     }
 

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -33,6 +33,14 @@ AgentActionClient::AgentActionClient(int r_id)
         "config/field_dimensions", 1,
         [this](rj_msgs::msg::FieldDimensions::SharedPtr msg) { field_dimensions_callback(msg); });
 
+    alive_robots_sub_ = create_subscription<rj_msgs::msg::AliveRobots>(
+        "strategy/alive_robots", 1,
+        [this](rj_msgs::msg::AliveRobots::SharedPtr msg) { alive_robots_callback(msg); });
+
+    game_settings_sub_ = create_subscription<rj_msgs::msg::GameSettings>(
+        "config/game_settings", 1,
+        [this](rj_msgs::msg::GameSettings::SharedPtr msg) { game_settings_callback(msg); });
+
     robot_communication_srv_ = create_service<rj_msgs::srv::AgentCommunication>(
         fmt::format("agent_{}_incoming", r_id),
         [this](const std::shared_ptr<rj_msgs::srv::AgentCommunication::Request> request,
@@ -62,6 +70,17 @@ AgentActionClient::AgentActionClient(int r_id)
             get_communication();
             check_communication_timeout();
         });
+
+    update_alive_robots_timer_ = create_wall_timer(std::chrono::milliseconds(1000),
+                                                   [this]() { update_position_alive_robots(); });
+
+    if (r_id == 0) {
+        current_position_ = std::make_unique<Goalie>(r_id);
+    } else if (r_id == 1 || r_id == 3 || r_id == 5) {
+        current_position_ = std::make_unique<Defense>(r_id);
+    } else if (r_id == 2 || r_id == 4) {
+        current_position_ = std::make_unique<Offense>(r_id);
+    }
 }
 
 void AgentActionClient::world_state_callback(const rj_msgs::msg::WorldState::SharedPtr& msg) {
@@ -91,7 +110,33 @@ void AgentActionClient::field_dimensions_callback(
         return;
     }
 
-    current_position_->update_field_dimensions(rj_convert::convert_from_ros(*msg));
+    FieldDimensions field_dimensions = rj_convert::convert_from_ros(*msg);
+    field_dimensions_ = field_dimensions;
+    current_position_->update_field_dimensions(field_dimensions);
+}
+
+void AgentActionClient::alive_robots_callback(const rj_msgs::msg::AliveRobots::SharedPtr& msg) {
+    alive_robots_ = msg->alive_robots;
+}
+
+void AgentActionClient::game_settings_callback(const rj_msgs::msg::GameSettings::SharedPtr& msg) {
+    is_simulated_ = msg->simulation;
+}
+
+bool AgentActionClient::check_robot_alive(u_int8_t robot_id) {
+    if (!is_simulated_) {
+        return std::find(alive_robots_.begin(), alive_robots_.end(), robot_id) !=
+               alive_robots_.end();
+    } else {
+        if (this->world_state()->get_robot(true, robot_id).visible) {
+            rj_geometry::Point robot_position =
+                this->world_state()->get_robot(true, robot_id).pose.position();
+            rj_geometry::Rect padded_field_rect = field_dimensions_.field_coordinates();
+            padded_field_rect.pad(field_padding_);
+            return padded_field_rect.contains_point(robot_position);
+        }
+        return false;
+    }
 }
 
 void AgentActionClient::get_task() {
@@ -224,6 +269,11 @@ void AgentActionClient::result_callback(const GoalHandleRobotMove::WrappedResult
 }
 
 void AgentActionClient::get_communication() {
+    // Don't even humor requests from robots that aren't alive
+    if (!check_robot_alive(robot_id_)) {
+        return;
+    }
+
     // Initialize default positions (if not already initialized)
     if (current_position_ == nullptr) {
         if (robot_id_ == 0) {
@@ -235,6 +285,18 @@ void AgentActionClient::get_communication() {
         }
     }
 
+    bool any_robots_alive = false;
+    for (u_int8_t i = 0; i < kNumShells; i++) {
+        if (check_robot_alive(i)) {
+            any_robots_alive = true;
+            break;
+        }
+    }
+
+    if (!any_robots_alive) {
+        return;
+    }
+
     auto optional_communication_request = current_position_->send_communication_request();
     if (!optional_communication_request.has_value()) {
         return;
@@ -242,56 +304,45 @@ void AgentActionClient::get_communication() {
 
     auto communication_request = optional_communication_request.value();
 
-    bool robots_visible = false;
-    for (u_int8_t i = 0; i < kNumShells; i++) {
-        if (this->world_state()->get_robot(true, i).visible) {
-            robots_visible = true;
-            break;
-        }
-    }
+    // create a buffer to hold the responses and the outgoing request
+    communication::AgentPosResponseWrapper buffered_response;
 
-    if (robots_visible) {
-        // SPDLOG_INFO("\033[92mSENDING REQUEST\033[0m");
-        // update the last communication
-        last_communication_ = communication_request.request;
-        // create a buffer to hold the responses and the outgoing request
-        communication::AgentPosResponseWrapper buffered_response;
+    auto request = std::make_shared<rj_msgs::srv::AgentCommunication::Request>();
+    request->agent_request = rj_convert::convert_to_ros(communication_request.request);
 
-        auto request = std::make_shared<rj_msgs::srv::AgentCommunication::Request>();
-        request->agent_request = rj_convert::convert_to_ros(communication_request.request);
-
-        // send communication requests
-        if (communication_request.broadcast) {
-            for (int i = 0; i < ((int)kNumShells); i++) {
-                if (i != robot_id_ && this->world_state()->get_robot(true, i).visible) {
-                    robot_communication_cli_[i]->async_send_request(
-                        request, [this, i](const std::shared_future<
-                                           rj_msgs::srv::AgentCommunication::Response::SharedPtr>
-                                               response) {
-                            receive_response_callback(response, ((u_int8_t)i));
-                        });
-                }
+    // send communication requests
+    std::vector<u_int8_t> sent_robot_ids = {};
+    if (communication_request.broadcast) {
+        for (u_int8_t i = 0; i < kNumShells; i++) {
+            if (i != robot_id_ && check_robot_alive(i)) {
+                robot_communication_cli_[i]->async_send_request(
+                    request, [this, i](const std::shared_future<
+                                       rj_msgs::srv::AgentCommunication::Response::SharedPtr>
+                                           response) {
+                        receive_response_callback(response, ((u_int8_t)i));
+                    });
+                sent_robot_ids.push_back(i);
             }
-            // set broadcast to true in buffer
-            buffered_response.broadcast = true;
-        } else {
-            for (u_int8_t i : communication_request.target_agents) {
+        }
+        // set broadcast to true in buffer
+        buffered_response.broadcast = true;
+    } else {
+        for (u_int8_t i : communication_request.target_agents) {
+            if (i != robot_id_ && check_robot_alive(i)) {
                 robot_communication_cli_[i]->async_send_request(
                     request, [this, i](const std::shared_future<
                                        rj_msgs::srv::AgentCommunication::Response::SharedPtr>
                                            response) { receive_response_callback(response, i); });
+                sent_robot_ids.push_back(i);
             }
-            // copy the robot ids of the robots sent to into the buffer
-            copy(communication_request.target_agents.begin(),
-                 communication_request.target_agents.end(),
-                 back_inserter(buffered_response.from_robot_ids));
         }
-
-        buffered_response.associated_request = communication_request.request;
-        buffered_response.urgent = communication_request.urgent;
-        buffered_response.created = RJ::now();
-        buffered_responses_.push_back(buffered_response);
     }
+
+    buffered_response.to_robot_ids = sent_robot_ids;
+    buffered_response.associated_request = communication_request.request;
+    buffered_response.urgent = communication_request.urgent;
+    buffered_response.created = RJ::now();
+    buffered_responses_.push_back(buffered_response);
 }
 
 void AgentActionClient::receive_communication_callback(
@@ -361,7 +412,7 @@ void AgentActionClient::receive_response_callback(
                 (buffered_responses_[i].broadcast &&
                  buffered_responses_[i].received_robot_ids.size() >= 5) ||
                 (buffered_responses_[i].received_robot_ids.size() ==
-                 buffered_responses_[i].from_robot_ids.size())) {
+                 buffered_responses_[i].to_robot_ids.size())) {
                 current_position_->receive_communication_response(buffered_responses_[i]);
                 buffered_responses_.erase(buffered_responses_.begin() + i);
                 return;
@@ -394,6 +445,24 @@ void AgentActionClient::check_communication_timeout() {
     // thread-safe getter for world_state
     auto lock = std::lock_guard(world_state_mutex_);
     return &last_world_state_;
+}
+
+void AgentActionClient::update_position_alive_robots() {
+    if (current_position_ == nullptr) {
+        return;
+    }
+
+    if (!is_simulated_) {
+        current_position_->update_alive_robots(alive_robots_);
+    } else {
+        std::vector<u_int8_t> alive_robots = {};
+        for (u_int8_t i = 0; i < kNumShells; i++) {
+            if (check_robot_alive(i)) {
+                alive_robots.push_back(i);
+            }
+        }
+        current_position_->update_alive_robots(std::move(alive_robots));
+    }
 }
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -117,10 +117,14 @@ void AgentActionClient::field_dimensions_callback(
 
 void AgentActionClient::alive_robots_callback(const rj_msgs::msg::AliveRobots::SharedPtr& msg) {
     alive_robots_ = msg->alive_robots;
+    for (u_int8_t alive_robot_id : alive_robots_) {
+        SPDLOG_INFO("\022[92mRobot {} is Alive\033[0m", alive_robot_id);
+    }
 }
 
 void AgentActionClient::game_settings_callback(const rj_msgs::msg::GameSettings::SharedPtr& msg) {
     is_simulated_ = msg->simulation;
+    SPDLOG_INFO("\033[92mIs Simulated: {}\033[0m", is_simulated_);
 }
 
 bool AgentActionClient::check_robot_alive(u_int8_t robot_id) {

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -181,7 +181,7 @@ void AgentActionClient::update_position(const rj_msgs::msg::PositionAssignment::
     if (current_position_ == nullptr) {
         current_position_ = std::move(next_position_);
     } else if (next_position_->get_name() != current_position_->get_name()) {
-        // Call robot's die functionality
+        // When a disconnected robot is found, notify the position
         current_position_->die();
         // Send any final death communications from robot
         get_communication();

--- a/soccer/src/soccer/strategy/agent/agent_action_client.hpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.hpp
@@ -11,7 +11,9 @@
 
 #include <rj_common/time.hpp>
 #include <rj_convert/ros_convert.hpp>
+#include <rj_msgs/msg/alive_robots.hpp>
 #include <rj_msgs/msg/coach_state.hpp>
+#include <rj_msgs/msg/game_settings.hpp>
 #include <rj_msgs/msg/position_assignment.hpp>
 #include <rj_msgs/msg/world_state.hpp>
 #include <rj_utils/logging.hpp>
@@ -54,12 +56,16 @@ private:
     rclcpp::Subscription<rj_msgs::msg::CoachState>::SharedPtr coach_state_sub_;
     rclcpp::Subscription<rj_msgs::msg::PositionAssignment>::SharedPtr positions_sub_;
     rclcpp::Subscription<rj_msgs::msg::FieldDimensions>::SharedPtr field_dimensions_sub_;
+    rclcpp::Subscription<rj_msgs::msg::AliveRobots>::SharedPtr alive_robots_sub_;
+    rclcpp::Subscription<rj_msgs::msg::GameSettings>::SharedPtr game_settings_sub_;
     // TODO(Kevin): communication module pub/sub here (e.g. passing)
 
     // callbacks for subs
     void world_state_callback(const rj_msgs::msg::WorldState::SharedPtr& msg);
     void coach_state_callback(const rj_msgs::msg::CoachState::SharedPtr& msg);
     void field_dimensions_callback(const rj_msgs::msg::FieldDimensions::SharedPtr& msg);
+    void alive_robots_callback(const rj_msgs::msg::AliveRobots::SharedPtr& msg);
+    void game_settings_callback(const rj_msgs::msg::GameSettings::SharedPtr& msg);
 
     std::unique_ptr<Position> current_position_;
 
@@ -124,8 +130,21 @@ private:
      *
      */
     void get_communication();
-    communication::AgentRequest last_communication_;
     std::vector<communication::AgentPosResponseWrapper> buffered_responses_;
+
+    rclcpp::TimerBase::SharedPtr update_alive_robots_timer_;
+    /**
+     * @brief Updates the current positions list of alive robots (1/second)
+     *
+     */
+    void update_position_alive_robots();
+
+    FieldDimensions field_dimensions_;
+    std::vector<u_int8_t> alive_robots_ = {};
+    bool is_simulated_ = false;
+    static constexpr double field_padding_ = 0.3;
+
+    bool check_robot_alive(u_int8_t robot_id);
 
     // timeout check
     /**
@@ -148,7 +167,6 @@ private:
     [[nodiscard]] WorldState* world_state();
     WorldState last_world_state_;
     mutable std::mutex world_state_mutex_;
-
 };  // class AgentActionClient
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/agent_action_client.hpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.hpp
@@ -144,6 +144,14 @@ private:
     bool is_simulated_ = false;
     static constexpr double field_padding_ = 0.3;
 
+    /**
+     * @brief checks whether a robot is visible, in the field, and (if the game is not
+     * simulated) whether or not the robot is in the alive robots list.
+     *
+     * @param robot_id the id of the robot to check alive
+     * @return true if robot is connected, visible, and near the field
+     * @return false if the robot is not connected or is not visible
+     */
     bool check_robot_alive(u_int8_t robot_id);
 
     // timeout check

--- a/soccer/src/soccer/strategy/agent/communication/communication.cpp
+++ b/soccer/src/soccer/strategy/agent/communication/communication.cpp
@@ -28,6 +28,14 @@ bool operator==(const BallInTransitRequest& a, const BallInTransitRequest& b) {
     return a.request_uid == b.request_uid;
 }
 
+bool operator==(const JoinWallRequest& a, const JoinWallRequest& b) {
+    return a.request_uid == b.request_uid;
+}
+
+bool operator==(const LeaveWallRequest& a, const LeaveWallRequest& b) {
+    return a.request_uid == b.request_uid;
+}
+
 bool operator==(const Acknowledge& a, const Acknowledge& b) {
     return a.response_uid == b.response_uid;
 }
@@ -41,6 +49,14 @@ bool operator==(const PositionResponse& a, const PositionResponse& b) {
 }
 
 bool operator==(const TestResponse& a, const TestResponse& b) {
+    return a.response_uid == b.response_uid;
+}
+
+bool operator==(const JoinWallResponse& a, const JoinWallResponse& b) {
+    return a.response_uid == b.response_uid;
+}
+
+bool operator==(const LeaveWallResponse& a, const LeaveWallResponse& b) {
     return a.response_uid == b.response_uid;
 }
 
@@ -83,6 +99,20 @@ void generate_uid(BallInTransitRequest& request) {
     request_uid_mutex.unlock();
 }
 
+void generate_uid(JoinWallRequest& request) {
+    request_uid_mutex.lock();
+    request.request_uid = request_uid;
+    request_uid++;
+    request_uid_mutex.unlock();
+}
+
+void generate_uid(LeaveWallRequest& request) {
+    request_uid_mutex.lock();
+    request.request_uid = request_uid;
+    request_uid++;
+    request_uid_mutex.unlock();
+}
+
 void generate_uid(Acknowledge& response) {
     response_uid_mutex.lock();
     response.response_uid = response_uid;
@@ -105,6 +135,20 @@ void generate_uid(PositionResponse& response) {
 }
 
 void generate_uid(TestResponse& response) {
+    response_uid_mutex.lock();
+    response.response_uid = response_uid;
+    response_uid++;
+    response_uid_mutex.unlock();
+}
+
+void generate_uid(JoinWallResponse& response) {
+    response_uid_mutex.lock();
+    response.response_uid = response_uid;
+    response_uid++;
+    response_uid_mutex.unlock();
+}
+
+void generate_uid(LeaveWallResponse& response) {
     response_uid_mutex.lock();
     response.response_uid = response_uid;
     response_uid++;

--- a/soccer/src/soccer/strategy/agent/communication/communication.hpp
+++ b/soccer/src/soccer/strategy/agent/communication/communication.hpp
@@ -13,6 +13,10 @@
 #include "rj_msgs/msg/agent_response.hpp"
 #include "rj_msgs/msg/agent_response_variant.hpp"
 #include "rj_msgs/msg/incoming_ball_request.hpp"
+#include "rj_msgs/msg/join_wall_request.hpp"
+#include "rj_msgs/msg/join_wall_response.hpp"
+#include "rj_msgs/msg/leave_wall_request.hpp"
+#include "rj_msgs/msg/leave_wall_response.hpp"
 #include "rj_msgs/msg/pass_request.hpp"
 #include "rj_msgs/msg/pass_response.hpp"
 #include "rj_msgs/msg/position_request.hpp"
@@ -96,11 +100,20 @@ struct BallInTransitRequest {
 };
 bool operator==(const BallInTransitRequest& a, const BallInTransitRequest& b);
 
-/**
- * @brief a conglomeration of the different request types.
- */
+struct JoinWallRequest {
+    u_int32_t request_uid;
+    u_int8_t robot_id;
+};
+bool operator==(const JoinWallRequest& a, const JoinWallRequest& b);
+
+struct LeaveWallRequest {
+    u_int32_t request_uid;
+    u_int8_t robot_id;
+};
+bool operator==(const LeaveWallRequest& a, const LeaveWallRequest& b);
+
 using AgentRequest = std::variant<PassRequest, TestRequest, PositionRequest, IncomingBallRequest,
-                                  BallInTransitRequest>;
+                                  BallInTransitRequest, JoinWallRequest, LeaveWallRequest>;
 
 // END REQUEST TYPES //
 
@@ -162,12 +175,20 @@ struct TestResponse {
 };
 bool operator==(const TestResponse& a, const TestResponse& b);
 
-/**
- * @brief conglomeration of the different response types.
- *
- */
-using AgentResponseVariant =
-    std::variant<Acknowledge, PassResponse, PositionResponse, TestResponse>;
+struct JoinWallResponse {
+    u_int32_t response_uid;
+    u_int8_t robot_id;
+};
+bool operator==(const JoinWallResponse& a, const JoinWallResponse& b);
+
+struct LeaveWallResponse {
+    u_int32_t response_uid;
+    u_int8_t robot_id;
+};
+bool operator==(const LeaveWallResponse& a, const LeaveWallResponse& b);
+
+using AgentResponseVariant = std::variant<Acknowledge, PassResponse, PositionResponse, TestResponse,
+                                          JoinWallResponse, LeaveWallResponse>;
 
 /**
  * @brief response message that is sent from the receiver of the request to the
@@ -236,7 +257,7 @@ struct AgentPosRequestWrapper {
  */
 struct AgentPosResponseWrapper {
     AgentRequest associated_request;
-    std::vector<u_int8_t> from_robot_ids;
+    std::vector<u_int8_t> to_robot_ids;
     std::vector<u_int8_t> received_robot_ids;
     bool broadcast;
     bool urgent;
@@ -250,11 +271,15 @@ void generate_uid(PositionRequest& request);
 void generate_uid(TestRequest& request);
 void generate_uid(IncomingBallRequest& request);
 void generate_uid(BallInTransitRequest& request);
+void generate_uid(JoinWallRequest& request);
+void generate_uid(LeaveWallRequest& request);
 
 void generate_uid(Acknowledge& response);
 void generate_uid(PassResponse& response);
 void generate_uid(PositionResponse& response);
 void generate_uid(TestResponse& response);
+void generate_uid(JoinWallResponse& response);
+void generate_uid(LeaveWallResponse& response);
 
 }  // namespace strategy::communication
 
@@ -335,6 +360,42 @@ struct RosConverter<strategy::communication::IncomingBallRequest,
 ASSOCIATE_CPP_ROS(strategy::communication::IncomingBallRequest, rj_msgs::msg::IncomingBallRequest);
 
 template <>
+struct RosConverter<strategy::communication::JoinWallRequest, rj_msgs::msg::JoinWallRequest> {
+    static rj_msgs::msg::JoinWallRequest to_ros(
+        const strategy::communication::JoinWallRequest& from) {
+        rj_msgs::msg::JoinWallRequest result;
+        result.request_uid = from.request_uid;
+        result.robot_id = from.robot_id;
+        return result;
+    }
+
+    static strategy::communication::JoinWallRequest from_ros(
+        const rj_msgs::msg::JoinWallRequest& from) {
+        return strategy::communication::JoinWallRequest{from.request_uid, from.robot_id};
+    }
+};
+
+ASSOCIATE_CPP_ROS(strategy::communication::JoinWallRequest, rj_msgs::msg::JoinWallRequest);
+
+template <>
+struct RosConverter<strategy::communication::LeaveWallRequest, rj_msgs::msg::LeaveWallRequest> {
+    static rj_msgs::msg::LeaveWallRequest to_ros(
+        const strategy::communication::LeaveWallRequest& from) {
+        rj_msgs::msg::LeaveWallRequest result;
+        result.request_uid = from.request_uid;
+        result.robot_id = from.robot_id;
+        return result;
+    }
+
+    static strategy::communication::LeaveWallRequest from_ros(
+        const rj_msgs::msg::LeaveWallRequest& from) {
+        return strategy::communication::LeaveWallRequest{from.request_uid, from.robot_id};
+    }
+};
+
+ASSOCIATE_CPP_ROS(strategy::communication::LeaveWallRequest, rj_msgs::msg::LeaveWallRequest);
+
+template <>
 struct RosConverter<strategy::communication::BallInTransitRequest,
                     rj_msgs::msg::BallInTransitRequest> {
     static rj_msgs::msg::BallInTransitRequest to_ros(
@@ -372,6 +433,12 @@ struct RosConverter<strategy::communication::AgentRequest, rj_msgs::msg::AgentRe
         } else if (const auto* ball_in_transit_request =
                        std::get_if<strategy::communication::BallInTransitRequest>(&from)) {
             result.ball_in_transit_request.emplace_back(convert_to_ros(*ball_in_transit_request));
+        } else if (const auto* join_wall_request =
+                       std::get_if<strategy::communication::JoinWallRequest>(&from)) {
+            result.join_wall_request.emplace_back(convert_to_ros(*join_wall_request));
+        } else if (const auto* leave_wall_request =
+                       std::get_if<strategy::communication::LeaveWallRequest>(&from)) {
+            result.leave_wall_request.emplace_back(convert_to_ros(*leave_wall_request));
         } else {
             throw std::runtime_error("Invalid variant of AgentRequest");
         }
@@ -390,6 +457,10 @@ struct RosConverter<strategy::communication::AgentRequest, rj_msgs::msg::AgentRe
             result = convert_from_ros(from.incoming_ball_request.front());
         } else if (!from.ball_in_transit_request.empty()) {
             result = convert_from_ros(from.ball_in_transit_request.front());
+        } else if (!from.join_wall_request.empty()) {
+            result = convert_from_ros(from.join_wall_request.front());
+        } else if (!from.leave_wall_request.empty()) {
+            result = convert_from_ros(from.leave_wall_request.front());
         } else {
             throw std::runtime_error("Invalid variant of AgentRequest");
         }
@@ -478,6 +549,42 @@ struct RosConverter<strategy::communication::TestResponse, rj_msgs::msg::TestRes
 ASSOCIATE_CPP_ROS(strategy::communication::TestResponse, rj_msgs::msg::TestResponse);
 
 template <>
+struct RosConverter<strategy::communication::JoinWallResponse, rj_msgs::msg::JoinWallResponse> {
+    static rj_msgs::msg::JoinWallResponse to_ros(
+        const strategy::communication::JoinWallResponse& from) {
+        rj_msgs::msg::JoinWallResponse result;
+        result.response_uid = from.response_uid;
+        result.robot_id = from.robot_id;
+        return result;
+    }
+
+    static strategy::communication::JoinWallResponse from_ros(
+        const rj_msgs::msg::JoinWallResponse& from) {
+        return strategy::communication::JoinWallResponse{from.response_uid, from.robot_id};
+    }
+};
+
+ASSOCIATE_CPP_ROS(strategy::communication::JoinWallResponse, rj_msgs::msg::JoinWallResponse);
+
+template <>
+struct RosConverter<strategy::communication::LeaveWallResponse, rj_msgs::msg::LeaveWallResponse> {
+    static rj_msgs::msg::LeaveWallResponse to_ros(
+        const strategy::communication::LeaveWallResponse& from) {
+        rj_msgs::msg::LeaveWallResponse result;
+        result.response_uid = from.response_uid;
+        result.robot_id = from.robot_id;
+        return result;
+    }
+
+    static strategy::communication::LeaveWallResponse from_ros(
+        const rj_msgs::msg::LeaveWallResponse& from) {
+        return strategy::communication::LeaveWallResponse{from.response_uid, from.robot_id};
+    }
+};
+
+ASSOCIATE_CPP_ROS(strategy::communication::LeaveWallResponse, rj_msgs::msg::LeaveWallResponse);
+
+template <>
 struct RosConverter<strategy::communication::AgentResponse, rj_msgs::msg::AgentResponse> {
     static rj_msgs::msg::AgentResponse to_ros(const strategy::communication::AgentResponse& from) {
         rj_msgs::msg::AgentResponse result;
@@ -495,6 +602,12 @@ struct RosConverter<strategy::communication::AgentResponse, rj_msgs::msg::AgentR
         } else if (const auto* pass_response =
                        std::get_if<strategy::communication::PassResponse>(&(from.response))) {
             result.response.pass_response.emplace_back(convert_to_ros(*pass_response));
+        } else if (const auto* join_wall_response =
+                       std::get_if<strategy::communication::JoinWallResponse>(&(from.response))) {
+            result.response.join_wall_response.emplace_back(convert_to_ros(*join_wall_response));
+        } else if (const auto* leave_wall_response =
+                       std::get_if<strategy::communication::LeaveWallResponse>(&(from.response))) {
+            result.response.leave_wall_response.emplace_back(convert_to_ros(*leave_wall_response));
         } else {
             throw std::runtime_error("Invalid variant of AgentResponse");
         }
@@ -513,6 +626,10 @@ struct RosConverter<strategy::communication::AgentResponse, rj_msgs::msg::AgentR
             result.response = convert_from_ros(from.response.position_response.front());
         } else if (!from.response.pass_response.empty()) {
             result.response = convert_from_ros(from.response.pass_response.front());
+        } else if (!from.response.join_wall_response.empty()) {
+            result.response = convert_from_ros(from.response.join_wall_response.front());
+        } else if (!from.response.leave_wall_response.empty()) {
+            result.response = convert_from_ros(from.response.leave_wall_response.front());
         } else {
             throw std::runtime_error("Invalid variant of AgentResponse");
         }

--- a/soccer/src/soccer/strategy/agent/communication/communication.hpp
+++ b/soccer/src/soccer/strategy/agent/communication/communication.hpp
@@ -100,12 +100,20 @@ struct BallInTransitRequest {
 };
 bool operator==(const BallInTransitRequest& a, const BallInTransitRequest& b);
 
+/**
+ * @brief request sent by an agent when it wants to join the wall.
+ *
+ */
 struct JoinWallRequest {
     u_int32_t request_uid;
     u_int8_t robot_id;
 };
 bool operator==(const JoinWallRequest& a, const JoinWallRequest& b);
 
+/**
+ * @brief request sent by an agent when it wants to leave the wall.
+ *
+ */
 struct LeaveWallRequest {
     u_int32_t request_uid;
     u_int8_t robot_id;
@@ -175,12 +183,21 @@ struct TestResponse {
 };
 bool operator==(const TestResponse& a, const TestResponse& b);
 
+/**
+ * @brief response from other robots who are currently apart of the wall so this
+ * robot can figure out where they are in the wall of robots.
+ *
+ */
 struct JoinWallResponse {
     u_int32_t response_uid;
     u_int8_t robot_id;
 };
 bool operator==(const JoinWallResponse& a, const JoinWallResponse& b);
 
+/**
+ * @brief response from other robots who are currently apart of the wall.
+ *
+ */
 struct LeaveWallResponse {
     u_int32_t response_uid;
     u_int8_t robot_id;
@@ -256,13 +273,13 @@ struct AgentPosRequestWrapper {
  *
  */
 struct AgentPosResponseWrapper {
-    AgentRequest associated_request;
-    std::vector<u_int8_t> to_robot_ids;
-    std::vector<u_int8_t> received_robot_ids;
-    bool broadcast;
-    bool urgent;
-    RJ::Time created;
-    std::vector<AgentResponseVariant> responses;
+    AgentRequest associated_request;           // the request sent for the given response
+    std::vector<u_int8_t> to_robot_ids;        // the robot ids the request was sent to
+    std::vector<u_int8_t> received_robot_ids;  // the robot ids responses were found from
+    bool broadcast;                            // true if the response should go to every robot
+    bool urgent;                               // true if only the first response should be handled
+    RJ::Time created;                          // the time the request was created
+    std::vector<AgentResponseVariant> responses;  // a list of the response from the other agent
 };
 
 // TODO (https://app.clickup.com/t/8677c0tqe): Make this templated and less ugly

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -18,8 +18,21 @@ Defense::State Defense::update_state() {
     rj_geometry::Point ball_position = world_state->ball.position;
     double distance_to_ball = robot_position.dist_to(ball_position);
 
+    if (current_state_ != WALLING && current_state_ != JOINING_WALL && waller_id_ != -1) {
+        send_leave_wall_request();
+        walling_robots_ = {(u_int8_t)robot_id_};
+        waller_id_ = -1;
+    }
+
     switch (current_state_) {
         case IDLING:
+            break;
+        case JOINING_WALL:
+            send_join_wall_request();
+            next_state = WALLING;
+            walling_robots_ = {(u_int8_t)robot_id_};
+            break;
+        case WALLING:
             break;
         case SEARCHING:
             break;
@@ -50,6 +63,11 @@ Defense::State Defense::update_state() {
 }
 
 std::optional<RobotIntent> Defense::state_to_task(RobotIntent intent) {
+    if (robot_id_ == 2 || robot_id_ == 4 || robot_id_ == 5) {
+        SPDLOG_INFO("\033[92mRobot {} is Waller Num {} out of {}\033[0m", robot_id_, waller_id_,
+                    walling_robots_.size());
+    }
+
     if (current_state_ == IDLING) {
         // DO NOTHING
     } else if (current_state_ == SEARCHING) {
@@ -68,14 +86,13 @@ std::optional<RobotIntent> Defense::state_to_task(RobotIntent intent) {
             auto face_ball_cmd = planning::MotionCommand{"path_target", motion_instance, face_ball};
             intent.motion_command = face_ball_cmd;
         } else {
-            // intercept the bal
+            // intercept the ball
             chasing_ball = true;
             auto collect_cmd = planning::MotionCommand{"collect"};
             intent.motion_command = collect_cmd;
         }
         return intent;
     } else if (current_state_ == PASSING) {
-        // TODO(https://app.clickup.com/t/8677rrgjn): Convert PASSING state into role_interface
         // attempt to pass the ball to the target robot
         rj_geometry::Point target_robot_pos =
             world_state()->get_robot(true, target_robot_id).pose.position();
@@ -89,6 +106,11 @@ std::optional<RobotIntent> Defense::state_to_task(RobotIntent intent) {
         intent.kick_speed = 4.0;
         intent.is_active = true;
         return intent;
+    } else if (current_state_ == WALLING) {
+        if (walling_robots_.size() > 0) {
+            Waller waller{waller_id_, (int)walling_robots_.size()};
+            return waller.get_task(intent, world_state(), this->field_dimensions_);
+        }
     } else if (current_state_ = FACING) {
         rj_geometry::Point robot_position =
             world_state()->get_robot(true, robot_id_).pose.position();
@@ -104,6 +126,138 @@ std::optional<RobotIntent> Defense::state_to_task(RobotIntent intent) {
     return std::nullopt;
 }
 
+void Defense::receive_communication_response(communication::AgentPosResponseWrapper response) {
+    // Call to super
+    Position::receive_communication_response(response);
+
+    // Handle join wall response
+    if (const communication::JoinWallRequest* join_request =
+            std::get_if<communication::JoinWallRequest>(&response.associated_request)) {
+        for (u_int32_t i = 0; i < response.responses.size(); i++) {
+            if (const communication::JoinWallResponse* join_response =
+                    std::get_if<communication::JoinWallResponse>(&response.responses[i])) {
+                handle_join_wall_response(*join_response);
+            }
+        }
+    }
+}
+
+communication::PosAgentResponseWrapper Defense::receive_communication_request(
+    communication::AgentPosRequestWrapper request) {
+    // Call to super
+    communication::PosAgentResponseWrapper response =
+        Position::receive_communication_request(request);
+
+    // Handle join and leave wall request
+    if (const communication::JoinWallRequest* join_request =
+            std::get_if<communication::JoinWallRequest>(&request.request)) {
+        response.response = handle_join_wall_request(*join_request);
+    } else if (const communication::LeaveWallRequest* leave_request =
+                   std::get_if<communication::LeaveWallRequest>(&request.request)) {
+        response.response = handle_leave_wall_request(*leave_request);
+    }
+
+    // Return the response
+    return response;
+}
+
+void Defense::send_join_wall_request() {
+    communication::JoinWallRequest join_request{};
+    join_request.robot_id = robot_id_;
+    communication::generate_uid(join_request);
+
+    communication::PosAgentRequestWrapper communication_request{};
+    communication_request.request = join_request;
+    communication_request.target_agents = {};
+    communication_request.urgent = false;
+    communication_request.broadcast = true;
+
+    communication_request_ = communication_request;
+
+    current_state_ = WALLING;
+}
+
+void Defense::send_leave_wall_request() {
+    communication::LeaveWallRequest leave_request{};
+    leave_request.robot_id = robot_id_;
+    communication::generate_uid(leave_request);
+
+    communication::PosAgentRequestWrapper communication_request{};
+    communication_request.request = leave_request;
+    communication_request.target_agents = walling_robots_;
+    communication_request.urgent = true;
+    communication_request.broadcast = false;
+
+    communication_request_ = communication_request;
+}
+
+communication::JoinWallResponse Defense::handle_join_wall_request(
+    communication::JoinWallRequest join_request) {
+    for (int i = 0; i < walling_robots_.size(); i++) {
+        if (walling_robots_[i] == join_request.robot_id) {
+            break;
+        } else if (walling_robots_[i] > join_request.robot_id) {
+            walling_robots_.insert(walling_robots_.begin() + i, join_request.robot_id);
+            // SPDLOG_INFO("\033[92mAdding robot id {} to location {} in walling_robots_ for robot
+            // {}\033[0m", join_request.robot_id, i, robot_id_);
+            waller_id_ = get_waller_id();
+            // SPDLOG_INFO("\033[92mUpdating waller id to {} for robot {}\033[0m", waller_id_,
+            // robot_id_);
+            break;
+        } else if (i == walling_robots_.size() - 1) {
+            walling_robots_.push_back(join_request.robot_id);
+            waller_id_ = get_waller_id();
+            // SPDLOG_INFO("\033[92mAdding robot id {} to location {} in walling_robots_ for robot
+            // {}\033[0m", join_request.robot_id, i+1, robot_id_);
+        }
+    }
+
+    communication::JoinWallResponse join_response{};
+    join_response.robot_id = robot_id_;
+    communication::generate_uid(join_response);
+
+    return join_response;
+}
+
+communication::Acknowledge Defense::handle_leave_wall_request(
+    communication::LeaveWallRequest leave_request) {
+    for (int i = walling_robots_.size() - 1; i > 0; i--) {
+        if (walling_robots_[i] == leave_request.robot_id) {
+            walling_robots_.erase(walling_robots_.begin() + i);
+            waller_id_ = get_waller_id();
+            break;
+        } else if (walling_robots_[i] > leave_request.robot_id) {
+            break;
+        }
+    }
+
+    communication::Acknowledge acknowledge_response{};
+    communication::generate_uid(acknowledge_response);
+
+    return acknowledge_response;
+}
+
+void Defense::handle_join_wall_response(communication::JoinWallResponse join_response) {
+    for (int i = 0; i < walling_robots_.size(); i++) {
+        if (walling_robots_[i] == join_response.robot_id) {
+            return;
+        } else if (walling_robots_[i] > join_response.robot_id) {
+            walling_robots_.insert(walling_robots_.begin() + i, join_response.robot_id);
+            // SPDLOG_INFO("\033[92mAdding robot id {} to location {} in walling_robots_ for robot
+            // {}\033[0m", join_response.robot_id, i, robot_id_);
+            waller_id_ = get_waller_id();
+            // SPDLOG_INFO("\033[92mUpdating waller id to {} for robot {}\033[0m", waller_id_,
+            // robot_id_);
+            return;
+        } else if (i == walling_robots_.size() - 1) {
+            walling_robots_.push_back(join_response.robot_id);
+            waller_id_ = get_waller_id();
+            // SPDLOG_INFO("\033[92mAdding robot id {} to location {} in walling_robots_ for robot
+            // {}\033[0m", join_response.robot_id, i+1, robot_id_);
+        }
+    }
+}
+
 void Defense::derived_acknowledge_pass() { current_state_ = FACING; }
 
 void Defense::derived_pass_ball() { current_state_ = PASSING; }
@@ -111,6 +265,11 @@ void Defense::derived_pass_ball() { current_state_ = PASSING; }
 void Defense::derived_acknowledge_ball_in_transit() {
     current_state_ = RECEIVING;
     chasing_ball = false;
+}
+
+int Defense::get_waller_id() {
+    return find(walling_robots_.begin(), walling_robots_.end(), robot_id_) -
+           walling_robots_.begin() + 1;
 }
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -193,17 +193,11 @@ communication::JoinWallResponse Defense::handle_join_wall_request(
             break;
         } else if (walling_robots_[i] > join_request.robot_id) {
             walling_robots_.insert(walling_robots_.begin() + i, join_request.robot_id);
-            // SPDLOG_INFO("\033[92mAdding robot id {} to location {} in walling_robots_ for robot
-            // {}\033[0m", join_request.robot_id, i, robot_id_);
             waller_id_ = get_waller_id();
-            // SPDLOG_INFO("\033[92mUpdating waller id to {} for robot {}\033[0m", waller_id_,
-            // robot_id_);
             break;
         } else if (i == walling_robots_.size() - 1) {
             walling_robots_.push_back(join_request.robot_id);
             waller_id_ = get_waller_id();
-            // SPDLOG_INFO("\033[92mAdding robot id {} to location {} in walling_robots_ for robot
-            // {}\033[0m", join_request.robot_id, i+1, robot_id_);
         }
     }
 
@@ -221,7 +215,7 @@ communication::Acknowledge Defense::handle_leave_wall_request(
             walling_robots_.erase(walling_robots_.begin() + i);
             waller_id_ = get_waller_id();
             break;
-        } else if (walling_robots_[i] > leave_request.robot_id) {
+        } else if (walling_robots_[i] < leave_request.robot_id) {
             break;
         }
     }
@@ -238,17 +232,11 @@ void Defense::handle_join_wall_response(communication::JoinWallResponse join_res
             return;
         } else if (walling_robots_[i] > join_response.robot_id) {
             walling_robots_.insert(walling_robots_.begin() + i, join_response.robot_id);
-            // SPDLOG_INFO("\033[92mAdding robot id {} to location {} in walling_robots_ for robot
-            // {}\033[0m", join_response.robot_id, i, robot_id_);
             waller_id_ = get_waller_id();
-            // SPDLOG_INFO("\033[92mUpdating waller id to {} for robot {}\033[0m", waller_id_,
-            // robot_id_);
             return;
         } else if (i == walling_robots_.size() - 1) {
             walling_robots_.push_back(join_response.robot_id);
             waller_id_ = get_waller_id();
-            // SPDLOG_INFO("\033[92mAdding robot id {} to location {} in walling_robots_ for robot
-            // {}\033[0m", join_response.robot_id, i+1, robot_id_);
         }
     }
 }
@@ -266,5 +254,13 @@ int Defense::get_waller_id() {
     return find(walling_robots_.begin(), walling_robots_.end(), robot_id_) -
            walling_robots_.begin() + 1;
 }
+
+void Defense::die() {
+    if (current_state_ == WALLING) {
+        send_leave_wall_request();
+    }
+}
+
+void Defense::revive() { current_state_ = JOINING_WALL; }
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -102,7 +102,7 @@ std::optional<RobotIntent> Defense::state_to_task(RobotIntent intent) {
         intent.is_active = true;
         return intent;
     } else if (current_state_ == WALLING) {
-        if (walling_robots_.size() > 0) {
+        if (!walling_robots_.empty()) {
             Waller waller{waller_id_, (int)walling_robots_.size()};
             return waller.get_task(intent, world_state(), this->field_dimensions_);
         }
@@ -128,9 +128,8 @@ void Defense::receive_communication_response(communication::AgentPosResponseWrap
     // Handle join wall response
     if (const communication::JoinWallRequest* join_request =
             std::get_if<communication::JoinWallRequest>(&response.associated_request)) {
-        for (u_int32_t i = 0; i < response.responses.size(); i++) {
-            if (const communication::JoinWallResponse* join_response =
-                    std::get_if<communication::JoinWallResponse>(&response.responses[i])) {
+        for (communication::AgentResponseVariant response : response.responses) {
+            if (const communication::JoinWallResponse* join_response = std::get_if<communication::JoinWallResponse>(&response)) {
                 handle_join_wall_response(*join_response);
             }
         }

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -63,11 +63,6 @@ Defense::State Defense::update_state() {
 }
 
 std::optional<RobotIntent> Defense::state_to_task(RobotIntent intent) {
-    if (robot_id_ == 2 || robot_id_ == 4 || robot_id_ == 5) {
-        SPDLOG_INFO("\033[92mRobot {} is Waller Num {} out of {}\033[0m", robot_id_, waller_id_,
-                    walling_robots_.size());
-    }
-
     if (current_state_ == IDLING) {
         // DO NOTHING
     } else if (current_state_ == SEARCHING) {

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -129,7 +129,8 @@ void Defense::receive_communication_response(communication::AgentPosResponseWrap
     if (const communication::JoinWallRequest* join_request =
             std::get_if<communication::JoinWallRequest>(&response.associated_request)) {
         for (communication::AgentResponseVariant response : response.responses) {
-            if (const communication::JoinWallResponse* join_response = std::get_if<communication::JoinWallResponse>(&response)) {
+            if (const communication::JoinWallResponse* join_response =
+                    std::get_if<communication::JoinWallResponse>(&response)) {
                 handle_join_wall_response(*join_response);
             }
         }

--- a/soccer/src/soccer/strategy/agent/position/defense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.hpp
@@ -108,9 +108,6 @@ private:
     // current state of the defense agent (state machine)
     int get_waller_id();
     State current_state_ = JOINING_WALL;
-
-    double BALL_RECEIVE_DISTANCE = 0.1;
-    double BALL_LOST_DISTANCE = 0.5;
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/defense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.hpp
@@ -28,6 +28,10 @@ public:
     Defense(int r_id);
     ~Defense() override = default;
 
+    void receive_communication_response(communication::AgentPosResponseWrapper response) override;
+    communication::PosAgentResponseWrapper receive_communication_request(
+        communication::AgentPosRequestWrapper request) override;
+
     void derived_acknowledge_pass() override;
     void derived_pass_ball() override;
     void derived_acknowledge_ball_in_transit() override;
@@ -47,19 +51,66 @@ private:
     std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
 
     enum State {
-        IDLING,     // simply staying in place
-        SEARCHING,  // moving around on the field to do something
-        RECEIVING,  // physically intercepting the ball from a pass
-        PASSING,    // physically kicking the ball towards another robot
-        FACING,     // turning to face the passing robot
+        IDLING,        // simply staying in place
+        JOINING_WALL,  // send message to find its place in the wall
+        WALLING,       // participating in the wall
+        SEARCHING,     // moving around on the field to do something
+        RECEIVING,     // physically intercepting the ball from a pass
+        PASSING,       // physically kicking the ball towards another robot
+        FACING,        // turning to face the passing robot
     };
 
     State update_state();
 
     std::optional<RobotIntent> state_to_task(RobotIntent intent);
 
+    /**
+     * @brief Sends a JoinWallRequest in broadcast to the other robots
+     */
+    void send_join_wall_request();
+
+    /**
+     * @brief Sends a LeaveWallRequest to each of the robots in walling_robots_.
+     */
+    void send_leave_wall_request();
+
+    /**
+     * @brief Adds the new waller to this robot's list of wallers and updates this robot's position
+     * in the wall.
+     *
+     * @param join_request the request received from another robot about joining the wall
+     * @return communication::JoinWallResponse A confirmation for the other robot to join the wall
+     * with this robot's ID
+     */
+    communication::JoinWallResponse handle_join_wall_request(
+        communication::JoinWallRequest join_request);
+
+    /**
+     * @brief Removes a given robot from this robot's list of wallers.
+     *
+     * @param leave_request the request from the robot who is leaving the wall
+     * @return communication::Acknowledge acknowledgement of the other robot's communication
+     */
+    communication::Acknowledge handle_leave_wall_request(
+        communication::LeaveWallRequest leave_request);
+
+    /**
+     * @brief Handles the response from the currently walling robots to find this robot's place in
+     * the wall.
+     *
+     * @param join_response the response from another robot that this robot can join the wall
+     */
+    void handle_join_wall_response(communication::JoinWallResponse join_response);
+
+    std::vector<u_int8_t> walling_robots_ = {};
+    int waller_id_ = -1;
+
     // current state of the defense agent (state machine)
-    State current_state_ = IDLING;
+    int get_waller_id();
+    State current_state_ = JOINING_WALL;
+
+    double BALL_RECEIVE_DISTANCE = 0.1;
+    double BALL_LOST_DISTANCE = 0.5;
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/defense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.hpp
@@ -36,6 +36,9 @@ public:
     void derived_pass_ball() override;
     void derived_acknowledge_ball_in_transit() override;
 
+    void die() override;
+    void revive() override;
+
 private:
     int move_ct_ = 0;
 

--- a/soccer/src/soccer/strategy/agent/position/position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/position.cpp
@@ -62,6 +62,10 @@ void Position::update_field_dimensions(FieldDimensions field_dims) {
     field_dimensions_ = std::move(field_dims);
 }
 
+void Position::update_alive_robots(std::vector<u_int8_t> alive_robots) {
+    alive_robots_ = alive_robots;
+}
+
 [[nodiscard]] WorldState* Position::world_state() {
     // thread-safe getter for world_state (see update_world_state())
     auto lock = std::lock_guard(world_state_mutex_);
@@ -119,7 +123,6 @@ communication::PosAgentResponseWrapper Position::receive_communication_request(
             std::get_if<communication::PassRequest>(&request.request)) {
         communication::PassResponse pass_response = receive_pass_request(*pass_request);
         comm_response.response = pass_response;
-        // TODO: "IncomingBallRequest" => "IncomingBallRequest" (or smth)
     } else if (const communication::IncomingBallRequest* incoming_ball_request =
                    std::get_if<communication::IncomingBallRequest>(&request.request)) {
         communication::Acknowledge incoming_pass_acknowledge =
@@ -152,7 +155,6 @@ void Position::send_direct_pass_request(std::vector<u_int8_t> target_robots) {
     communication_request.target_agents = target_robots;
     communication_request.urgent = true;
     communication_request.broadcast = false;
-
     communication_request_ = communication_request;
 }
 

--- a/soccer/src/soccer/strategy/agent/position/position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/position.cpp
@@ -64,6 +64,16 @@ void Position::update_field_dimensions(FieldDimensions field_dims) {
 
 void Position::update_alive_robots(std::vector<u_int8_t> alive_robots) {
     alive_robots_ = alive_robots;
+
+    if (alive &&
+        std::find(alive_robots_.begin(), alive_robots_.end(), robot_id_) != alive_robots_.end()) {
+        alive = false;
+        die();
+    } else if (!alive && std::find(alive_robots_.begin(), alive_robots_.end(), robot_id_) ==
+                             alive_robots_.end()) {
+        alive = true;
+        revive();
+    }
 }
 
 [[nodiscard]] WorldState* Position::world_state() {

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -9,6 +9,7 @@
 #include <rj_common/time.hpp>
 #include <rj_geometry/geometry_conversions.hpp>
 #include <rj_geometry/point.hpp>
+#include <rj_msgs/msg/alive_robots.hpp>
 #include <rj_msgs/msg/coach_state.hpp>
 #include <rj_msgs/msg/global_override.hpp>
 
@@ -70,6 +71,7 @@ public:
     void update_world_state(WorldState world_state);
     void update_coach_state(rj_msgs::msg::CoachState coach_state);
     void update_field_dimensions(FieldDimensions field_dimensions);
+    void update_alive_robots(std::vector<u_int8_t> alive_robots);
     const std::string get_name();
 
     /**
@@ -156,7 +158,7 @@ public:
      * @brief method called in acknowledge_pass that updates the position to its next state
      *
      */
-    virtual void derived_acknowledge_pass() = 0;
+    virtual void derived_acknowledge_pass(){};
 
     /**
      * @brief update the robot state to be passing the ball
@@ -170,7 +172,7 @@ public:
      * state.
      *
      */
-    virtual void derived_pass_ball() = 0;
+    virtual void derived_pass_ball(){};
 
     /**
      * @brief the ball is on the way, so the robot should change its state accordingly
@@ -187,7 +189,7 @@ public:
      * corresponding next state
      *
      */
-    virtual void derived_acknowledge_ball_in_transit() = 0;
+    virtual void derived_acknowledge_ball_in_transit(){};
 
 protected:
     // should be overriden in subclass constructors
@@ -262,6 +264,9 @@ protected:
 
     // farthest distance the robot is willing to go before it declares it has lost the ball
     static constexpr double ball_lost_distance_ = 0.5;
+
+    // vector of alive robots from the agent action client
+    std::vector<u_int8_t> alive_robots_ = {};
 
 private:
     // private to avoid allowing WorldState to be accessed directly by derived

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -192,14 +192,14 @@ public:
     virtual void derived_acknowledge_ball_in_transit(){};
 
     /**
-     * @brief When a robot dies on field (or is reassigned by the coach) they should call their
+     * @brief When a robot disconnects on field (or is reassigned by the coach) they should call their
      * implementation of die to inform necessary robots that they died.
      *
      */
     virtual void die(){};
 
     /**
-     * @brief When a robot goes dark on the field and comes back to life revive will take care
+     * @brief When a robot disconnects and comes back to life revive will take care
      * of bringing them back into the correct state.
      *
      */

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -191,6 +191,20 @@ public:
      */
     virtual void derived_acknowledge_ball_in_transit(){};
 
+    /**
+     * @brief When a robot dies on field (or is reassigned by the coach) they should call their
+     * implementation of die to inform necessary robots that they died.
+     *
+     */
+    virtual void die(){};
+
+    /**
+     * @brief When a robot goes dark on the field and comes back to life revive will take care
+     * of bringing them back into the correct state.
+     *
+     */
+    virtual void revive(){};
+
 protected:
     // should be overriden in subclass constructors
     std::string position_name_{"Position"};
@@ -267,6 +281,9 @@ protected:
 
     // vector of alive robots from the agent action client
     std::vector<u_int8_t> alive_robots_ = {};
+
+    // true if this robot is alive
+    bool alive = false;
 
 private:
     // private to avoid allowing WorldState to be accessed directly by derived

--- a/soccer/src/soccer/strategy/agent/position/waller.cpp
+++ b/soccer/src/soccer/strategy/agent/position/waller.cpp
@@ -33,7 +33,7 @@ std::optional<RobotIntent> Waller::get_task(RobotIntent intent, const WorldState
     rj_geometry::Point mid_point{(goal_center_point) + (ball_dir_vector * min_wall_rad)};
 
     // Calculate the wall spacing
-    auto wall_spacing = 2.5 * kRobotDiameter + kBallRadius;
+    auto wall_spacing = robot_diameter_multiplier_ * kRobotDiameter + kBallRadius;
 
     // Calculate the target point
     rj_geometry::Point target_point{};

--- a/soccer/src/soccer/strategy/agent/position/waller.cpp
+++ b/soccer/src/soccer/strategy/agent/position/waller.cpp
@@ -42,14 +42,6 @@ std::optional<RobotIntent> Waller::get_task(RobotIntent intent, const WorldState
         mid_point +
         ball_dir_vector * ((total_wallers_ - waller_pos_ - (total_wallers_ / 2)) * wall_spacing);
 
-    // if (total_wallers_ % 2 == 0) {
-    //     target_point =
-    //         mid_point + ball_dir_vector * ((total_wallers_ - waller_pos_ - 0.5) * wall_spacing);
-    // } else {
-    //     target_point =
-    //         mid_point + ball_dir_vector * ((total_wallers_ - waller_pos_) * wall_spacing);
-    // }
-
     target_point = target_point.rotate(mid_point, M_PI / 2);
 
     // Stop at end of path

--- a/soccer/src/soccer/strategy/agent/position/waller.cpp
+++ b/soccer/src/soccer/strategy/agent/position/waller.cpp
@@ -2,9 +2,10 @@
 
 namespace strategy {
 
-Waller::Waller(int waller_num) {
+Waller::Waller(int waller_num, int total_wallers) {
     defense_type_ = "Waller";
     waller_pos_ = waller_num;
+    total_wallers_ = total_wallers;
 }
 
 std::optional<RobotIntent> Waller::get_task(RobotIntent intent, const WorldState* world_state,
@@ -31,6 +32,26 @@ std::optional<RobotIntent> Waller::get_task(RobotIntent intent, const WorldState
     // Find target Point
     rj_geometry::Point mid_point{(goal_center_point) + (ball_dir_vector * min_wall_rad)};
 
+    // Calculate the wall spacing
+    auto wall_spacing = 2.5 * kRobotDiameter + kBallRadius;
+
+    // Calculate the target point
+    rj_geometry::Point target_point{};
+
+    target_point =
+        mid_point +
+        ball_dir_vector * ((total_wallers_ - waller_pos_ - (total_wallers_ / 2)) * wall_spacing);
+
+    // if (total_wallers_ % 2 == 0) {
+    //     target_point =
+    //         mid_point + ball_dir_vector * ((total_wallers_ - waller_pos_ - 0.5) * wall_spacing);
+    // } else {
+    //     target_point =
+    //         mid_point + ball_dir_vector * ((total_wallers_ - waller_pos_) * wall_spacing);
+    // }
+
+    target_point = target_point.rotate(mid_point, M_PI / 2);
+
     // Stop at end of path
     rj_geometry::Point target_vel{0.0, 0.0};
 
@@ -41,7 +62,7 @@ std::optional<RobotIntent> Waller::get_task(RobotIntent intent, const WorldState
     bool ignore_ball{true};
 
     // Create Motion Command
-    planning::LinearMotionInstant target{mid_point, target_vel};
+    planning::LinearMotionInstant target{target_point, target_vel};
     intent.motion_command =
         planning::MotionCommand{"path_target", target, face_option, ignore_ball};
     return intent;

--- a/soccer/src/soccer/strategy/agent/position/waller.hpp
+++ b/soccer/src/soccer/strategy/agent/position/waller.hpp
@@ -26,7 +26,7 @@ namespace strategy {
  */
 class Waller : public RoleInterface {
 public:
-    Waller(int waller_num);
+    Waller(int waller_num, int total_wallers);
     ~Waller() = default;
 
     /**
@@ -42,6 +42,7 @@ public:
 private:
     std::string defense_type_;
     int waller_pos_;
+    int total_wallers_;
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/waller.hpp
+++ b/soccer/src/soccer/strategy/agent/position/waller.hpp
@@ -44,7 +44,7 @@ private:
     int waller_pos_;
     int total_wallers_;
 
-    static constexpr double robot_diameter_multiplier_ = 2.5;
+    static constexpr double robot_diameter_multiplier_ = 1.5;
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/waller.hpp
+++ b/soccer/src/soccer/strategy/agent/position/waller.hpp
@@ -43,6 +43,8 @@ private:
     std::string defense_type_;
     int waller_pos_;
     int total_wallers_;
+
+    static constexpr double robot_diameter_multiplier_ = 2.5;
 };
 
 }  // namespace strategy


### PR DESCRIPTION
## Description
This PR sets up communication between wallers so that wallers will line up in order on the field.

## Associated / Resolved Issue
[coordinate wallers](https://app.clickup.com/t/8677qektb)

## Steps to Test
### Test Case 1
1. make perf && make run-sim

**Expected result:**
Robots 1, 3, and/or 5 (depends on who is on the field) will form a wall to block the goal from the ball.

## Key Files to Review
Communication
 * JoinWallRequest.msg
 * LeaveWallRequest.msg
 * JoinWallResponse.msg
 * LeaveWallResponse.msg
 * soccer/src/soccer/strategy/agent/communication/communication.*pp

Defense + Waller
 * soccer/src/soccer/strategy/agent/position/defense.*pp
 * soccer/src/soccer/strategy/agent/position/waller.*pp

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [X] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack
