### PR TITLE
Update global overrides

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -112,15 +112,9 @@ First, use git to create a new branch under this naming scheme:
 For instance, the author's branch would be named
 ``kevin-fu/robocup-sw-tutorial``.
 
-Then take a look at the defense play in
-``rj_gameplay/rj_gameplay/play/defense.py``. Launch soccer (our UI) and the
+Launch soccer (our UI) and the
 ER-force simulator, same way as you did in the installation guide, then select
-this play as the test play to see it in action. Click the green checkmark in our
-UI. You should see 3 robots form a wall, 2 robots mark the opposing team, and 1
-robot play goalie.
-
-Figure out which line(s) to change so that 4 robots form a wall instead of 3.
-When done, take a screenshot of the four wallers.
+this play as the test play to see it in action. 
 
 Now that you've made a change to the repo, run ``git status``. You should see
 that whatever files you changed show up in red, which indicates that they are
@@ -156,7 +150,7 @@ description, you can delete the template and write something simple like
 "Completes RC SW tutorials." Add that screenshot of your four-waller setup as a
 comment below your brand new PR. Nice work!
 
-3. rj_gameplay and Python
+1. rj_gameplay and Python
 -------------------------
 
 In this section, you'll be tasked with creating a new Python class to give our

--- a/rj_msgs/msg/GlobalOverride.msg
+++ b/rj_msgs/msg/GlobalOverride.msg
@@ -3,4 +3,4 @@
 # In starts: max_speed = -1m/s; min_distance_from_ball = 0m
 float32 max_speed
 float32 min_dist_from_ball
-float32 max_dribbler_speed = 255
+int32 max_dribbler_speed

--- a/rj_msgs/msg/GlobalOverride.msg
+++ b/rj_msgs/msg/GlobalOverride.msg
@@ -3,3 +3,4 @@
 # In starts: max_speed = -1m/s; min_distance_from_ball = 0m
 float32 max_speed
 float32 min_dist_from_ball
+float32 max_dribbler_speed = 255

--- a/soccer/src/soccer/control/manipulator_control.cpp
+++ b/soccer/src/soccer/control/manipulator_control.cpp
@@ -20,6 +20,7 @@ ManipulatorControl::ManipulatorControl(int shell_id, rclcpp::Node* node) : shell
             "/strategy/coach_state", rclcpp::QoS(1),
             [this](rj_msgs::msg::CoachState::SharedPtr coach_state) {  // NOLINT
                 last_coach_state_ = *coach_state;
+                dribbler_speed_ = last_coach_state_.global_override.max_dribbler_speed;
             });
 
     intent_sub_ = node->create_subscription<rj_msgs::msg::RobotIntent>(
@@ -29,7 +30,7 @@ ManipulatorControl::ManipulatorControl(int shell_id, rclcpp::Node* node) : shell
                                          .shoot_mode(intent->shoot_mode)
                                          .trigger_mode(intent->trigger_mode)
                                          .kick_speed(intent->kick_speed)
-                                         .dribbler_speed(this->last_coach_state_.global_override.max_dribbler_speed));
+                                         .dribbler_speed(dribbler_speed_));
         });
 }
 

--- a/soccer/src/soccer/control/manipulator_control.cpp
+++ b/soccer/src/soccer/control/manipulator_control.cpp
@@ -25,8 +25,8 @@ ManipulatorControl::ManipulatorControl(int shell_id, rclcpp::Node* node) : shell
 
     intent_sub_ = node->create_subscription<rj_msgs::msg::RobotIntent>(
         gameplay::topics::robot_intent_topic(shell_id), rclcpp::QoS(1),
-        [manipulator_pub, this](rj_msgs::msg::RobotIntent::SharedPtr intent) {  // NOLINT
-            manipulator_pub->publish(rj_msgs::build<rj_msgs::msg::ManipulatorSetpoint>()
+        [this](rj_msgs::msg::RobotIntent::SharedPtr intent) {  // NOLINT
+            manipulator_pub_->publish(rj_msgs::build<rj_msgs::msg::ManipulatorSetpoint>()
                                          .shoot_mode(intent->shoot_mode)
                                          .trigger_mode(intent->trigger_mode)
                                          .kick_speed(intent->kick_speed)

--- a/soccer/src/soccer/control/manipulator_control.cpp
+++ b/soccer/src/soccer/control/manipulator_control.cpp
@@ -16,14 +16,20 @@ ManipulatorControl::ManipulatorControl(int shell_id, rclcpp::Node* node) : shell
         topics::manipulator_setpoint_topic(shell_id), rclcpp::QoS(10));
 
     manipulator_pub_ = manipulator_pub;
+    coach_state_sub_ = node->create_subscription<rj_msgs::msg::CoachState>(
+            "/strategy/coach_state", rclcpp::QoS(1),
+            [this](rj_msgs::msg::CoachState::SharedPtr coach_state) {  // NOLINT
+                last_coach_state_ = *coach_state;
+            });
+
     intent_sub_ = node->create_subscription<rj_msgs::msg::RobotIntent>(
         gameplay::topics::robot_intent_topic(shell_id), rclcpp::QoS(1),
-        [manipulator_pub](rj_msgs::msg::RobotIntent::SharedPtr intent) {  // NOLINT
+        [manipulator_pub, this](rj_msgs::msg::RobotIntent::SharedPtr intent) {  // NOLINT
             manipulator_pub->publish(rj_msgs::build<rj_msgs::msg::ManipulatorSetpoint>()
                                          .shoot_mode(intent->shoot_mode)
                                          .trigger_mode(intent->trigger_mode)
                                          .kick_speed(intent->kick_speed)
-                                         .dribbler_speed(intent->dribbler_speed));
+                                         .dribbler_speed(this->last_coach_state_.global_override.max_dribbler_speed));
         });
 }
 

--- a/soccer/src/soccer/control/manipulator_control.cpp
+++ b/soccer/src/soccer/control/manipulator_control.cpp
@@ -17,11 +17,11 @@ ManipulatorControl::ManipulatorControl(int shell_id, rclcpp::Node* node) : shell
 
     manipulator_pub_ = manipulator_pub;
     coach_state_sub_ = node->create_subscription<rj_msgs::msg::CoachState>(
-            "/strategy/coach_state", rclcpp::QoS(1),
-            [this](rj_msgs::msg::CoachState::SharedPtr coach_state) {  // NOLINT
-                last_coach_state_ = *coach_state;
-                dribbler_speed_ = last_coach_state_.global_override.max_dribbler_speed;
-            });
+        "/strategy/coach_state", rclcpp::QoS(1),
+        [this](rj_msgs::msg::CoachState::SharedPtr coach_state) {  // NOLINT
+            last_coach_state_ = *coach_state;
+            dribbler_speed_ = last_coach_state_.global_override.max_dribbler_speed;
+        });
 
     intent_sub_ = node->create_subscription<rj_msgs::msg::RobotIntent>(
         gameplay::topics::robot_intent_topic(shell_id), rclcpp::QoS(1),

--- a/soccer/src/soccer/control/manipulator_control.cpp
+++ b/soccer/src/soccer/control/manipulator_control.cpp
@@ -25,8 +25,8 @@ ManipulatorControl::ManipulatorControl(int shell_id, rclcpp::Node* node) : shell
 
     intent_sub_ = node->create_subscription<rj_msgs::msg::RobotIntent>(
         gameplay::topics::robot_intent_topic(shell_id), rclcpp::QoS(1),
-        [this](rj_msgs::msg::RobotIntent::SharedPtr intent) {  // NOLINT
-            manipulator_pub_->publish(rj_msgs::build<rj_msgs::msg::ManipulatorSetpoint>()
+        [manipulator_pub, this](rj_msgs::msg::RobotIntent::SharedPtr intent) {  // NOLINT
+            manipulator_pub->publish(rj_msgs::build<rj_msgs::msg::ManipulatorSetpoint>()
                                          .shoot_mode(intent->shoot_mode)
                                          .trigger_mode(intent->trigger_mode)
                                          .kick_speed(intent->kick_speed)

--- a/soccer/src/soccer/control/manipulator_control.hpp
+++ b/soccer/src/soccer/control/manipulator_control.hpp
@@ -6,6 +6,7 @@
 #include <rj_msgs/msg/manipulator_setpoint.hpp>
 #include <rj_msgs/msg/robot_intent.hpp>
 #include <rj_param_utils/param.hpp>
+#include <rj_msgs/msg/coach_state.hpp>
 
 namespace control {
 
@@ -23,6 +24,9 @@ private:
     int shell_id_;
     rclcpp::Publisher<rj_msgs::msg::ManipulatorSetpoint>::SharedPtr manipulator_pub_;
     rclcpp::Subscription<rj_msgs::msg::RobotIntent>::SharedPtr intent_sub_;
+    rclcpp::Subscription<rj_msgs::msg::CoachState>::SharedPtr coach_state_sub_;
+
+    rj_msgs::msg::CoachState last_coach_state_{};
 };
 
 }  // namespace control

--- a/soccer/src/soccer/control/manipulator_control.hpp
+++ b/soccer/src/soccer/control/manipulator_control.hpp
@@ -27,6 +27,7 @@ private:
     rclcpp::Subscription<rj_msgs::msg::CoachState>::SharedPtr coach_state_sub_;
 
     rj_msgs::msg::CoachState last_coach_state_{};
+    double dribbler_speed_ = 0;
 };
 
 }  // namespace control

--- a/soccer/src/soccer/control/manipulator_control.hpp
+++ b/soccer/src/soccer/control/manipulator_control.hpp
@@ -3,10 +3,10 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <rj_constants/topic_names.hpp>
+#include <rj_msgs/msg/coach_state.hpp>
 #include <rj_msgs/msg/manipulator_setpoint.hpp>
 #include <rj_msgs/msg/robot_intent.hpp>
 #include <rj_param_utils/param.hpp>
-#include <rj_msgs/msg/coach_state.hpp>
 
 namespace control {
 

--- a/soccer/src/soccer/planning/planner/plan_request.hpp
+++ b/soccer/src/soccer/planning/planner/plan_request.hpp
@@ -30,7 +30,7 @@ struct PlanRequest {
                 rj_geometry::ShapeSet virtual_obstacles, TrajectoryCollection* planned_trajectories,
                 unsigned shell_id, const WorldState* world_state, int8_t priority = 0,
                 rj_drawing::RosDebugDrawer* debug_drawer = nullptr, bool ball_sense = false,
-                float min_dist_from_ball = 0)
+                float min_dist_from_ball = 0, float dribbler_speed = 0)
         : start(start),
           motion_command(command),  // NOLINT
           constraints(constraints),
@@ -42,7 +42,8 @@ struct PlanRequest {
           world_state(world_state),
           debug_drawer(debug_drawer),
           ball_sense(ball_sense),
-          min_dist_from_ball(min_dist_from_ball) {}
+          min_dist_from_ball(min_dist_from_ball),
+          dribbler_speed(dribbler_speed) {}
 
     /**
      * The robot's starting state.
@@ -107,6 +108,11 @@ struct PlanRequest {
      * How far away to stay from the ball, if the MotionCommand chooses to avoid the ball.
      */
     float min_dist_from_ball = 0;
+
+    /**
+     * Dribbler Speed
+    */
+   float dribbler_speed = 0;
 };
 
 /**

--- a/soccer/src/soccer/planning/planner/plan_request.hpp
+++ b/soccer/src/soccer/planning/planner/plan_request.hpp
@@ -111,8 +111,8 @@ struct PlanRequest {
 
     /**
      * Dribbler Speed
-    */
-   float dribbler_speed = 0;
+     */
+    float dribbler_speed = 0;
 };
 
 /**

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -246,7 +246,6 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     const auto play_state = global_state_.play_state();
     const auto min_dist_from_ball = global_state_.coach_state().global_override.min_dist_from_ball;
     const auto max_robot_speed = global_state_.coach_state().global_override.max_speed;
-    intent.dribbler_speed = global_state_.coach_state().global_override.max_dribbler_speed;
     const auto& robot = world_state->our_robots.at(robot_id_);
     const auto start = RobotInstant{robot.pose, robot.velocity, robot.timestamp};
 

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -202,7 +202,7 @@ void PlannerForRobot::execute_intent(const RobotIntent& intent) {
                                       .shoot_mode(intent.shoot_mode)
                                       .trigger_mode(intent.trigger_mode)
                                       .kick_speed(intent.kick_speed)
-                                      .dribbler_speed(intent.dribbler_speed));
+                                      .dribbler_speed(plan_request.dribble_speed));
 
         /*
         // TODO (PR #1970): fix TrajectoryCollection
@@ -246,6 +246,7 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     const auto play_state = global_state_.play_state();
     const auto min_dist_from_ball = global_state_.coach_state().global_override.min_dist_from_ball;
     const auto max_robot_speed = global_state_.coach_state().global_override.max_speed;
+    const auto max_dribbler_speed = global_state_.coach_state().global_override.max_dribbler_speed;
     const auto& robot = world_state->our_robots.at(robot_id_);
     const auto start = RobotInstant{robot.pose, robot.velocity, robot.timestamp};
 
@@ -298,6 +299,8 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
         constraints.mot.max_speed = max_robot_speed;
     }
 
+    float dribble_speed = std::min(intent.dribbler_speed, max_dribbler_speed);
+
     return PlanRequest{start,
                        motion_command,
                        constraints,
@@ -309,7 +312,8 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
                        intent.priority,
                        &debug_draw_,
                        had_break_beam_,
-                       min_dist_from_ball};
+                       min_dist_from_ball,
+                       dribble_speed};
 }
 
 Trajectory PlannerForRobot::unsafe_plan_for_robot(const planning::PlanRequest& request) {

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -246,7 +246,7 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     const auto play_state = global_state_.play_state();
     const auto min_dist_from_ball = global_state_.coach_state().global_override.min_dist_from_ball;
     const auto max_robot_speed = global_state_.coach_state().global_override.max_speed;
-
+    intent.dribbler_speed = global_state_.coach_state().global_override.max_dribbler_speed;
     const auto& robot = world_state->our_robots.at(robot_id_);
     const auto start = RobotInstant{robot.pose, robot.velocity, robot.timestamp};
 

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -33,6 +33,11 @@ Goalie::State Goalie::update_state() {
         return CLEARING;
     }
 
+    // when line kick fails but ball leaves box, don't chase it
+    if (!ball_in_box) {
+        return IDLING;
+    }
+
     rj_geometry::Point robot_position = world_state->get_robot(true, robot_id_).pose.position();
     double distance_to_ball = robot_position.dist_to(ball_pt);
     if (latest_state_ == PASSING) {
@@ -69,6 +74,7 @@ std::optional<RobotIntent> Goalie::state_to_task(RobotIntent intent) {
         intent.shoot_mode = RobotIntent::ShootMode::CHIP;
         intent.trigger_mode = RobotIntent::TriggerMode::ON_BREAK_BEAM;
         intent.kick_speed = 4.0;
+        intent.dribbler_speed = 255.0;
         intent.is_active = true;
 
         return intent;

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -120,6 +120,7 @@ void CoachNode::check_for_play_state_change() {
                 // instead.
                 global_override.max_speed = 10.0;
                 global_override.min_dist_from_ball = 0;
+                global_override.max_dribbler_speed = 255;
                 break;
         }
 

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -108,10 +108,12 @@ void CoachNode::check_for_play_state_change() {
             case PlayState::State::Halt:
                 global_override.max_speed = 0;
                 global_override.min_dist_from_ball = 0;
+                global_override.max_dribbler_speed = 0;
                 break;
             case PlayState::State::Stop:
                 global_override.max_speed = 1.5;
                 global_override.min_dist_from_ball = 0.5;
+                global_override.max_dribbler_speed = 0;
                 break;
             case PlayState::State::Playing:
                 // Unbounded speed. Setting to -1 or 0 crashes planner, so use large number


### PR DESCRIPTION
## Description
Make the dibbler respect the states of the external referee. 

## Associated / Resolved Issue
[ClickUp card](https://app.clickup.com/t/8677w00dc)

## Steps to Test
### Test Case 1
1. Run the external sim 
2. Echo the strategy/coach_state topic in another terminal tab
3. Check the dribbler speed change with the different stages
4. Run it on the actual field

**Expected result:** The dribbler should not run during stop and halt. It should only run while it is in the playing state. 

## Key Files to Review
* coach_node.cpp
* manipulator_control.cpp