### PR TITLE
Shoot only

### DIFF
--- a/rj_msgs/CMakeLists.txt
+++ b/rj_msgs/CMakeLists.txt
@@ -67,6 +67,7 @@ rosidl_generate_interfaces(
   request/IncomingBallRequest.msg
   request/BallInTransitRequest.msg
   request/ScorerRequest.msg
+  request/ResetScorerRequest.msg
 
   # Agent Response Messages
   response/Acknowledge.msg

--- a/rj_msgs/CMakeLists.txt
+++ b/rj_msgs/CMakeLists.txt
@@ -66,6 +66,7 @@ rosidl_generate_interfaces(
   request/TestRequest.msg
   request/IncomingBallRequest.msg
   request/BallInTransitRequest.msg
+  request/ScorerRequest.msg
 
   # Agent Response Messages
   response/Acknowledge.msg

--- a/rj_msgs/CMakeLists.txt
+++ b/rj_msgs/CMakeLists.txt
@@ -73,6 +73,7 @@ rosidl_generate_interfaces(
   response/PassResponse.msg
   response/PositionResponse.msg
   response/TestResponse.msg
+  response/ScorerResponse.msg
 
   # Services
   srv/AgentCommunication.srv

--- a/rj_msgs/msg/AgentRequest.msg
+++ b/rj_msgs/msg/AgentRequest.msg
@@ -9,3 +9,4 @@ PassRequest[<=1] pass_request
 IncomingBallRequest[<=1] incoming_ball_request
 BallInTransitRequest[<=1] ball_in_transit_request
 ScorerRequest[<=1] scorer_request
+ResetScorerRequest[<=1] reset_scorer_request

--- a/rj_msgs/msg/AgentRequest.msg
+++ b/rj_msgs/msg/AgentRequest.msg
@@ -8,3 +8,4 @@ PositionRequest[<=1] position_request
 PassRequest[<=1] pass_request
 IncomingBallRequest[<=1] incoming_ball_request
 BallInTransitRequest[<=1] ball_in_transit_request
+ScorerRequest[<=1] scorer_request

--- a/rj_msgs/msg/AgentResponseVariant.msg
+++ b/rj_msgs/msg/AgentResponseVariant.msg
@@ -2,3 +2,4 @@ Acknowledge[<=1] acknowledge_response
 TestResponse[<=1] test_response
 PositionResponse[<=1] position_response
 PassResponse[<=1] pass_response
+ScorerResponse[<=1] scorer_response

--- a/rj_msgs/request/ResetScorerRequest.msg
+++ b/rj_msgs/request/ResetScorerRequest.msg
@@ -1,0 +1,1 @@
+uint32 request_uid

--- a/rj_msgs/request/ScorerRequest.msg
+++ b/rj_msgs/request/ScorerRequest.msg
@@ -1,0 +1,3 @@
+uint32 request_uid
+uint8 robot_id
+float64 goal_distance

--- a/rj_msgs/request/ScorerRequest.msg
+++ b/rj_msgs/request/ScorerRequest.msg
@@ -1,3 +1,1 @@
 uint32 request_uid
-uint8 robot_id
-float64 goal_distance

--- a/rj_msgs/request/ScorerRequest.msg
+++ b/rj_msgs/request/ScorerRequest.msg
@@ -1,1 +1,3 @@
 uint32 request_uid
+uint8 robot_id
+float64 ball_distance

--- a/rj_msgs/response/ScorerResponse.msg
+++ b/rj_msgs/response/ScorerResponse.msg
@@ -1,3 +1,3 @@
 uint32 response_uid
 uint8 robot_id
-float64 goal_distance
+float64 ball_distance

--- a/rj_msgs/response/ScorerResponse.msg
+++ b/rj_msgs/response/ScorerResponse.msg
@@ -1,0 +1,3 @@
+uint32 response_uid
+uint8 robot_id
+float64 goal_distance

--- a/soccer/src/soccer/planning/planner/collect_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/collect_path_planner.cpp
@@ -104,7 +104,6 @@ Trajectory CollectPathPlanner::plan(const PlanRequest& plan_request) {
     std::vector<DynamicObstacle> dynamic_obstacles;
     fill_obstacles(plan_request, &static_obstacles, &dynamic_obstacles, false);
 
-    SPDLOG_WARN("current_state_ {}", current_state_);
     switch (current_state_) {
         // Moves from the current location to the slow point of approach
         case CoarseApproach:

--- a/soccer/src/soccer/planning/planner/collect_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/collect_path_planner.cpp
@@ -29,11 +29,6 @@ Trajectory CollectPathPlanner::plan(const PlanRequest& plan_request) {
     RobotConstraints robot_constraints = plan_request.constraints;
     MotionConstraints& motion_constraints = robot_constraints.mot;
 
-    // List of obstacles
-    ShapeSet obstacles;
-    std::vector<DynamicObstacle> dynamic_obstacles;
-    fill_obstacles(plan_request, &obstacles, &dynamic_obstacles, false);
-
     // The small beginning part of the previous path
     Trajectory partial_path;
 
@@ -104,22 +99,30 @@ Trajectory CollectPathPlanner::plan(const PlanRequest& plan_request) {
     // Check if we should transition to control from approach
     process_state_transition(ball, start_instant);
 
+    // List of obstacles
+    ShapeSet static_obstacles;
+    std::vector<DynamicObstacle> dynamic_obstacles;
+    fill_obstacles(plan_request, &static_obstacles, &dynamic_obstacles, false);
+
+    SPDLOG_WARN("current_state_ {}", current_state_);
     switch (current_state_) {
         // Moves from the current location to the slow point of approach
-        case CourseApproach:
-            previous_ = coarse_approach(plan_request, start_instant, obstacles, dynamic_obstacles);
+        case CoarseApproach:
+            previous_ =
+                coarse_approach(plan_request, start_instant, static_obstacles, dynamic_obstacles);
             break;
         // Moves from the slow point of approach to just before point of contact
         case FineApproach:
-            previous_ = fine_approach(plan_request, start_instant, obstacles, dynamic_obstacles);
+            previous_ =
+                fine_approach(plan_request, start_instant, static_obstacles, dynamic_obstacles);
             break;
         // Move through the ball and stop
         case Control:
-            previous_ = control(plan_request, partial_start_instant, partial_path, obstacles,
+            previous_ = control(plan_request, partial_start_instant, partial_path, static_obstacles,
                                 dynamic_obstacles);
             break;
         default:
-            previous_ = invalid(plan_request, obstacles, dynamic_obstacles);
+            previous_ = invalid(plan_request, static_obstacles, dynamic_obstacles);
             break;
     }
 
@@ -134,7 +137,7 @@ void CollectPathPlanner::check_solution_validity(BallState ball, RobotInstant st
     //
     // See if we are not near the ball and both almost stopped
     if (!near_ball && current_state_ == Control) {
-        current_state_ = CourseApproach;
+        current_state_ = CoarseApproach;
         approach_direction_created_ = false;
         control_path_created_ = false;
     }
@@ -148,8 +151,14 @@ void CollectPathPlanner::process_state_transition(BallState ball, RobotInstant s
 
     // If we are in range to the slow dist
     if (dist < collect::PARAM_approach_dist_target + kRobotMouthRadius &&
-        current_state_ == CourseApproach) {
+        current_state_ == CoarseApproach) {
         current_state_ = FineApproach;
+    }
+
+    // If the ball gets knocked far away, go back to CoarseApproach
+    if (dist > collect::PARAM_approach_dist_target + kRobotMouthRadius &&
+        current_state_ == FineApproach) {
+        current_state_ = CoarseApproach;
     }
 
     // If we are close enough to the target point near the ball
@@ -379,8 +388,7 @@ Trajectory CollectPathPlanner::control(const PlanRequest& plan_request, RobotIns
 Trajectory CollectPathPlanner::invalid(const PlanRequest& plan_request,
                                        const rj_geometry::ShapeSet& static_obstacles,
                                        const std::vector<DynamicObstacle>& dynamic_obstacles) {
-    SPDLOG_WARN("Invalid state in collect planner. Restarting");
-    current_state_ = CourseApproach;
+    current_state_ = CoarseApproach;
 
     // Stop movement until next frame since it's the safest option
     // programmatically
@@ -398,7 +406,7 @@ Trajectory CollectPathPlanner::invalid(const PlanRequest& plan_request,
 
 void CollectPathPlanner::reset() {
     previous_ = Trajectory();
-    current_state_ = CollectPathPathPlannerStates::CourseApproach;
+    current_state_ = CollectPathPathPlannerStates::CoarseApproach;
     average_ball_vel_initialized_ = false;
     approach_direction_created_ = false;
     control_path_created_ = false;
@@ -406,7 +414,7 @@ void CollectPathPlanner::reset() {
 }
 
 bool CollectPathPlanner::is_done() const {
-    // FSM: CourseApproach -> FineApproach -> Control
+    // FSM: CoarseApproach -> FineApproach -> Control
     // (see process_state_transition())
     if (current_state_ != Control) {
         return false;

--- a/soccer/src/soccer/planning/planner/collect_path_planner.hpp
+++ b/soccer/src/soccer/planning/planner/collect_path_planner.hpp
@@ -19,7 +19,7 @@ public:
     enum CollectPathPathPlannerStates {
         // From start of subbehavior to the start of the slow part of the
         // approach
-        CourseApproach,
+        CoarseApproach,
         // From the slow part of the approach to the touching of the ball
         FineApproach,
         // From touching the ball to stopped with the ball in the mouth
@@ -62,7 +62,7 @@ private:
 
     Trajectory previous_;
 
-    CollectPathPathPlannerStates current_state_ = CollectPathPathPlannerStates::CourseApproach;
+    CollectPathPathPlannerStates current_state_ = CollectPathPathPlannerStates::CoarseApproach;
 
     // Ball Velocity Filtering Variables
     rj_geometry::Point average_ball_vel_;

--- a/soccer/src/soccer/planning/planner/line_kick_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/line_kick_path_planner.cpp
@@ -14,7 +14,7 @@ namespace planning {
 
 Trajectory LineKickPathPlanner::plan(const PlanRequest& plan_request) {
     // TODO(?): ros param these
-    const float approach_speed = 0.25;
+    const float approach_speed = 0.05;
 
     const float ball_avoid_distance = 0.10;
 

--- a/soccer/src/soccer/planning/planner/pivot_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/pivot_path_planner.cpp
@@ -63,7 +63,8 @@ Trajectory PivotPathPlanner::plan(const PlanRequest& request) {
     new_constraints.max_speed =
         std::min(new_constraints.max_speed, rotation_constraints.max_speed * radius) * .5;
 
-    double start_angle = pivot_point.angle_to(start_instant.position());
+    double start_angle = pivot_point.angle_to(
+        request.world_state->get_robot(true, request.shell_id).pose.position());
     double target_angle = pivot_point.angle_to(final_position);
     double angle_change = fix_angle_radians(target_angle - start_angle);
 

--- a/soccer/src/soccer/planning/planner/pivot_path_planner.hpp
+++ b/soccer/src/soccer/planning/planner/pivot_path_planner.hpp
@@ -13,8 +13,8 @@ namespace planning {
  * the ball to <command.target.position>.
  *
  * Params taken from MotionCommand:
- *   target.pivot_point - planner will pivot about this point
- *   target.position - planner will stop on this point when done pivoting
+ *   target.pivot_point - robot will pivot about this point
+ *   target.position - robot will face this point when done
  */
 class PivotPathPlanner : public PathPlanner {
 public:
@@ -46,7 +46,6 @@ private:
     std::optional<double> cached_angle_change_;
 
     // TODO(Kevin): ros param this
-    // in gameplay it is 0.05, this is just to see the change
-    double IS_DONE_ANGLE_CHANGE_THRESH = 0.1;
+    double IS_DONE_ANGLE_CHANGE_THRESH = 1.0;
 };
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -42,20 +42,27 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
     // Add our robots, either static or dynamic depending on whether they have
     // already been planned. In both cases, radius is based on velocity like
     // above for opp robots.
+    // TODO: reenable dynamic obstacles for our robots (currently
+    // TrajectoryCollection is never filled at planner level)
     for (size_t shell = 0; shell < kNumShells; shell++) {
-        const auto& robot = in.world_state->our_robots.at(shell);
-        if (!robot.visible || shell == in.shell_id) {
+        const auto& our_robot = in.world_state->our_robots.at(shell);
+        if (!our_robot.visible || shell == in.shell_id) {
             continue;
         }
 
-        const Trajectory* ptr_to_traj = std::get<0>(in.planned_trajectories->get(shell)).get();
-        if (out_dynamic != nullptr && ptr_to_traj != nullptr) {
-            // Dynamic obstacle
-            out_dynamic->emplace_back(obs_radius, ptr_to_traj);
-        } else {
-            // Static obstacle
-            out_static->add(std::make_shared<rj_geometry::Circle>(obs_center, obs_radius));
-        }
+        /* const Trajectory* ptr_to_traj = std::get<0>(in.planned_trajectories->get(shell)).get();
+         */
+        /* if (out_dynamic != nullptr && ptr_to_traj != nullptr) { */
+        /*     // Dynamic obstacle */
+        /*     out_dynamic->emplace_back(obs_radius, ptr_to_traj); */
+        /* } else { */
+        /*     // Static obstacle */
+        /*     out_static->add(std::make_shared<rj_geometry::Circle>(obs_center, obs_radius)); */
+        /* } */
+
+        // Static obstacle
+        fill_robot_obstacle(our_robot, obs_center, obs_radius);
+        out_static->add(std::make_shared<rj_geometry::Circle>(obs_center, obs_radius));
     }
 
     // Finally, add the ball as a dynamic obstacle.

--- a/soccer/src/soccer/strategy/agent/communication/communication.cpp
+++ b/soccer/src/soccer/strategy/agent/communication/communication.cpp
@@ -28,6 +28,10 @@ bool operator==(const BallInTransitRequest& a, const BallInTransitRequest& b) {
     return a.request_uid == b.request_uid;
 }
 
+bool operator==(const ScorerRequest& a, const ScorerRequest& b) {
+    return a.request_uid == b.request_uid;
+}
+
 bool operator==(const Acknowledge& a, const Acknowledge& b) {
     return a.response_uid == b.response_uid;
 }
@@ -77,6 +81,13 @@ void generate_uid(IncomingBallRequest& request) {
 }
 
 void generate_uid(BallInTransitRequest& request) {
+    request_uid_mutex.lock();
+    request.request_uid = request_uid;
+    request_uid++;
+    request_uid_mutex.unlock();
+}
+
+void generate_uid(ScorerRequest& request) {
     request_uid_mutex.lock();
     request.request_uid = request_uid;
     request_uid++;

--- a/soccer/src/soccer/strategy/agent/communication/communication.cpp
+++ b/soccer/src/soccer/strategy/agent/communication/communication.cpp
@@ -32,6 +32,10 @@ bool operator==(const ScorerRequest& a, const ScorerRequest& b) {
     return a.request_uid == b.request_uid;
 }
 
+bool operator==(const ResetScorerRequest& a, const ResetScorerRequest& b) {
+    return a.request_uid == b.request_uid;
+}
+
 bool operator==(const Acknowledge& a, const Acknowledge& b) {
     return a.response_uid == b.response_uid;
 }
@@ -92,6 +96,13 @@ void generate_uid(BallInTransitRequest& request) {
 }
 
 void generate_uid(ScorerRequest& request) {
+    request_uid_mutex.lock();
+    request.request_uid = request_uid;
+    request_uid++;
+    request_uid_mutex.unlock();
+}
+
+void generate_uid(ResetScorerRequest& request) {
     request_uid_mutex.lock();
     request.request_uid = request_uid;
     request_uid++;

--- a/soccer/src/soccer/strategy/agent/communication/communication.cpp
+++ b/soccer/src/soccer/strategy/agent/communication/communication.cpp
@@ -48,6 +48,10 @@ bool operator==(const TestResponse& a, const TestResponse& b) {
     return a.response_uid == b.response_uid;
 }
 
+bool operator==(const ScorerResponse& a, const ScorerResponse& b) {
+    return a.response_uid == b.response_uid;
+}
+
 bool operator==(const AgentResponse& a, const AgentResponse& b) {
     return (a.associated_request == b.associated_request) && (a.response == b.response);
 }
@@ -116,6 +120,13 @@ void generate_uid(PositionResponse& response) {
 }
 
 void generate_uid(TestResponse& response) {
+    response_uid_mutex.lock();
+    response.response_uid = response_uid;
+    response_uid++;
+    response_uid_mutex.unlock();
+}
+
+void generate_uid(ScorerResponse& response) {
     response_uid_mutex.lock();
     response.response_uid = response_uid;
     response_uid++;

--- a/soccer/src/soccer/strategy/agent/communication/communication.hpp
+++ b/soccer/src/soccer/strategy/agent/communication/communication.hpp
@@ -17,11 +17,11 @@
 #include "rj_msgs/msg/pass_response.hpp"
 #include "rj_msgs/msg/position_request.hpp"
 #include "rj_msgs/msg/position_response.hpp"
+#include "rj_msgs/msg/reset_scorer_request.hpp"
 #include "rj_msgs/msg/scorer_request.hpp"
 #include "rj_msgs/msg/scorer_response.hpp"
 #include "rj_msgs/msg/test_request.hpp"
 #include "rj_msgs/msg/test_response.hpp"
-#include "rj_msgs/msg/reset_scorer_request.hpp"
 
 namespace strategy::communication {
 
@@ -113,7 +113,7 @@ bool operator==(const ScorerRequest& a, const ScorerRequest& b);
 
 /**
  * @brief request sent by a scorer after they shoot to avoid double touch penalties.
- * 
+ *
  */
 struct ResetScorerRequest {
     u_int32_t request_uid;
@@ -418,13 +418,15 @@ ASSOCIATE_CPP_ROS(strategy::communication::ScorerRequest, rj_msgs::msg::ScorerRe
 
 template <>
 struct RosConverter<strategy::communication::ResetScorerRequest, rj_msgs::msg::ResetScorerRequest> {
-    static rj_msgs::msg::ResetScorerRequest to_ros(const strategy::communication::ResetScorerRequest& from) {
+    static rj_msgs::msg::ResetScorerRequest to_ros(
+        const strategy::communication::ResetScorerRequest& from) {
         rj_msgs::msg::ResetScorerRequest result;
         result.request_uid = from.request_uid;
         return result;
     }
 
-    static strategy::communication::ResetScorerRequest from_ros(const rj_msgs::msg::ResetScorerRequest& from) {
+    static strategy::communication::ResetScorerRequest from_ros(
+        const rj_msgs::msg::ResetScorerRequest& from) {
         return strategy::communication::ResetScorerRequest{
             from.request_uid,
         };
@@ -454,7 +456,8 @@ struct RosConverter<strategy::communication::AgentRequest, rj_msgs::msg::AgentRe
         } else if (const auto* scorer_request =
                        std::get_if<strategy::communication::ScorerRequest>(&from)) {
             result.scorer_request.emplace_back(convert_to_ros(*scorer_request));
-        } else if (const auto* reset_scorer_request = std::get_if<strategy::communication::ResetScorerRequest>(&from)) {
+        } else if (const auto* reset_scorer_request =
+                       std::get_if<strategy::communication::ResetScorerRequest>(&from)) {
             result.reset_scorer_request.emplace_back(convert_to_ros(*reset_scorer_request));
         } else {
             throw std::runtime_error("Invalid variant of AgentRequest");

--- a/soccer/src/soccer/strategy/agent/communication/communication.hpp
+++ b/soccer/src/soccer/strategy/agent/communication/communication.hpp
@@ -17,10 +17,10 @@
 #include "rj_msgs/msg/pass_response.hpp"
 #include "rj_msgs/msg/position_request.hpp"
 #include "rj_msgs/msg/position_response.hpp"
-#include "rj_msgs/msg/test_request.hpp"
-#include "rj_msgs/msg/test_response.hpp"
 #include "rj_msgs/msg/scorer_request.hpp"
 #include "rj_msgs/msg/scorer_response.hpp"
+#include "rj_msgs/msg/test_request.hpp"
+#include "rj_msgs/msg/test_response.hpp"
 
 namespace strategy::communication {
 
@@ -101,7 +101,7 @@ bool operator==(const BallInTransitRequest& a, const BallInTransitRequest& b);
 /**
  * @brief request sent by an agent to determine whether or not it should be going to steal
  * the ball to then shoot the ball
- * 
+ *
  */
 struct ScorerRequest {
     u_int32_t request_uid;
@@ -180,7 +180,7 @@ bool operator==(const TestResponse& a, const TestResponse& b);
  * @brief response to return to another robot asking to be the scorer (only offensive
  * robots will return this response to let another offensive robot know whether or not
  * they should be the scorer)
- * 
+ *
  */
 struct ScorerResponse {
     u_int32_t response_uid;
@@ -385,8 +385,7 @@ ASSOCIATE_CPP_ROS(strategy::communication::BallInTransitRequest,
 
 template <>
 struct RosConverter<strategy::communication::ScorerRequest, rj_msgs::msg::ScorerRequest> {
-    static rj_msgs::msg::ScorerRequest to_ros(
-        const strategy::communication::ScorerRequest& from) {
+    static rj_msgs::msg::ScorerRequest to_ros(const strategy::communication::ScorerRequest& from) {
         rj_msgs::msg::ScorerRequest result;
         result.request_uid = from.request_uid;
         result.robot_id = from.robot_id;
@@ -424,7 +423,8 @@ struct RosConverter<strategy::communication::AgentRequest, rj_msgs::msg::AgentRe
         } else if (const auto* ball_in_transit_request =
                        std::get_if<strategy::communication::BallInTransitRequest>(&from)) {
             result.ball_in_transit_request.emplace_back(convert_to_ros(*ball_in_transit_request));
-        } else if (const auto* scorer_request = std::get_if<strategy::communication::ScorerRequest>(&from)) {
+        } else if (const auto* scorer_request =
+                       std::get_if<strategy::communication::ScorerRequest>(&from)) {
             result.scorer_request.emplace_back(convert_to_ros(*scorer_request));
         } else {
             throw std::runtime_error("Invalid variant of AgentRequest");
@@ -535,7 +535,8 @@ ASSOCIATE_CPP_ROS(strategy::communication::TestResponse, rj_msgs::msg::TestRespo
 
 template <>
 struct RosConverter<strategy::communication::ScorerResponse, rj_msgs::msg::ScorerResponse> {
-    static rj_msgs::msg::ScorerResponse to_ros(const strategy::communication::ScorerResponse& from) {
+    static rj_msgs::msg::ScorerResponse to_ros(
+        const strategy::communication::ScorerResponse& from) {
         rj_msgs::msg::ScorerResponse result;
         result.response_uid = from.response_uid;
         result.robot_id = from.robot_id;
@@ -543,12 +544,10 @@ struct RosConverter<strategy::communication::ScorerResponse, rj_msgs::msg::Score
         return result;
     }
 
-    static strategy::communication::ScorerResponse from_ros(const rj_msgs::msg::ScorerResponse& from) {
-        strategy::communication::ScorerResponse result{
-            from.response_uid,
-            from.robot_id,
-            from.ball_distance
-        };
+    static strategy::communication::ScorerResponse from_ros(
+        const rj_msgs::msg::ScorerResponse& from) {
+        strategy::communication::ScorerResponse result{from.response_uid, from.robot_id,
+                                                       from.ball_distance};
         return result;
     }
 };
@@ -573,7 +572,8 @@ struct RosConverter<strategy::communication::AgentResponse, rj_msgs::msg::AgentR
         } else if (const auto* pass_response =
                        std::get_if<strategy::communication::PassResponse>(&(from.response))) {
             result.response.pass_response.emplace_back(convert_to_ros(*pass_response));
-        } else if (const auto* scorer_response = std::get_if<strategy::communication::ScorerResponse>(&(from.response))) {
+        } else if (const auto* scorer_response =
+                       std::get_if<strategy::communication::ScorerResponse>(&(from.response))) {
             result.response.scorer_response.emplace_back(convert_to_ros(*scorer_response));
         } else {
             throw std::runtime_error("Invalid variant of AgentResponse");

--- a/soccer/src/soccer/strategy/agent/communication/communication.hpp
+++ b/soccer/src/soccer/strategy/agent/communication/communication.hpp
@@ -105,8 +105,6 @@ bool operator==(const BallInTransitRequest& a, const BallInTransitRequest& b);
  */
 struct ScorerRequest {
     u_int32_t request_uid;
-    u_int8_t robot_id;
-    double goal_distance;
 };
 bool operator==(const ScorerRequest& a, const ScorerRequest& b);
 
@@ -185,7 +183,7 @@ bool operator==(const TestResponse& a, const TestResponse& b);
 struct ScorerResponse {
     u_int32_t response_uid;
     u_int8_t robot_id;
-    double goal_distance;
+    double ball_distance;
 };
 bool operator==(const ScorerResponse& a, const ScorerResponse& b);
 
@@ -389,8 +387,6 @@ struct RosConverter<strategy::communication::ScorerRequest, rj_msgs::msg::Scorer
         const strategy::communication::ScorerRequest& from) {
         rj_msgs::msg::ScorerRequest result;
         result.request_uid = from.request_uid;
-        result.robot_id = from.robot_id;
-        result.goal_distance = from.goal_distance;
         return result;
     }
 
@@ -398,8 +394,6 @@ struct RosConverter<strategy::communication::ScorerRequest, rj_msgs::msg::Scorer
         const rj_msgs::msg::ScorerRequest& from) {
         return strategy::communication::ScorerRequest{
             from.request_uid,
-            from.robot_id,
-            from.goal_distance
         };
     }
 };
@@ -539,7 +533,7 @@ struct RosConverter<strategy::communication::ScorerResponse, rj_msgs::msg::Score
         rj_msgs::msg::ScorerResponse result;
         result.response_uid = from.response_uid;
         result.robot_id = from.robot_id;
-        result.goal_distance = from.goal_distance;
+        result.ball_distance = from.ball_distance;
         return result;
     }
 
@@ -547,7 +541,7 @@ struct RosConverter<strategy::communication::ScorerResponse, rj_msgs::msg::Score
         strategy::communication::ScorerResponse result{
             from.response_uid,
             from.robot_id,
-            from.goal_distance
+            from.ball_distance
         };
         return result;
     }

--- a/soccer/src/soccer/strategy/agent/communication/communication.hpp
+++ b/soccer/src/soccer/strategy/agent/communication/communication.hpp
@@ -148,7 +148,8 @@ bool operator==(const LeaveWallRequest& a, const LeaveWallRequest& b);
  * @brief a conglomeration of the different request types.
  */
 using AgentRequest = std::variant<PassRequest, TestRequest, PositionRequest, IncomingBallRequest,
-                                  BallInTransitRequest, ScorerRequest, ResetScorerRequest, JoinWallRequest, LeaveWallRequest>;
+                                  BallInTransitRequest, ScorerRequest, ResetScorerRequest,
+                                  JoinWallRequest, LeaveWallRequest>;
 
 // END REQUEST TYPES //
 

--- a/soccer/src/soccer/strategy/agent/communication/communication.hpp
+++ b/soccer/src/soccer/strategy/agent/communication/communication.hpp
@@ -105,6 +105,8 @@ bool operator==(const BallInTransitRequest& a, const BallInTransitRequest& b);
  */
 struct ScorerRequest {
     u_int32_t request_uid;
+    u_int8_t robot_id;
+    double ball_distance;
 };
 bool operator==(const ScorerRequest& a, const ScorerRequest& b);
 
@@ -387,6 +389,8 @@ struct RosConverter<strategy::communication::ScorerRequest, rj_msgs::msg::Scorer
         const strategy::communication::ScorerRequest& from) {
         rj_msgs::msg::ScorerRequest result;
         result.request_uid = from.request_uid;
+        result.robot_id = from.robot_id;
+        result.ball_distance = from.ball_distance;
         return result;
     }
 
@@ -394,6 +398,8 @@ struct RosConverter<strategy::communication::ScorerRequest, rj_msgs::msg::Scorer
         const rj_msgs::msg::ScorerRequest& from) {
         return strategy::communication::ScorerRequest{
             from.request_uid,
+            from.robot_id,
+            from.ball_distance,
         };
     }
 };

--- a/soccer/src/soccer/strategy/agent/position/defense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/defense.cpp
@@ -51,6 +51,9 @@ Defense::State Defense::update_state() {
 
 std::optional<RobotIntent> Defense::state_to_task(RobotIntent intent) {
     if (current_state_ == IDLING) {
+        auto empty_motion_cmd = planning::MotionCommand{};
+        intent.motion_command = empty_motion_cmd;
+        return intent;
         // DO NOTHING
     } else if (current_state_ == SEARCHING) {
         // TODO(https://app.clickup.com/t/8677qektb): Define defensive searching behavior

--- a/soccer/src/soccer/strategy/agent/position/goalie.hpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.hpp
@@ -29,6 +29,9 @@ public:
     void derived_acknowledge_ball_in_transit() override;
 
 private:
+    // point goalie will aim for when clearing balls
+    const rj_geometry::Point clear_point_{0.0, 4.5};
+
     // temp
     int send_idle_ct_ = 0;
 
@@ -40,6 +43,7 @@ private:
         IDLING,          // doing nothing
         BLOCKING,        // blocking the ball from reaching the goal
         CLEARING,        // clearing the ball out of the goal box
+        PREPARING_SHOT,  // pivot around ball in preparation for shot
         BALL_NOT_FOUND,  // the ball is not in play
         RECEIVING,       // physically intercepting the ball from a pass
         PASSING,         // physically kicking the ball at another robot

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -50,7 +50,8 @@ Offense::State Offense::update_state() {
         case SHOOTING:
             // transition to idling if we no longer have the ball (i.e. it was passed or it was
             // stolen)
-            if (check_is_done()) {
+            if (check_is_done() || distance_to_ball > ball_lost_distance_) {
+                send_reset_scorer_request();
                 next_state = SEARCHING;
             }
             break;
@@ -179,6 +180,10 @@ communication::PosAgentResponseWrapper Offense::receive_communication_request(
             std::get_if<communication::ScorerRequest>(&request.request)) {
         communication::ScorerResponse scorer_response = receive_scorer_request(*scorer_request);
         comm_response.response = scorer_response;
+    } else if (const communication::ResetScorerRequest* reset_scorer_request =
+                   std::get_if<communication::ResetScorerRequest>(&request.request)) {
+        communication::Acknowledge response = receive_reset_scorer_request(*reset_scorer_request);
+        comm_response.response = response;
     }
 
     return comm_response;
@@ -202,6 +207,19 @@ void Offense::send_scorer_request() {
     communication_request_ = communication_request;
 }
 
+void Offense::send_reset_scorer_request() {
+    communication::ResetScorerRequest reset_scorer_request{};
+    communication::generate_uid(reset_scorer_request);
+
+    communication::PosAgentRequestWrapper communication_request{};
+    communication_request.request = reset_scorer_request;
+    communication_request.broadcast = true;
+
+    communication_request_ = communication_request;
+    last_scorer_ = true;
+    scorer_ = false;
+}
+
 communication::ScorerResponse Offense::receive_scorer_request(
     communication::ScorerRequest scorer_request) {
     communication::ScorerResponse scorer_response{};
@@ -220,10 +238,27 @@ communication::ScorerResponse Offense::receive_scorer_request(
         current_state_ = FACING;
     }
 
+    // Give fake answer if previous scorer
+    if (last_scorer_) {
+        scorer_response.ball_distance = 300;
+    }
+
     return scorer_response;
 }
 
-void Offense::handle_scorer_response(const std::vector<communication::AgentResponseVariant>& responses) {
+communication::Acknowledge Offense::receive_reset_scorer_request(
+    communication::ResetScorerRequest reset_scorer_request) {
+    communication::Acknowledge acknowledge{};
+    communication::generate_uid(acknowledge);
+
+    last_scorer_ = false;
+    send_scorer_request();
+
+    return acknowledge;
+}
+
+void Offense::handle_scorer_response(
+    const std::vector<communication::AgentResponseVariant>& responses) {
     rj_geometry::Point this_robot_position =
         world_state()->get_robot(true, robot_id_).pose.position();
     rj_geometry::Point ball_position = world_state()->ball.position;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -32,7 +32,7 @@ Offense::State Offense::update_state() {
             next_state = SEARCHING;
             break;
         case SEARCHING:
-            if (scorer) {
+            if (scorer_) {
                 next_state = STEALING;
             }
             break;
@@ -65,7 +65,7 @@ Offense::State Offense::update_state() {
             // distance
             if (check_is_done() || distance_to_ball < ball_receive_distance_) {
                 // send direct pass request to robot 4
-                if (scorer) {
+                if (scorer_) {
                     next_state = SHOOTING;
                 } else {
                     send_direct_pass_request({4});
@@ -215,15 +215,15 @@ communication::ScorerResponse Offense::receive_scorer_request(
     scorer_response.ball_distance = ball_distance;
 
     // Switch scorers if better scorer
-    if (scorer && scorer_request.ball_distance < ball_distance) {
-        scorer = false;
+    if (scorer_ && scorer_request.ball_distance < ball_distance) {
+        scorer_ = false;
         current_state_ = FACING;
     }
 
     return scorer_response;
 }
 
-void Offense::handle_scorer_response(std::vector<communication::AgentResponseVariant> responses) {
+void Offense::handle_scorer_response(const std::vector<communication::AgentResponseVariant>& responses) {
     rj_geometry::Point this_robot_position =
         world_state()->get_robot(true, robot_id_).pose.position();
     rj_geometry::Point ball_position = world_state()->ball.position;
@@ -239,7 +239,7 @@ void Offense::handle_scorer_response(std::vector<communication::AgentResponseVar
     }
 
     // Make this robot the scorer
-    scorer = true;
+    scorer_ = true;
 }
 
 void Offense::derived_acknowledge_pass() { current_state_ = FACING; }

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -89,6 +89,9 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
         return intent;
     } else if (current_state_ == SEARCHING) {
         // DEFINE SEARCHING BEHAVIOR
+        auto empty_motion_cmd = planning::MotionCommand{};
+        intent.motion_command = empty_motion_cmd;
+        return intent;
     } else if (current_state_ == PASSING) {
         // attempt to pass the ball to the target robot
         rj_geometry::Point target_robot_pos =
@@ -104,7 +107,6 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
         intent.is_active = true;
         return intent;
     } else if (current_state_ == SHOOTING) {
-        SPDLOG_INFO("\033[92mRobot {} is SHOOTING\033[0m", robot_id_);
         // TODO: Shoot the ball at the goal
         rj_geometry::Point their_goal_pos = field_dimensions_.their_goal_loc();
         planning::LinearMotionInstant target{their_goal_pos};
@@ -209,6 +211,7 @@ communication::ScorerResponse Offense::receive_scorer_request(communication::Sco
     // Switch scorers if better scorer
     if (scorer && scorer_request.ball_distance < ball_distance) {
         scorer = false;
+        current_state_ = FACING;
     }    
 
     return scorer_response;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -43,14 +43,14 @@ Offense::State Offense::update_state() {
             // stolen)
             if (check_is_done()) {
                 // SPDLOG_INFO("\033[92mRobot {} is finished passing\033[0m", robot_id_);
-                SPDLOG_INFO("\033[92mRobot {} finished pass - is done\033[0m", robot_id_);
+                // SPDLOG_INFO("\033[92mRobot {} finished pass - is done\033[0m", robot_id_);
                 next_state = IDLING;
             }
 
             if (distance_to_ball > ball_lost_distance_) {
                 //     SPDLOG_INFO("\033[92mRobot {} is finished pass - ball_lost_distance\033[0m",
                 //                 robot_id_);
-                SPDLOG_INFO("\033[92mRobot {} finished pass\033[0m", robot_id_);
+                // SPDLOG_INFO("\033[92mRobot {} finished pass\033[0m", robot_id_);
                 next_state = IDLING;
             }
             break;
@@ -84,6 +84,19 @@ Offense::State Offense::update_state() {
             if (check_is_done()) {
                 next_state = IDLING;
             }
+    }
+
+    // If this robot is the scorer, they can bypass everything and either receive the ball or score
+    if (scorer) {
+        if (current_state_ == STEALING) {
+            if (check_is_done()) {
+                next_state = SHOOTING;
+            }
+        } else if (current_state_ == SHOOTING) {
+            if (check_is_done()) {
+                next_state = STEALING;
+            }
+        }
     }
 
     return next_state;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -61,7 +61,8 @@ Offense::State Offense::update_state() {
             }
             break;
         case STEALING:
-            // The collect planner check_is_done() is wonky so I added a second clause to check distance
+            // The collect planner check_is_done() is wonky so I added a second clause to check
+            // distance
             if (check_is_done() || distance_to_ball < ball_receive_distance_) {
                 // send direct pass request to robot 4
                 if (scorer) {
@@ -161,17 +162,21 @@ void Offense::receive_communication_response(communication::AgentPosResponseWrap
     Position::receive_communication_response(response);
 
     // Check to see if we are dealing with scorer requests
-    if (const communication::ScorerRequest* scorer_response = std::get_if<communication::ScorerRequest>(&response.associated_request)) {
+    if (const communication::ScorerRequest* scorer_response =
+            std::get_if<communication::ScorerRequest>(&response.associated_request)) {
         handle_scorer_response(response.responses);
         return;
     }
 }
 
-communication::PosAgentResponseWrapper Offense::receive_communication_request(communication::AgentPosRequestWrapper request) {
-    communication::PosAgentResponseWrapper comm_response = Position::receive_communication_request(request);
+communication::PosAgentResponseWrapper Offense::receive_communication_request(
+    communication::AgentPosRequestWrapper request) {
+    communication::PosAgentResponseWrapper comm_response =
+        Position::receive_communication_request(request);
 
     // If a scorer request was received override the position receive_communication_request return
-    if (const communication::ScorerRequest* scorer_request = std::get_if<communication::ScorerRequest>(&request.request)) {
+    if (const communication::ScorerRequest* scorer_request =
+            std::get_if<communication::ScorerRequest>(&request.request)) {
         communication::ScorerResponse scorer_response = receive_scorer_request(*scorer_request);
         comm_response.response = scorer_response;
     }
@@ -197,7 +202,8 @@ void Offense::send_scorer_request() {
     communication_request_ = communication_request;
 }
 
-communication::ScorerResponse Offense::receive_scorer_request(communication::ScorerRequest scorer_request) {
+communication::ScorerResponse Offense::receive_scorer_request(
+    communication::ScorerRequest scorer_request) {
     communication::ScorerResponse scorer_response{};
     communication::generate_uid(scorer_response);
     scorer_response.robot_id = robot_id_;
@@ -212,18 +218,20 @@ communication::ScorerResponse Offense::receive_scorer_request(communication::Sco
     if (scorer && scorer_request.ball_distance < ball_distance) {
         scorer = false;
         current_state_ = FACING;
-    }    
+    }
 
     return scorer_response;
 }
 
 void Offense::handle_scorer_response(std::vector<communication::AgentResponseVariant> responses) {
-    rj_geometry::Point this_robot_position = world_state()->get_robot(true, robot_id_).pose.position();
+    rj_geometry::Point this_robot_position =
+        world_state()->get_robot(true, robot_id_).pose.position();
     rj_geometry::Point ball_position = world_state()->ball.position;
     double this_ball_distance = this_robot_position.dist_to(ball_position);
 
     for (communication::AgentResponseVariant response : responses) {
-        if (const communication::ScorerResponse* scorer_response = std::get_if<communication::ScorerResponse>(&response)) {
+        if (const communication::ScorerResponse* scorer_response =
+                std::get_if<communication::ScorerResponse>(&response)) {
             if (scorer_response->ball_distance < this_ball_distance) {
                 return;
             }

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -180,9 +180,9 @@ communication::PosAgentResponseWrapper Offense::receive_communication_request(
             std::get_if<communication::ScorerRequest>(&request.request)) {
         communication::ScorerResponse scorer_response = receive_scorer_request(*scorer_request);
         comm_response.response = scorer_response;
-    } else if (const communication::ResetScorerRequest* reset_scorer_request =
+    } else if (const communication::ResetScorerRequest* _ =
                    std::get_if<communication::ResetScorerRequest>(&request.request)) {
-        communication::Acknowledge response = receive_reset_scorer_request(*reset_scorer_request);
+        communication::Acknowledge response = receive_reset_scorer_request();
         comm_response.response = response;
     }
 
@@ -246,8 +246,7 @@ communication::ScorerResponse Offense::receive_scorer_request(
     return scorer_response;
 }
 
-communication::Acknowledge Offense::receive_reset_scorer_request(
-    communication::ResetScorerRequest reset_scorer_request) {
+communication::Acknowledge Offense::receive_reset_scorer_request() {
     communication::Acknowledge acknowledge{};
     communication::generate_uid(acknowledge);
 

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -26,58 +26,55 @@ Offense::State Offense::update_state() {
     rj_geometry::Point ball_position = world_state->ball.position;
     double distance_to_ball = robot_position.dist_to(ball_position);
 
-    switch (current_state_) {
-        case IDLING:
-            send_scorer_request();
-            next_state = SEARCHING;
-            break;
-        case SEARCHING:
-            if (scorer_) {
-                next_state = STEALING;
-            }
-            break;
-        case PASSING:
-            // transition to idling if we no longer have the ball (i.e. it was passed or it was
-            // stolen)
-            if (check_is_done()) {
-                next_state = IDLING;
-            }
+    if (current_state_ == IDLING) {
+        send_scorer_request();
+        next_state = SEARCHING;
+    } else if (current_state_ == SEARCHING) {
+        if (scorer_) {
+            next_state = STEALING;
+        }
+    } else if (current_state_ == PASSING) {
+        // transition to idling if we no longer have the ball (i.e. it was passed or it was
+        // stolen)
+        if (check_is_done()) {
+            next_state = IDLING;
+        }
 
-            if (distance_to_ball > ball_lost_distance_) {
-                next_state = IDLING;
+        if (distance_to_ball > ball_lost_distance_) {
+            next_state = IDLING;
+        }
+    } else if (current_state_ == PREPARING_SHOT) {
+        if (check_is_done()) {
+            next_state = SHOOTING;
+        }
+    } else if (current_state_ == SHOOTING) {
+        // transition to idling if we no longer have the ball (i.e. it was passed or it was
+        // stolen)
+        if (check_is_done() || distance_to_ball > ball_lost_distance_) {
+            send_reset_scorer_request();
+            next_state = SEARCHING;
+        }
+    } else if (current_state_ == RECEIVING) {
+        // transition to idling if we are close enough to the ball
+        if (distance_to_ball < ball_receive_distance_) {
+            next_state = IDLING;
+        }
+    } else if (current_state_ == STEALING) {
+        // The collect planner check_is_done() is wonky so I added a second clause to check
+        // distance
+        if (check_is_done() || distance_to_ball < ball_receive_distance_) {
+            // send direct pass request to robot 4
+            if (scorer_) {
+                next_state = PREPARING_SHOT;
+            } else {
+                /* send_direct_pass_request({4}); */
+                /* next_state = SEARCHING; */
             }
-            break;
-        case SHOOTING:
-            // transition to idling if we no longer have the ball (i.e. it was passed or it was
-            // stolen)
-            if (check_is_done() || distance_to_ball > ball_lost_distance_) {
-                send_reset_scorer_request();
-                next_state = SEARCHING;
-            }
-            break;
-        case RECEIVING:
-            // transition to idling if we are close enough to the ball
-            if (distance_to_ball < ball_receive_distance_) {
-                next_state = IDLING;
-            }
-            break;
-        case STEALING:
-            // The collect planner check_is_done() is wonky so I added a second clause to check
-            // distance
-            if (check_is_done() || distance_to_ball < ball_receive_distance_) {
-                // send direct pass request to robot 4
-                if (scorer_) {
-                    next_state = SHOOTING;
-                } else {
-                    send_direct_pass_request({4});
-                    next_state = SEARCHING;
-                }
-            }
-            break;
-        case FACING:
-            if (check_is_done()) {
-                next_state = IDLING;
-            }
+        }
+    } else if (current_state_ == FACING) {
+        if (check_is_done()) {
+            next_state = IDLING;
+        }
     }
 
     return next_state;
@@ -108,8 +105,21 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
         intent.kick_speed = 4.0;
         intent.is_active = true;
         return intent;
+    } else if (current_state_ == PREPARING_SHOT) {
+        // pivot around ball...
+        auto ball_pt = world_state()->ball.position;
+
+        // ...to face their goal
+        rj_geometry::Point their_goal_pos = field_dimensions_.their_goal_loc();
+        planning::LinearMotionInstant target_instant{their_goal_pos};
+
+        auto pivot_cmd = planning::MotionCommand{"pivot"};
+        pivot_cmd.target = target_instant;
+        pivot_cmd.pivot_point = ball_pt;
+        intent.motion_command = pivot_cmd;
+        intent.dribbler_speed = 255.0;
+        return intent;
     } else if (current_state_ == SHOOTING) {
-        // TODO: Shoot the ball at the goal
         rj_geometry::Point their_goal_pos = field_dimensions_.their_goal_loc();
         planning::LinearMotionInstant target{their_goal_pos};
         auto line_kick_cmd = planning::MotionCommand{"line_kick", target};
@@ -140,9 +150,18 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
         return intent;
     } else if (current_state_ == STEALING) {
         // intercept the ball
-        auto collect_cmd = planning::MotionCommand{"collect"};
-        intent.motion_command = collect_cmd;
-        return intent;
+        // if ball fast, use settle, otherwise collect
+        if (world_state()->ball.velocity.mag() > 0.75) {
+            auto settle_cmd = planning::MotionCommand{"settle"};
+            intent.motion_command = settle_cmd;
+            intent.dribbler_speed = 255.0;
+            return intent;
+        } else {
+            auto collect_cmd = planning::MotionCommand{"collect"};
+            intent.motion_command = collect_cmd;
+            intent.dribbler_speed = 255.0;
+            return intent;
+        }
     } else if (current_state_ == FACING) {
         rj_geometry::Point robot_position =
             world_state()->get_robot(true, robot_id_).pose.position();

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -42,7 +42,7 @@ private:
         SHOOTING,   // physically kicking the ball towards the net
         RECEIVING,  // physically intercepting the ball from a pass (gets possession)
         STEALING,   // attempting to intercept the ball from the other team
-        FACING,
+        FACING,     // turning to face the ball
     };
 
     State update_state();

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -25,6 +25,9 @@ public:
     Offense(int r_id);
     ~Offense() override = default;
 
+    void receive_communication_response(communication::AgentPosResponseWrapper response) override;
+    communication::PosAgentResponseWrapper receive_communication_request(communication::AgentPosRequestWrapper request) override;
+
     void derived_acknowledge_pass() override;
     void derived_pass_ball() override;
     void derived_acknowledge_ball_in_transit() override;
@@ -51,6 +54,12 @@ private:
 
     // current state of the offensive agent (state machine)
     State current_state_ = IDLING;
+
+    bool scorer = false;
+
+    void send_scorer_request();
+    communication::ScorerResponse receive_scorer_request(communication::ScorerRequest scorer_request);
+    void handle_scorer_response(std::vector<communication::AgentResponseVariant> scorer_responses);
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -46,6 +46,7 @@ private:
         RECEIVING,  // physically intercepting the ball from a pass (gets possession)
         STEALING,   // attempting to intercept the ball from the other team
         FACING,     // turning to face the ball
+        SCORER,     // overrides everything and will attempt to steal the bal and shoot it
     };
 
     State update_state();
@@ -57,8 +58,27 @@ private:
 
     bool scorer = false;
 
+    /**
+     * @brief Send request to the other robots to see if this robot should be the scorer
+     * 
+     */
     void send_scorer_request();
+
+    /**
+     * @brief Finds this robot's distance to the ball and sends it back to the robot who asked if
+     * it should be the scorer
+     * 
+     * @param scorer_request request from the prospective scorer robot
+     * @return communication::ScorerResponse this robots response to the prospective scorer robot
+     */
     communication::ScorerResponse receive_scorer_request(communication::ScorerRequest scorer_request);
+
+    /**
+     * @brief This agent can go through the distance of every other offensive robot from the goal
+     * to decide whether this robot should become the scorer.
+     * 
+     * @param scorer_responses a vector of the distance to the ball for each other offense robot
+     */
     void handle_scorer_response(std::vector<communication::AgentResponseVariant> scorer_responses);
 };
 

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -26,7 +26,8 @@ public:
     ~Offense() override = default;
 
     void receive_communication_response(communication::AgentPosResponseWrapper response) override;
-    communication::PosAgentResponseWrapper receive_communication_request(communication::AgentPosRequestWrapper request) override;
+    communication::PosAgentResponseWrapper receive_communication_request(
+        communication::AgentPosRequestWrapper request) override;
 
     void derived_acknowledge_pass() override;
     void derived_pass_ball() override;
@@ -60,23 +61,24 @@ private:
 
     /**
      * @brief Send request to the other robots to see if this robot should be the scorer
-     * 
+     *
      */
     void send_scorer_request();
 
     /**
      * @brief Finds this robot's distance to the ball and sends it back to the robot who asked if
      * it should be the scorer
-     * 
+     *
      * @param scorer_request request from the prospective scorer robot
      * @return communication::ScorerResponse this robots response to the prospective scorer robot
      */
-    communication::ScorerResponse receive_scorer_request(communication::ScorerRequest scorer_request);
+    communication::ScorerResponse receive_scorer_request(
+        communication::ScorerRequest scorer_request);
 
     /**
      * @brief This agent can go through the distance of every other offensive robot from the goal
      * to decide whether this robot should become the scorer.
-     * 
+     *
      * @param scorer_responses a vector of the distance to the ball for each other offense robot
      */
     void handle_scorer_response(std::vector<communication::AgentResponseVariant> scorer_responses);

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -40,14 +40,15 @@ private:
     // TODO (Kevin): strategy design pattern for BallHandler/Receiver
 
     enum State {
-        IDLING,     // simply staying in place
-        SEARCHING,  // moving around on the field to get open
-        PASSING,    // physically kicking the ball towards another robot
-        SHOOTING,   // physically kicking the ball towards the net
-        RECEIVING,  // physically intercepting the ball from a pass (gets possession)
-        STEALING,   // attempting to intercept the ball from the other team
-        FACING,     // turning to face the ball
-        SCORER,     // overrides everything and will attempt to steal the bal and shoot it
+        IDLING,          // simply staying in place
+        SEARCHING,       // moving around on the field to get open
+        PASSING,         // physically kicking the ball towards another robot
+        PREPARING_SHOT,  // pivot around ball in preparation for shot
+        SHOOTING,        // physically kicking the ball towards the net
+        RECEIVING,       // physically intercepting the ball from a pass (gets possession)
+        STEALING,        // attempting to intercept the ball from the other team
+        FACING,          // turning to face the ball
+        SCORER,          // overrides everything and will attempt to steal the bal and shoot it
     };
 
     State update_state();

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -58,6 +58,7 @@ private:
     State current_state_ = IDLING;
 
     bool scorer_ = false;
+    bool last_scorer_ = false;
 
     /**
      * @brief Send request to the other robots to see if this robot should be the scorer
@@ -81,7 +82,26 @@ private:
      *
      * @param scorer_responses a vector of the distance to the ball for each other offense robot
      */
-    void handle_scorer_response(const std::vector<communication::AgentResponseVariant>& scorer_responses);
+    void handle_scorer_response(
+        const std::vector<communication::AgentResponseVariant>& scorer_responses);
+
+    /**
+     * @brief Send a request to the other offensive agents to let them know to reset who is the
+     * scorer.
+     *
+     */
+    void send_reset_scorer_request();
+
+    /**
+     * @brief When the scorer is being reset all offense robots should send a scorer requests
+     * and reset their last_scorer_ flag.
+     *
+     * @param reset_scorer_request the reset scorer request
+     * @return communication::Acknowledge acknowledgement that this robot will reset their scorer
+     * status
+     */
+    communication::Acknowledge receive_reset_scorer_request(
+        communication::ResetScorerRequest reset_scorer_request);
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -57,7 +57,7 @@ private:
     // current state of the offensive agent (state machine)
     State current_state_ = IDLING;
 
-    bool scorer = false;
+    bool scorer_ = false;
 
     /**
      * @brief Send request to the other robots to see if this robot should be the scorer
@@ -81,7 +81,7 @@ private:
      *
      * @param scorer_responses a vector of the distance to the ball for each other offense robot
      */
-    void handle_scorer_response(std::vector<communication::AgentResponseVariant> scorer_responses);
+    void handle_scorer_response(const std::vector<communication::AgentResponseVariant>& scorer_responses);
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -100,8 +100,7 @@ private:
      * @return communication::Acknowledge acknowledgement that this robot will reset their scorer
      * status
      */
-    communication::Acknowledge receive_reset_scorer_request(
-        communication::ResetScorerRequest reset_scorer_request);
+    communication::Acknowledge receive_reset_scorer_request();
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -139,30 +139,18 @@ void CoachNode::assign_positions() {
     std::array<uint32_t, kNumShells> positions{};
     positions[goalie_id_] = Positions::Goalie;
     if (!possessing_) {
-        // All robots set to defense
+        // except goalie, all robots set to defense
         for (int i = 0; i < kNumShells; i++) {
             if (i != goalie_id_) {
                 positions[i] = Positions::Defense;
             }
         }
-        // Lowest non-goalie robot set to offense
-        if (goalie_id_ == 0) {
-            positions[1] = Positions::Offense;
-        } else {
-            positions[0] = Positions::Offense;
-        }
     } else {
-        // All robots set to offense
+        // except goalie, all robots set to offense
         for (int i = 0; i < kNumShells; i++) {
             if (i != goalie_id_) {
                 positions[i] = Positions::Offense;
             }
-        }
-        // Lowest non-goalie robot set to defense
-        if (goalie_id_ == 0) {
-            positions[1] = Positions::Defense;
-        } else {
-            positions[0] = Positions::Defense;
         }
     }
 


### PR DESCRIPTION
## Description
This PR outlines the basics of a shoot only offense.  In this offense strategy, one robot (the closest to the ball that is playing offense) will attempt to obtain the ball and shoot the ball at the opponents goal.

EDIT: PR #2069 was merged into this branch. It adds a pivot step before any shot on goal to improve line kick consistency, but only does so at the Position level, which is not ideal (should be a planner, but planners are hard to compose).

## Associated / Resolved Issue
[coordinate shoot-only offense](https://app.clickup.com/t/8677u14px)

## Steps to Test
### Test Case 1
1. make perf && make run-sim
2. assign any number of robots to offense
3. click start (the robots will reassign is switched to offense and closer to the ball while sim is playing if you want to see that just start then assign robots to offense)

**Expected result:**The robot closest to the ball should get the ball and shoot it into the net.  Currently the robot keeps doing this on loop which may be undesired, but I would assume the coach will reassign him so I have the scorer on loop.

## Key Files to Review
Messages
 * rj_msgs/request/ScorerRequest.msg
 * rj_msgs/response/ScorerResponse.msg
 * soccer/src/soccer/strategy/agent/communication.*pp

Offense
 * soccer/src/soccer/strategy/agent/position/offense.*pp

## Review Checklist

- [X] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [X] **Remove extra print statements**: Any print statements used for debugging should be removed
- [X] **Tag reviewers**: Tag some people for review and ping them on Slack
