### PR TITLE
Improve kick consistency

### DIFF
--- a/soccer/src/soccer/planning/planner/collect_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/collect_path_planner.cpp
@@ -29,11 +29,6 @@ Trajectory CollectPathPlanner::plan(const PlanRequest& plan_request) {
     RobotConstraints robot_constraints = plan_request.constraints;
     MotionConstraints& motion_constraints = robot_constraints.mot;
 
-    // List of obstacles
-    ShapeSet obstacles;
-    std::vector<DynamicObstacle> dynamic_obstacles;
-    fill_obstacles(plan_request, &obstacles, &dynamic_obstacles, false);
-
     // The small beginning part of the previous path
     Trajectory partial_path;
 
@@ -104,22 +99,30 @@ Trajectory CollectPathPlanner::plan(const PlanRequest& plan_request) {
     // Check if we should transition to control from approach
     process_state_transition(ball, start_instant);
 
+    // List of obstacles
+    ShapeSet static_obstacles;
+    std::vector<DynamicObstacle> dynamic_obstacles;
+    fill_obstacles(plan_request, &static_obstacles, &dynamic_obstacles, false);
+
+    SPDLOG_WARN("current_state_ {}", current_state_);
     switch (current_state_) {
         // Moves from the current location to the slow point of approach
-        case CourseApproach:
-            previous_ = coarse_approach(plan_request, start_instant, obstacles, dynamic_obstacles);
+        case CoarseApproach:
+            previous_ =
+                coarse_approach(plan_request, start_instant, static_obstacles, dynamic_obstacles);
             break;
         // Moves from the slow point of approach to just before point of contact
         case FineApproach:
-            previous_ = fine_approach(plan_request, start_instant, obstacles, dynamic_obstacles);
+            previous_ =
+                fine_approach(plan_request, start_instant, static_obstacles, dynamic_obstacles);
             break;
         // Move through the ball and stop
         case Control:
-            previous_ = control(plan_request, partial_start_instant, partial_path, obstacles,
+            previous_ = control(plan_request, partial_start_instant, partial_path, static_obstacles,
                                 dynamic_obstacles);
             break;
         default:
-            previous_ = invalid(plan_request, obstacles, dynamic_obstacles);
+            previous_ = invalid(plan_request, static_obstacles, dynamic_obstacles);
             break;
     }
 
@@ -134,7 +137,7 @@ void CollectPathPlanner::check_solution_validity(BallState ball, RobotInstant st
     //
     // See if we are not near the ball and both almost stopped
     if (!near_ball && current_state_ == Control) {
-        current_state_ = CourseApproach;
+        current_state_ = CoarseApproach;
         approach_direction_created_ = false;
         control_path_created_ = false;
     }
@@ -148,8 +151,14 @@ void CollectPathPlanner::process_state_transition(BallState ball, RobotInstant s
 
     // If we are in range to the slow dist
     if (dist < collect::PARAM_approach_dist_target + kRobotMouthRadius &&
-        current_state_ == CourseApproach) {
+        current_state_ == CoarseApproach) {
         current_state_ = FineApproach;
+    }
+
+    // If the ball gets knocked far away, go back to CoarseApproach
+    if (dist > collect::PARAM_approach_dist_target + kRobotMouthRadius &&
+        current_state_ == FineApproach) {
+        current_state_ = CoarseApproach;
     }
 
     // If we are close enough to the target point near the ball
@@ -379,8 +388,7 @@ Trajectory CollectPathPlanner::control(const PlanRequest& plan_request, RobotIns
 Trajectory CollectPathPlanner::invalid(const PlanRequest& plan_request,
                                        const rj_geometry::ShapeSet& static_obstacles,
                                        const std::vector<DynamicObstacle>& dynamic_obstacles) {
-    SPDLOG_WARN("Invalid state in collect planner. Restarting");
-    current_state_ = CourseApproach;
+    current_state_ = CoarseApproach;
 
     // Stop movement until next frame since it's the safest option
     // programmatically
@@ -398,7 +406,7 @@ Trajectory CollectPathPlanner::invalid(const PlanRequest& plan_request,
 
 void CollectPathPlanner::reset() {
     previous_ = Trajectory();
-    current_state_ = CollectPathPathPlannerStates::CourseApproach;
+    current_state_ = CollectPathPathPlannerStates::CoarseApproach;
     average_ball_vel_initialized_ = false;
     approach_direction_created_ = false;
     control_path_created_ = false;
@@ -406,7 +414,7 @@ void CollectPathPlanner::reset() {
 }
 
 bool CollectPathPlanner::is_done() const {
-    // FSM: CourseApproach -> FineApproach -> Control
+    // FSM: CoarseApproach -> FineApproach -> Control
     // (see process_state_transition())
     if (current_state_ != Control) {
         return false;

--- a/soccer/src/soccer/planning/planner/collect_path_planner.hpp
+++ b/soccer/src/soccer/planning/planner/collect_path_planner.hpp
@@ -19,7 +19,7 @@ public:
     enum CollectPathPathPlannerStates {
         // From start of subbehavior to the start of the slow part of the
         // approach
-        CourseApproach,
+        CoarseApproach,
         // From the slow part of the approach to the touching of the ball
         FineApproach,
         // From touching the ball to stopped with the ball in the mouth
@@ -62,7 +62,7 @@ private:
 
     Trajectory previous_;
 
-    CollectPathPathPlannerStates current_state_ = CollectPathPathPlannerStates::CourseApproach;
+    CollectPathPathPlannerStates current_state_ = CollectPathPathPlannerStates::CoarseApproach;
 
     // Ball Velocity Filtering Variables
     rj_geometry::Point average_ball_vel_;

--- a/soccer/src/soccer/planning/planner/line_kick_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/line_kick_path_planner.cpp
@@ -14,7 +14,7 @@ namespace planning {
 
 Trajectory LineKickPathPlanner::plan(const PlanRequest& plan_request) {
     // TODO(?): ros param these
-    const float approach_speed = 0.25;
+    const float approach_speed = 0.05;
 
     const float ball_avoid_distance = 0.10;
 

--- a/soccer/src/soccer/planning/planner/pivot_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/pivot_path_planner.cpp
@@ -63,7 +63,8 @@ Trajectory PivotPathPlanner::plan(const PlanRequest& request) {
     new_constraints.max_speed =
         std::min(new_constraints.max_speed, rotation_constraints.max_speed * radius) * .5;
 
-    double start_angle = pivot_point.angle_to(start_instant.position());
+    double start_angle = pivot_point.angle_to(
+        request.world_state->get_robot(true, request.shell_id).pose.position());
     double target_angle = pivot_point.angle_to(final_position);
     double angle_change = fix_angle_radians(target_angle - start_angle);
 

--- a/soccer/src/soccer/planning/planner/pivot_path_planner.hpp
+++ b/soccer/src/soccer/planning/planner/pivot_path_planner.hpp
@@ -46,6 +46,6 @@ private:
     std::optional<double> cached_angle_change_;
 
     // TODO(Kevin): ros param this
-    double IS_DONE_ANGLE_CHANGE_THRESH = 2.0;
+    double IS_DONE_ANGLE_CHANGE_THRESH = 1.0;
 };
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/pivot_path_planner.hpp
+++ b/soccer/src/soccer/planning/planner/pivot_path_planner.hpp
@@ -13,8 +13,8 @@ namespace planning {
  * the ball to <command.target.position>.
  *
  * Params taken from MotionCommand:
- *   target.pivot_point - planner will pivot about this point
- *   target.position - planner will stop on this point when done pivoting
+ *   target.pivot_point - robot will pivot about this point
+ *   target.position - robot will face this point when done
  */
 class PivotPathPlanner : public PathPlanner {
 public:
@@ -46,7 +46,6 @@ private:
     std::optional<double> cached_angle_change_;
 
     // TODO(Kevin): ros param this
-    // in gameplay it is 0.05, this is just to see the change
-    double IS_DONE_ANGLE_CHANGE_THRESH = 0.1;
+    double IS_DONE_ANGLE_CHANGE_THRESH = 2.0;
 };
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -42,20 +42,27 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
     // Add our robots, either static or dynamic depending on whether they have
     // already been planned. In both cases, radius is based on velocity like
     // above for opp robots.
+    // TODO: reenable dynamic obstacles for our robots (currently
+    // TrajectoryCollection is never filled at planner level)
     for (size_t shell = 0; shell < kNumShells; shell++) {
-        const auto& robot = in.world_state->our_robots.at(shell);
-        if (!robot.visible || shell == in.shell_id) {
+        const auto& our_robot = in.world_state->our_robots.at(shell);
+        if (!our_robot.visible || shell == in.shell_id) {
             continue;
         }
 
-        const Trajectory* ptr_to_traj = std::get<0>(in.planned_trajectories->get(shell)).get();
-        if (out_dynamic != nullptr && ptr_to_traj != nullptr) {
-            // Dynamic obstacle
-            out_dynamic->emplace_back(obs_radius, ptr_to_traj);
-        } else {
-            // Static obstacle
-            out_static->add(std::make_shared<rj_geometry::Circle>(obs_center, obs_radius));
-        }
+        /* const Trajectory* ptr_to_traj = std::get<0>(in.planned_trajectories->get(shell)).get();
+         */
+        /* if (out_dynamic != nullptr && ptr_to_traj != nullptr) { */
+        /*     // Dynamic obstacle */
+        /*     out_dynamic->emplace_back(obs_radius, ptr_to_traj); */
+        /* } else { */
+        /*     // Static obstacle */
+        /*     out_static->add(std::make_shared<rj_geometry::Circle>(obs_center, obs_radius)); */
+        /* } */
+
+        // Static obstacle
+        fill_robot_obstacle(our_robot, obs_center, obs_radius);
+        out_static->add(std::make_shared<rj_geometry::Circle>(obs_center, obs_radius));
     }
 
     // Finally, add the ball as a dynamic obstacle.

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -40,14 +40,15 @@ private:
     // TODO (Kevin): strategy design pattern for BallHandler/Receiver
 
     enum State {
-        IDLING,     // simply staying in place
-        SEARCHING,  // moving around on the field to get open
-        PASSING,    // physically kicking the ball towards another robot
-        SHOOTING,   // physically kicking the ball towards the net
-        RECEIVING,  // physically intercepting the ball from a pass (gets possession)
-        STEALING,   // attempting to intercept the ball from the other team
-        FACING,     // turning to face the ball
-        SCORER,     // overrides everything and will attempt to steal the bal and shoot it
+        IDLING,          // simply staying in place
+        SEARCHING,       // moving around on the field to get open
+        PASSING,         // physically kicking the ball towards another robot
+        PREPARING_SHOT,  // pivot around ball in preparation for shot
+        SHOOTING,        // physically kicking the ball towards the net
+        RECEIVING,       // physically intercepting the ball from a pass (gets possession)
+        STEALING,        // attempting to intercept the ball from the other team
+        FACING,          // turning to face the ball
+        SCORER,          // overrides everything and will attempt to steal the bal and shoot it
     };
 
     State update_state();

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -139,30 +139,18 @@ void CoachNode::assign_positions() {
     std::array<uint32_t, kNumShells> positions{};
     positions[goalie_id_] = Positions::Goalie;
     if (!possessing_) {
-        // All robots set to defense
+        // except goalie, all robots set to defense
         for (int i = 0; i < kNumShells; i++) {
             if (i != goalie_id_) {
                 positions[i] = Positions::Defense;
             }
         }
-        // Lowest non-goalie robot set to offense
-        if (goalie_id_ == 0) {
-            positions[1] = Positions::Offense;
-        } else {
-            positions[0] = Positions::Offense;
-        }
     } else {
-        // All robots set to offense
+        // except goalie, all robots set to offense
         for (int i = 0; i < kNumShells; i++) {
             if (i != goalie_id_) {
                 positions[i] = Positions::Offense;
             }
-        }
-        // Lowest non-goalie robot set to defense
-        if (goalie_id_ == 0) {
-            positions[1] = Positions::Defense;
-        } else {
-            positions[0] = Positions::Defense;
         }
     }
 


### PR DESCRIPTION
## Description
Improved shooting consistency by adding pivot to the Offense FSM.

Ideally this would be a part of the kick planner itself, but our planner stack sucks. It is not easy to compose planners (I tried in #2068 ) and even when you are able to, often one of the composed planners will fail to plan. This is mitigated at the Position level thanks to the safeguards on PlannerNode put in place by #2020 .

## Steps to Test
### Test Case 1
1. Run sim
2. Set as many robots as you'd like to Offense
3. Run

**Expected result:** the closest Offense shoots, per #2063 . this kick is smoother than the kicks in #2063 

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack

