### PR TITLE
Remove coach node global overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ coverage.xml
 
 # Debugging launch files
 launch/debug-*
+
+# clangd
+.clangd/
+compile_commands.json

--- a/launch/soccer.launch.py
+++ b/launch/soccer.launch.py
@@ -189,14 +189,15 @@ def generate_launch_description():
                 parameters=[param_config_filepath],
                 on_exit=Shutdown(),
             ),
-            Node(
-                condition=IfCondition(PythonExpression(["not ", use_manual_control])),
-                package="rj_robocup",
-                executable="coach_node",
-                output="screen",
-                parameters=[param_config_filepath],
-                on_exit=Shutdown(),
-            ),
+
+            #Node(
+                #condition=IfCondition(PythonExpression(["not ", use_manual_control])),
+                #package="rj_robocup",
+                #executable="coach_node",
+                #output="screen",
+                #parameters=[param_config_filepath],
+                #on_exit=Shutdown(),
+            #),
             # spawn internal_ref/external_ref based on internal_ref LaunchArgument
             Node(
                 condition=IfCondition(PythonExpression([use_internal_ref])),

--- a/launch/soccer.launch.py
+++ b/launch/soccer.launch.py
@@ -189,15 +189,14 @@ def generate_launch_description():
                 parameters=[param_config_filepath],
                 on_exit=Shutdown(),
             ),
-
-            #Node(
-                #condition=IfCondition(PythonExpression(["not ", use_manual_control])),
-                #package="rj_robocup",
-                #executable="coach_node",
-                #output="screen",
-                #parameters=[param_config_filepath],
-                #on_exit=Shutdown(),
-            #),
+            # Node(
+            # condition=IfCondition(PythonExpression(["not ", use_manual_control])),
+            # package="rj_robocup",
+            # executable="coach_node",
+            # output="screen",
+            # parameters=[param_config_filepath],
+            # on_exit=Shutdown(),
+            # ),
             # spawn internal_ref/external_ref based on internal_ref LaunchArgument
             Node(
                 condition=IfCondition(PythonExpression([use_internal_ref])),

--- a/rj_common/include/rj_common/network.hpp
+++ b/rj_common/include/rj_common/network.hpp
@@ -59,7 +59,7 @@ static const std::string kSharedVisionSourceAddress = "224.5.23.2";
  * one (or try them all in worst-case).
  */
 
-static const std::string kRefereeInterface = "192.168.20.119";
+static const std::string kRefereeInterface = "127.0.0.1";
 /* static const std::string kRefereeInterface = "172.0.0.1"; */
 static const std::string kVisionInterface =
     kRefereeInterface;  // In all but rare cirucmstances, this should match kRefereeInterface.

--- a/rj_gameplay/stp/pylint_stp.py
+++ b/rj_gameplay/stp/pylint_stp.py
@@ -1,5 +1,6 @@
 """ This file contains custom checkers for pylint.
 """
+
 from typing import List
 
 import astroid.node_classes

--- a/rj_msgs/CMakeLists.txt
+++ b/rj_msgs/CMakeLists.txt
@@ -34,7 +34,6 @@ rosidl_generate_interfaces(
   msg/FieldDimensions.msg
   msg/FieldOrientation.msg
   msg/GameSettings.msg
-  msg/GlobalOverride.msg
   msg/Goalie.msg
   msg/ManipulatorSetpoint.msg
   msg/MatchState.msg

--- a/rj_msgs/msg/CoachState.msg
+++ b/rj_msgs/msg/CoachState.msg
@@ -1,4 +1,3 @@
 # state and restart are an enum defined in soccer/src/soccer/.hpp
 PlayState play_state
 bool our_possession
-GlobalOverride global_override

--- a/rj_msgs/msg/GlobalOverride.msg
+++ b/rj_msgs/msg/GlobalOverride.msg
@@ -1,6 +1,0 @@
-# In halt: max speed = 0m/s; min_dist_from_ball = 0m
-# In stop: max_speed = 1.5m/s; min_distance_from_ball = 0.5m
-# In starts: max_speed = -1m/s; min_distance_from_ball = 0m
-float32 max_speed
-float32 min_dist_from_ball
-int32 max_dribbler_speed

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -249,7 +249,7 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     double max_robot_speed = 10.0;
     int max_dribbler_speed = 255;
 
-    switch(play_state.state()) {
+    switch (play_state.state()) {
         case PlayState::State::Halt:
             min_dist_from_ball = 0.0;
             max_robot_speed = 0.0;

--- a/soccer/src/soccer/planning/planner_node.cpp
+++ b/soccer/src/soccer/planning/planner_node.cpp
@@ -244,9 +244,39 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     const auto* world_state = global_state_.world_state();
     const auto goalie_id = global_state_.goalie_id();
     const auto play_state = global_state_.play_state();
-    const auto min_dist_from_ball = global_state_.coach_state().global_override.min_dist_from_ball;
-    const auto max_robot_speed = global_state_.coach_state().global_override.max_speed;
-    const auto max_dribbler_speed = global_state_.coach_state().global_override.max_dribbler_speed;
+
+    float min_dist_from_ball = 0.0;
+    double max_robot_speed = 10.0;
+    int max_dribbler_speed = 255;
+
+    switch(play_state.state()) {
+        case PlayState::State::Halt:
+            min_dist_from_ball = 0.0;
+            max_robot_speed = 0.0;
+            max_dribbler_speed = 0;
+            break;
+        case PlayState::State::Stop:
+            min_dist_from_ball = 0.5;
+            max_robot_speed = 1.5;
+            max_dribbler_speed = 0;
+            break;
+        case PlayState::State::Playing:
+        default:
+            // Unbounded speed. Setting to -1 or 0 crashes planner, so use large number
+            // instead.
+            min_dist_from_ball = 0.0;
+            max_robot_speed = 10.0;
+            max_dribbler_speed = 255;
+            break;
+    }
+
+    // Removed need to access coach_node for global overrides
+    /*
+        min_dist_from_ball = global_state_.coach_state().global_override.min_dist_from_ball;
+        max_robot_speed = global_state_.coach_state().global_override.max_speed;
+        max_dribbler_speed = global_state_.coach_state().global_override.max_dribbler_speed;
+    */
+
     const auto& robot = world_state->our_robots.at(robot_id_);
     const auto start = RobotInstant{robot.pose, robot.velocity, robot.timestamp};
 

--- a/soccer/src/soccer/strategy/agent/position/position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/position.cpp
@@ -51,7 +51,6 @@ void Position::update_world_state(WorldState world_state) {
 void Position::update_coach_state(rj_msgs::msg::CoachState msg) {
     our_possession_ = msg.our_possession;
     // TODO: how is planner supposed to get this global override info?
-    global_override_ = msg.global_override;
     /* SPDLOG_INFO("match_restart {}, match_state {}, our_possession {}", match_restart_,
      * match_state_, our_possession_); */
 }

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -11,7 +11,6 @@
 #include <rj_geometry/point.hpp>
 #include <rj_msgs/msg/alive_robots.hpp>
 #include <rj_msgs/msg/coach_state.hpp>
-#include <rj_msgs/msg/global_override.hpp>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
@@ -219,7 +218,6 @@ protected:
     // TODO: this is not thread-safe, does it need to be?
     // (if so match world_state below)
     bool our_possession_{};
-    rj_msgs::msg::GlobalOverride global_override_{};
 
     FieldDimensions field_dimensions_ = FieldDimensions::kDefaultDimensions;
 

--- a/soccer/src/soccer/strategy/coach/coach_node.cpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.cpp
@@ -118,31 +118,6 @@ void CoachNode::check_for_play_state_change() {
     if (play_state_has_changed_) {
         rj_msgs::msg::CoachState coach_message;
         coach_message.play_state = current_play_state_;
-        rj_msgs::msg::GlobalOverride global_override;
-
-        switch (current_play_state_.state) {
-            case PlayState::State::Halt:
-                global_override.max_speed = 0;
-                global_override.min_dist_from_ball = 0;
-                global_override.max_dribbler_speed = 0;
-                break;
-            case PlayState::State::Stop:
-                global_override.max_speed = 1.5;
-                global_override.min_dist_from_ball = 0.5;
-                global_override.max_dribbler_speed = 0;
-                break;
-            case PlayState::State::Playing:
-            default:
-                // Unbounded speed. Setting to -1 or 0 crashes planner, so use large number
-                // instead.
-                global_override.max_speed = 10.0;
-                global_override.min_dist_from_ball = 0;
-                global_override.max_dribbler_speed = 255;
-                break;
-        }
-
-        // publish new necessary information
-        coach_message.global_override = global_override;
 
         coach_message.our_possession = possessing_;
 

--- a/soccer/src/soccer/strategy/coach/coach_node.hpp
+++ b/soccer/src/soccer/strategy/coach/coach_node.hpp
@@ -10,7 +10,6 @@
 #include <rj_msgs/msg/alive_robots.hpp>
 #include <rj_msgs/msg/coach_state.hpp>
 #include <rj_msgs/msg/game_settings.hpp>
-#include <rj_msgs/msg/global_override.hpp>
 #include <rj_msgs/msg/goalie.hpp>
 #include <rj_msgs/msg/play_state.hpp>
 #include <rj_msgs/msg/position_assignment.hpp>


### PR DESCRIPTION
## Description
Removes global overrides from coach node and moves them to planner

## Associated / Resolved Issue
Resolves # https://app.clickup.com/t/86ayb2mu2

## Steps to Test
Seems to work, but in ros2 playstates like stop are not being respected

## Review Checklist

- [ ] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [ ] **Remove extra print statements**: Any print statements used for debugging should be removed
- [ ] **Tag reviewers**: Tag some people for review and ping them on Slack

## (Optional) Sub-issues (for drafts)
_Note: if you find yourself breaking this PR into many smaller features, it may make sense to break up the PR into logical units based on these features._
- [ ] Step 1
- [ ] Step 2
