### PR TITLE
added clangd files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ coverage.xml
 
 # Debugging launch files
 launch/debug-*
+
+# clangd
+.clangd/
+compile_commands.json

--- a/rj_gameplay/stp/pylint_stp.py
+++ b/rj_gameplay/stp/pylint_stp.py
@@ -1,5 +1,6 @@
 """ This file contains custom checkers for pylint.
 """
+
 from typing import List
 
 import astroid.node_classes


### PR DESCRIPTION
## Description
For lsp support in my editor, I'm using clangd which adds a large amount of files to the repository. I would like to hide these files by adding them to the .gitignore file.