### PR TITLE
Making ball a static obstacle

### DIFF
--- a/rj_geometry/include/rj_geometry/circle.hpp
+++ b/rj_geometry/include/rj_geometry/circle.hpp
@@ -23,11 +23,11 @@ public:
         rsq_ = r_ * r_;
     }
 
-    Circle(const Circle& other) {
-        center = other.center;
-        r_ = other.radius();
-        rsq_ = r_ * r_;
-    }
+    ~Circle() = default;
+    Circle(const Circle& other) = default;
+    Circle(Circle&& other) = default;
+    Circle& operator=(const Circle& other) = default;
+    Circle& operator=(Circle&& other) = default;
 
     Shape* clone() const override;
 

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -68,7 +68,8 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
     // Finally, add the ball as a dynamic obstacle.
     // (This is for when the other team is trying to do ball placement, so we
     // don't interfere with them.)
-    out_static->add(std::make_shared<rj_geometry::Circle>(in.world_state->ball.position, kBallRadius + in.min_dist_from_ball));
+    out_static->add(std::make_shared<rj_geometry::Circle>(in.world_state->ball.position,
+                                                          kBallRadius + in.min_dist_from_ball));
     if (avoid_ball && out_dynamic != nullptr && out_ball_trajectory != nullptr) {
         // Where should we store the ball trajectory?
         *out_ball_trajectory = in.world_state->ball.make_trajectory();

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -67,8 +67,7 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
 
     // Adding ball as a static obstacle (because dynamic obstacles are not working)
     // Only added when STOP state is enabled
-    double ball_vel_scaled = in.world_state->ball.velocity.mag() * .1;
-    double radius = kBallRadius + in.min_dist_from_ball * (1.0 + ball_vel_scaled);
+    double radius = kBallRadius * (1.0 + ball.velocity.mag()) + in.min_dist_from_ball;
     if (in.min_dist_from_ball > 0) {
         out_static->add(
             std::make_shared<rj_geometry::Circle>(in.world_state->ball.position, radius));

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -65,6 +65,10 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
         out_static->add(std::make_shared<rj_geometry::Circle>(obs_center, obs_radius));
     }
 
+    //Adding ball as a static obstacle (because dynamic obstacles are not working)
+    double ball_vel = in.world_state->ball.velocity.linear().mag();
+    out_static->add(std::make_shared<rj_geometry::Circle>(in.world_state->ball.position, kBallRadius * (1.0 + ball_vel) + in.min_dist_from_ball));
+
     // Finally, add the ball as a dynamic obstacle.
     // (This is for when the other team is trying to do ball placement, so we
     // don't interfere with them.)

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -65,9 +65,10 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
         out_static->add(std::make_shared<rj_geometry::Circle>(obs_center, obs_radius));
     }
 
-    //Adding ball as a static obstacle (because dynamic obstacles are not working)
-    double ball_vel = in.world_state->ball.velocity.linear().mag();
-    out_static->add(std::make_shared<rj_geometry::Circle>(in.world_state->ball.position, kBallRadius * (1.0 + ball_vel) + in.min_dist_from_ball));
+    // Adding ball as a static obstacle (because dynamic obstacles are not working)
+    double ball_vel = in.world_state->ball.velocity.mag();
+    out_static->add(std::make_shared<rj_geometry::Circle>(
+        in.world_state->ball.position, kBallRadius * (1.0 + ball_vel) + in.min_dist_from_ball));
 
     // Finally, add the ball as a dynamic obstacle.
     // (This is for when the other team is trying to do ball placement, so we
@@ -75,7 +76,7 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
     if (avoid_ball && out_dynamic != nullptr && out_ball_trajectory != nullptr) {
         // Where should we store the ball trajectory?
         *out_ball_trajectory = in.world_state->ball.make_trajectory();
-        double radius = kBallRadius + in.min_dist_from_ball;
+        double radius = kBallRadius * (1.0 + ball_vel) + in.min_dist_from_ball;
 
         out_dynamic->emplace_back(radius, out_ball_trajectory);
 

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -66,11 +66,12 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
     }
 
     // Adding ball as a static obstacle (because dynamic obstacles are not working)
+    // Only added when STOP state is enabled
     double ball_vel_scaled = in.world_state->ball.velocity.mag() * .1;
     double radius = kBallRadius + in.min_dist_from_ball * (1.0 + ball_vel_scaled);
     if (in.min_dist_from_ball > 0) {
-        out_static->add(std::make_shared<rj_geometry::Circle>(
-            in.world_state->ball.position, radius));
+        out_static->add(
+            std::make_shared<rj_geometry::Circle>(in.world_state->ball.position, radius));
     }
 
     // Finally, add the ball as a dynamic obstacle.

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -66,9 +66,12 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
     }
 
     // Adding ball as a static obstacle (because dynamic obstacles are not working)
-    double ball_vel = in.world_state->ball.velocity.mag();
-    out_static->add(std::make_shared<rj_geometry::Circle>(
-        in.world_state->ball.position, kBallRadius * (1.0 + ball_vel) + in.min_dist_from_ball));
+    double ball_vel_scaled = in.world_state->ball.velocity.mag() * .1;
+    double radius = kBallRadius + in.min_dist_from_ball * (1.0 + ball_vel_scaled);
+    if (in.min_dist_from_ball > 0) {
+        out_static->add(std::make_shared<rj_geometry::Circle>(
+            in.world_state->ball.position, radius));
+    }
 
     // Finally, add the ball as a dynamic obstacle.
     // (This is for when the other team is trying to do ball placement, so we
@@ -76,8 +79,6 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
     if (avoid_ball && out_dynamic != nullptr && out_ball_trajectory != nullptr) {
         // Where should we store the ball trajectory?
         *out_ball_trajectory = in.world_state->ball.make_trajectory();
-        double radius = kBallRadius * (1.0 + ball_vel) + in.min_dist_from_ball;
-
         out_dynamic->emplace_back(radius, out_ball_trajectory);
 
         if (in.debug_drawer != nullptr) {

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -68,6 +68,7 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
     // Finally, add the ball as a dynamic obstacle.
     // (This is for when the other team is trying to do ball placement, so we
     // don't interfere with them.)
+    out_static->add(std::make_shared<rj_geometry::Circle>(in.world_state->ball.position, kBallRadius + in.min_dist_from_ball));
     if (avoid_ball && out_dynamic != nullptr && out_ball_trajectory != nullptr) {
         // Where should we store the ball trajectory?
         *out_ball_trajectory = in.world_state->ball.make_trajectory();

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -2,19 +2,19 @@
 
 namespace planning {
 
-rj_geometry::Circle make_inflated_static_obs(rj_geometry::Point position, rj_geometry::Point velocity, double radius)
- {
+rj_geometry::Circle make_inflated_static_obs(rj_geometry::Point position,
+                                             rj_geometry::Point velocity, double radius) {
     // params for obstacle shift
-    constexpr double obs_center_shift {0.5};
-    constexpr double obs_radius_inflation {1.0};
+    constexpr double obs_center_shift{0.5};
+    constexpr double obs_radius_inflation{1.0};
 
-    rj_geometry::Point obs_center {position + (velocity * radius * obs_center_shift)};
+    rj_geometry::Point obs_center{position + (velocity * radius * obs_center_shift)};
 
-    double safety_margin {velocity.mag() * obs_radius_inflation};
-    double obs_radius {radius + (safety_margin * radius)};
+    double safety_margin{velocity.mag() * obs_radius_inflation};
+    double obs_radius{radius + (safety_margin * radius)};
 
     return rj_geometry::Circle{obs_center, static_cast<float>(obs_radius)};
- }
+}
 
 rj_geometry::Circle make_robot_obstacle(const RobotState& robot) {
     return make_inflated_static_obs(robot.pose.position(), robot.velocity.linear(), kRobotRadius);
@@ -33,7 +33,8 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
         const RobotState& their_robot = in.world_state->their_robots.at(shell);
 
         if (their_robot.visible) {
-            out_static->add(std::make_shared<rj_geometry::Circle>(make_robot_obstacle(their_robot)));
+            out_static->add(
+                std::make_shared<rj_geometry::Circle>(make_robot_obstacle(their_robot)));
         }
     }
 
@@ -65,7 +66,8 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
     // Adding ball as a static obstacle (because dynamic obstacles are not working)
     // Only added when STOP state is enabled
     if (in.min_dist_from_ball > 0 || avoid_ball) {
-        auto ball_obs = make_inflated_static_obs(in.world_state->ball.position, in.world_state->ball.velocity, kBallRadius);
+        auto ball_obs = make_inflated_static_obs(in.world_state->ball.position,
+                                                 in.world_state->ball.velocity, kBallRadius);
         ball_obs.radius(ball_obs.radius() + in.min_dist_from_ball);
 
         // Draw ball obstacle in simulator

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -67,10 +67,18 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
 
     // Adding ball as a static obstacle (because dynamic obstacles are not working)
     // Only added when STOP state is enabled
-    double radius = kBallRadius * (1.0 + ball.velocity.mag()) + in.min_dist_from_ball;
     if (in.min_dist_from_ball > 0) {
+        double radius = kBallRadius + (1.0 + in.world_state->ball.velocity.mag()) + in.min_dist_from_ball;
         out_static->add(
             std::make_shared<rj_geometry::Circle>(in.world_state->ball.position, radius));
+
+        // Draw ball obstacle in simulator
+        if (in.debug_drawer != nullptr) {
+            QColor draw_color = Qt::red;
+            in.debug_drawer->draw_circle(
+                rj_geometry::Circle(in.world_state->ball.position, static_cast<float>(radius)),
+                draw_color);
+        }
     }
 
     // Finally, add the ball as a dynamic obstacle.
@@ -80,13 +88,6 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
         // Where should we store the ball trajectory?
         *out_ball_trajectory = in.world_state->ball.make_trajectory();
         out_dynamic->emplace_back(radius, out_ball_trajectory);
-
-        if (in.debug_drawer != nullptr) {
-            QColor draw_color = Qt::red;
-            in.debug_drawer->draw_circle(
-                rj_geometry::Circle(in.world_state->ball.position, static_cast<float>(radius)),
-                draw_color);
-        }
     }
 }
 

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -67,8 +67,9 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
 
     // Adding ball as a static obstacle (because dynamic obstacles are not working)
     // Only added when STOP state is enabled
+    double radius =
+        kBallRadius * (1.0 + in.world_state->ball.velocity.mag()) + in.min_dist_from_ball;
     if (in.min_dist_from_ball > 0) {
-        double radius = kBallRadius + (1.0 + in.world_state->ball.velocity.mag()) + in.min_dist_from_ball;
         out_static->add(
             std::make_shared<rj_geometry::Circle>(in.world_state->ball.position, radius));
 

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -72,8 +72,6 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
     // Finally, add the ball as a dynamic obstacle.
     // (This is for when the other team is trying to do ball placement, so we
     // don't interfere with them.)
-    out_static->add(std::make_shared<rj_geometry::Circle>(in.world_state->ball.position,
-                                                          kBallRadius + in.min_dist_from_ball));
     if (avoid_ball && out_dynamic != nullptr && out_ball_trajectory != nullptr) {
         // Where should we store the ball trajectory?
         *out_ball_trajectory = in.world_state->ball.make_trajectory();


### PR DESCRIPTION
## Description
The STOP play state is currently not working because the robots are still able to go within the zone of the ball. We resolved this issue by making the ball a static obstacle instead of a dynamic obstacle.

## Associated / Resolved Issue
Resolves [ClickUp card](https://app.clickup.com/t/86ayj3tzd)

## Steps to Test
Run the simulator in the STOP state. The robots should not be in the zone of the ball.

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack
