### PR TITLE
Fixed on_actionResetField_triggered() method

### DIFF
--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -828,17 +828,23 @@ void MainWindow::on_actionStopBall_triggered() {
 }
 
 void MainWindow::on_actionResetField_triggered() {
-    const int NUM_COLS = 2;
-    const int ROBOTS_PER_COL = kRobotsPerTeam / NUM_COLS;
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(2, -1, 0), 0, false);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(2, -1, 0), 0, true);
 
-    for (size_t i = 0; i < kRobotsPerTeam; ++i) {
-        double x_pos = +2.5 - i / ROBOTS_PER_COL;
-        double y_pos = i % ROBOTS_PER_COL - ROBOTS_PER_COL / NUM_COLS;
-        auto pose = rj_geometry::Pose(x_pos, y_pos, 0);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(2, 0, 0), 1, false);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(2, 0, 0), 1, true);
 
-        _ui.fieldView->set_robot_pose(pose, i, false);
-        _ui.fieldView->set_robot_pose(pose, i, true);
-    }
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(2, 1, 0), 2, false);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(2, 1, 0), 2, true);
+
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(3, -1, 0), 3, false);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(3, -1, 0), 3, true);
+
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(3, 0, 0), 4, false);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(3, 0, 0), 4, true);
+
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(3, 1, 0), 5, false);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(3, 1, 0), 5, true);
 
     _ui.fieldView->set_ball_position(rj_geometry::Point(0.0, 0.0));
     _ui.fieldView->set_ball_velocity(rj_geometry::Point(0.0, 0.0));


### PR DESCRIPTION
## Description
Describe your pull request.
Added hard-coded positions to the method in main_window.cpp that resets the field. Previous algorithm set invalid y-coordinate which prevents robots 0 and 3 from showing up on the field

## Associated / Resolved Issue
Resolves # or [ClickUp card](link-to-clickup-card)
#86ayqjnmt - robot 0 and 3: learn how to configure ER-force sim

## Design Documents
[Link](link-to-design-doc)

## Steps to Test
### Test Case 1: Startup of simulator
1. Step 1 Run the simulator
2. Step 2 Observe the robots' positions

### Test Case 2: Resetting from Play, Stop, and Halt
1. Step 1 Hit Play
2. Step 2 Reset Field
3. Step 3 Hit Play, then Stop
4. Step 4 Reset Field
5. Step 5 Hit Play then Halt
6. Step 6 Reset field

**Expected result:**???
In most circumstances, the robots should form a rectangle 3-wide and 2-tall in the upper center of the field, and the ball should be in the center of the field.

## Key Files to Review
Group 1
 * File 1 main_window.cpp
 * File 2

Group 2
 * File 3
 * File 4

## Review Checklist

- [ ] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [ ] **Remove extra print statements**: Any print statements used for debugging should be removed
- [ ] **Tag reviewers**: Tag some people for review and ping them on Slack

## (Optional) Sub-issues (for drafts)
_Note: if you find yourself breaking this PR into many smaller features, it may make sense to break up the PR into logical units based on these features._
- [ ] Step 1
- [ ] Step 2
