### PR TITLE
Add dynamic state management

### DIFF
--- a/rj_constants/include/rj_constants/constants.hpp
+++ b/rj_constants/include/rj_constants/constants.hpp
@@ -30,5 +30,8 @@ constexpr float kDotsSmallOffset = 0.035;
 constexpr float kDotsLargeOffset = 0.054772;
 constexpr float kDotsRadius = 0.02;
 
+/** constants for planning */
+constexpr double kAvoidBallDistance = 0.01;
+
 const std::string kTeamNameLower = "robojackets";
 const std::string kTeamName = "RoboJackets";

--- a/soccer/src/soccer/planning/planner/line_kick_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/line_kick_path_planner.cpp
@@ -1,4 +1,4 @@
-#include "line_kick_path_planner.hpp"
+#include "planning/planner/line_kick_path_planner.hpp"
 
 #include <rj_geometry/util.hpp>
 
@@ -13,30 +13,13 @@ using namespace rj_geometry;
 namespace planning {
 
 Trajectory LineKickPathPlanner::plan(const PlanRequest& plan_request) {
-    // TODO(?): ros param these
-    const float approach_speed = 0.05;
-
-    const float ball_avoid_distance = 0.10;
-
-    const MotionCommand& command = plan_request.motion_command;
-
-    if (plan_request.virtual_obstacles.hit(plan_request.start.position())) {
-        prev_path_ = Trajectory{};
-        return prev_path_;
+    if (plan_request.play_state == PlayState::halt() ||
+        plan_request.play_state == PlayState::stop()) {
+        return Trajectory{};
     }
 
-    if (target_kick_pos_.has_value() &&
-        command.target.position.dist_to(target_kick_pos_.value()) > 0.1) {
-        prev_path_ = Trajectory{};
-        target_kick_pos_ = std::nullopt;
-    }
+    const BallState& ball = plan_request.world_state->ball;
 
-    const RobotInstant& start_instant = plan_request.start;
-    const auto& motion_constraints = plan_request.constraints.mot;
-    const auto& rotation_constraints = plan_request.constraints.rot;
-    const auto& ball = plan_request.world_state->ball;
-
-    // track ball velocity to know if done or not
     if (!average_ball_vel_initialized_) {
         average_ball_vel_ = ball.velocity;
         average_ball_vel_initialized_ = true;
@@ -50,230 +33,84 @@ Trajectory LineKickPathPlanner::plan(const PlanRequest& plan_request) {
         average_ball_vel_ = apply_low_pass_filter(average_ball_vel_, ball.velocity, 0.8);
     }
 
-    if (prev_path_.empty()) {
-        final_approach_ = false;
+    // only process state transition if already started the planning
+    if (has_created_plan) {
+        process_state_transition();
     }
-
-    ShapeSet static_obstacles;
-    std::vector<DynamicObstacle> dynamic_obstacles;
-    fill_obstacles(plan_request, &static_obstacles, &dynamic_obstacles, false, nullptr);
-
-    auto obstacles_with_ball = static_obstacles;
-    const RJ::Time cur_time = start_instant.stamp;
-    obstacles_with_ball.add(
-        make_shared<Circle>(ball.predict_at(cur_time).position, ball_avoid_distance));
-
-    // This segfaults. Please rewrite the entire thing.
-#if 0
-    if (final_approach_ && target_kick_pos_) {
-        RJ::Seconds duration_into_path = cur_time - prev_path_.begin_time();
-
-        RobotInstant target = prev_path_.last();
-        RJ::Time time = ball.query_time_near(*target_kick_pos_);
-
-        auto time_left = prev_path_.duration() - duration_into_path;
-
-        if (time_left < RJ::Seconds(-0.3) || time_left > RJ::Seconds(5.0)) {
-            final_approach_ = false;
-            prev_path_ = {};
-        } else if (time_left < RJ::Seconds(0)) {
-            prev_path_.set_debug_text("reuse past done " + std::to_string(time_left.count()));
-            return prev_path_;
-        } else {
-            RJ::Seconds time_for_ball = time - cur_time;
-            prev_path_.scale_duration(prev_path_.duration() * (time_left / time_for_ball),
-                                      start_instant.stamp);
-            prev_path_.set_debug_text("reuse final slow " + std::to_string(time_for_ball.count()) +
-                                      " " + std::to_string(time_left.count()));
-            prev_path_.stamp(RJ::now());
-            return prev_path_;
-        }
+    switch (current_state_) {
+        case INITIAL_APPROACH:
+            prev_path_ = initial(plan_request);
+            break;
+        case FINAL_APPROACH:
+            prev_path_ = final(plan_request);
+            break;
     }
-#endif
+    prev_path_.stamp(RJ::now());
+    has_created_plan = true;
+    return prev_path_;
+}
 
-    // only plan line kick if not is_done
-    if (!this->is_done()) {
-        LinearMotionInstant target{
-            ball.position, (command.target.position - ball.position).normalized(approach_speed)};
+Trajectory LineKickPathPlanner::initial(const PlanRequest& plan_request) {
+    // Getting ball info
+    const BallState& ball = plan_request.world_state->ball;
 
-        auto ball_trajectory = ball.make_trajectory();
+    // Creating a modified plan_request to send to PathTargetPlanner
+    PlanRequest modified_request = plan_request;
 
-        Trajectory path;
-        if (std::abs(target.velocity.angle_between((target.position - start_instant.position()))) >
-            degrees_to_radians(10)) {
-            target.position -= target.velocity.normalized(ball_avoid_distance * 2 + kRobotRadius);
-            if (!prev_path_.empty() &&
-                target.position.dist_to(prev_path_.last().position()) <
-                    Replanner::goal_pos_change_threshold() &&
-                reuse_path_count_ < 20) {
-                target.velocity = prev_path_.last().linear_velocity();
-                reuse_path_count_++;
-            } else {
-                reuse_path_count_ = 0;
-            }
+    // Where to navigate to
+    auto distance_from_ball = kBallRadius + kRobotRadius + kAvoidBallBy;
 
-            Replanner::PlanParams params{
-                start_instant,
-                target,
-                obstacles_with_ball,
-                dynamic_obstacles,
-                plan_request.constraints,
-                AngleFns::face_angle(ball.position.angle_to(command.target.position))};
-            path = Replanner::create_plan(params, prev_path_);
-            path.set_debug_text("slow ball 1");
-        } else {
-            if (!prev_path_.empty() &&
-                target.position.dist_to(prev_path_.last().position()) <
-                    Replanner::goal_pos_change_threshold() &&
-                reuse_path_count_ < 20) {
-                target.velocity = prev_path_.last().linear_velocity();
-                reuse_path_count_++;
-            } else {
-                reuse_path_count_ = 0;
-            }
+    auto ball_position = ball.predict_at(RJ::now() + RJ::Seconds{kPredictIn}).position;
 
-            target.position += target.velocity.normalized(kRobotRadius);
+    auto goal_to_ball = (plan_request.motion_command.target.position - ball_position);
+    auto offset_from_ball = distance_from_ball * goal_to_ball.normalized();
 
-            Replanner::PlanParams params{start_instant,
-                                         target,
-                                         static_obstacles,
-                                         dynamic_obstacles,
-                                         plan_request.constraints,
-                                         AngleFns::face_point(command.target.position)};
-            path = Replanner::create_plan(params, prev_path_);
-            path.set_debug_text("slow ball 2");
-        }
-        target_kick_pos_ = command.target.position;
-        path.stamp(RJ::now());
-        prev_path_ = path;
-        return path;
-    }
+    // Updating the motion command
+    LinearMotionInstant target{ball_position - offset_from_ball};
 
-    return Trajectory{};
-    // (Kevin) pretty sure everything under this line is not used
+    MotionCommand modified_command{"path_target", target,
+                                   FacePoint{plan_request.motion_command.target.position}};
+    modified_request.motion_command = modified_command;
 
-    if (!prev_path_.empty() && target_kick_pos_) {
-        auto previous_duration_remaining = prev_path_.end_time() - start_instant.stamp;
+    // Getting the new path from PathTargetPlanner
+    Trajectory path = path_target_.plan(modified_request);
 
-        LinearMotionInstant target;
-        RJ::Time intercept_time = ball.query_time_near(*target_kick_pos_, &target.position);
-        RJ::Time end_time_adjusted = prev_path_.end_time() - RJ::Seconds(1.0);
-        if (previous_duration_remaining < RJ::Seconds(0.0)) {
-            target.velocity =
-                (command.target.position - target.position).normalized(approach_speed);
-            target.position -= target.velocity.normalized(kRobotRadius + kBallRadius * 2);
-
-            Replanner::PlanParams params{start_instant,
-                                         target,
-                                         static_obstacles,
-                                         dynamic_obstacles,
-                                         plan_request.constraints,
-                                         AngleFns::face_point(command.target.position)};
-            Trajectory path = Replanner::create_plan(params, prev_path_);
-
-            if (!path.empty()) {
-                path.set_debug_text(
-                    "FinalPath" + std::to_string(path.duration().count()) + " " +
-                    std::to_string(RJ::Seconds(intercept_time - start_instant.stamp).count()) +
-                    " " + std::to_string(intercept_time.time_since_epoch().count()));
-                path.stamp(RJ::now());
-                prev_path_ = path;
-                return path;
-            }
-        }
-
-        if (prev_path_.check_time(start_instant.stamp) &&
-            !trajectory_hits_static(prev_path_, static_obstacles, start_instant.stamp, nullptr) &&
-            end_time_adjusted < intercept_time && reuse_path_count_ < 10) {
-            reuse_path_count_++;
-            Point near_point;
-            prev_path_.set_debug_text("Reuse prev_path");
-            if (ball.query_time_near(prev_path_.last().position(), &near_point) >=
-                end_time_adjusted) {
-                return prev_path_;
-            }
-        }
-    }
-
-    Trajectory partial_path;
-    RJ::Seconds partial_path_time = 0ms;
-    auto tmp_start_instant = start_instant;
-    const auto partial_replan_lead_time = RJ::Seconds(Replanner::partial_replan_lead_time());
-
-    if (!prev_path_.empty() && prev_path_.check_time(start_instant.stamp)) {
-        if (start_instant.stamp < prev_path_.end_time() - partial_replan_lead_time * 2) {
-            partial_path = prev_path_.sub_trajectory(
-                start_instant.stamp, start_instant.stamp + partial_replan_lead_time);
-            partial_path_time = partial_replan_lead_time;
-            tmp_start_instant = partial_path.last();
-        }
-    }
-
-    for (auto t = RJ::Seconds(0.4); t < RJ::Seconds(6); t += RJ::Seconds(0.2)) {
-        RJ::Time rollout_time = cur_time + t;
-
-        auto ball_state_predicted = ball.predict_at(rollout_time);
-        LinearMotionInstant target{ball_state_predicted.position};
-        target_kick_pos_ = target.position;
-        target.velocity = (command.target.position - target.position).normalized(approach_speed);
-        target.position -= target.velocity.normalized(kRobotRadius + kBallRadius * 2);
-
-        vector<Point> intermediate_points;
-        if (std::abs(target.velocity.angle_between(
-                (target.position - tmp_start_instant.position()))) > degrees_to_radians(60)) {
-            intermediate_points.push_back(
-                target.position -
-                target.velocity.normalized(kRobotRadius * 2.0 + kBallRadius * 2.0));
-        }
-
-        Trajectory path = CreatePath::simple(tmp_start_instant.linear_motion(), target,
-                                             plan_request.constraints.mot, tmp_start_instant.stamp,
-                                             intermediate_points);
-
-        if (!path.empty()) {
-            if (path.duration() + partial_path_time <= t) {
-                if (!partial_path.empty()) {
-                    path = Trajectory(std::move(partial_path), path);
-                }
-                plan_angles(&path, tmp_start_instant, AngleFns::face_point(target.position),
-                            plan_request.constraints.rot);
-
-                path.set_debug_text("FoundPath" + std::to_string(path.duration().count()));
-                reuse_path_count_ = 0;
-                path.stamp(RJ::now());
-                prev_path_ = path;
-                return path;
-            }
-        }
-    }
-
-    auto ball_predicted = ball.predict_at(cur_time);
-    LinearMotionInstant target{ball_predicted.position};
-    target.velocity = (command.target.position - target.position).normalized(approach_speed);
-    target.position -= target.velocity.normalized(kRobotRadius * 3);
-
-    auto ball_path = ball.make_trajectory();
-    dynamic_obstacles.emplace_back(kBallRadius, &ball_path);
-
-    Replanner::PlanParams params{start_instant,
-                                 target,
-                                 static_obstacles,
-                                 dynamic_obstacles,
-                                 plan_request.constraints,
-                                 AngleFns::face_point(command.target.position)};
-    Trajectory path = Replanner::create_plan(params, prev_path_);
-
-    path.set_debug_text("Approaching cautious");
-
-    path.stamp(RJ::now());
-    prev_path_ = path;
     return path;
+}
+
+Trajectory LineKickPathPlanner::final(const PlanRequest& plan_request) {
+    // remove ball from obstacles not needed?
+
+    const BallState& ball = plan_request.world_state->ball;
+
+    // Creating a modified plan_request to send to PathTargetPlanner
+    PlanRequest modified_request = plan_request;
+
+    // velocity
+    auto goal_to_ball = (plan_request.motion_command.target.position - ball.position);
+    auto vel = goal_to_ball.normalized() * kFinalRobotSpeed;
+
+    LinearMotionInstant target{ball.position, vel};
+    MotionCommand modified_command{"path_target", target,
+                                   FacePoint{plan_request.motion_command.target.position}, true};
+    modified_request.motion_command = modified_command;
+
+    // Getting the new path from PathTargetPlanner
+    Trajectory path = path_target_.plan(modified_request);
+
+    return path;
+}
+
+void LineKickPathPlanner::process_state_transition() {
+    if (current_state_ == INITIAL_APPROACH && (path_target_.is_done())) {
+        current_state_ = FINAL_APPROACH;
+    }
 }
 
 bool LineKickPathPlanner::is_done() const {
     // if ball is fast, assume we have kicked it correctly
     // (either way we can't go recapture it)
-    return average_ball_vel_.mag() > IS_DONE_BALL_VEL;
+    return average_ball_vel_.mag() > kIsDoneBallVel;
 }
 
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/plan_request.cpp
+++ b/soccer/src/soccer/planning/planner/plan_request.cpp
@@ -66,8 +66,9 @@ void fill_obstacles(const PlanRequest& in, rj_geometry::ShapeSet* out_static,
     // Adding ball as a static obstacle (because dynamic obstacles are not working)
     // Only added when STOP state is enabled
     if (in.min_dist_from_ball > 0 || avoid_ball) {
-        auto ball_obs = make_inflated_static_obs(in.world_state->ball.position,
-                                                 in.world_state->ball.velocity, kBallRadius);
+        auto ball_obs =
+            make_inflated_static_obs(in.world_state->ball.position, in.world_state->ball.velocity,
+                                     kBallRadius + kAvoidBallDistance);
         ball_obs.radius(ball_obs.radius() + in.min_dist_from_ball);
 
         // Draw ball obstacle in simulator

--- a/soccer/src/soccer/planning/planner/plan_request.hpp
+++ b/soccer/src/soccer/planning/planner/plan_request.hpp
@@ -111,6 +111,7 @@ struct PlanRequest {
     // Whether the robot has a ball
     bool ball_sense = false;
     /**
+    /**
      * How far away to stay from the ball, if the MotionCommand chooses to avoid the ball.
      */
     float min_dist_from_ball = 0;

--- a/soccer/src/soccer/planning/planner/plan_request.hpp
+++ b/soccer/src/soccer/planning/planner/plan_request.hpp
@@ -8,6 +8,7 @@
 #include <planning/planner/motion_command.hpp>
 #include <planning/trajectory.hpp>
 
+#include "../global_state.hpp"
 #include "context.hpp"
 #include "planning/dynamic_obstacle.hpp"
 #include "planning/instant.hpp"
@@ -28,9 +29,9 @@ struct PlanRequest {
     PlanRequest(RobotInstant start, MotionCommand command,  // NOLINT
                 RobotConstraints constraints, rj_geometry::ShapeSet field_obstacles,
                 rj_geometry::ShapeSet virtual_obstacles, TrajectoryCollection* planned_trajectories,
-                unsigned shell_id, const WorldState* world_state, int8_t priority = 0,
-                rj_drawing::RosDebugDrawer* debug_drawer = nullptr, bool ball_sense = false,
-                float min_dist_from_ball = 0, float dribbler_speed = 0)
+                unsigned shell_id, const WorldState* world_state, PlayState play_state,
+                int8_t priority = 0, rj_drawing::RosDebugDrawer* debug_drawer = nullptr,
+                bool ball_sense = false, float min_dist_from_ball = 0, float dribbler_speed = 0)
         : start(start),
           motion_command(command),  // NOLINT
           constraints(constraints),
@@ -40,6 +41,7 @@ struct PlanRequest {
           shell_id(shell_id),
           priority(priority),
           world_state(world_state),
+          play_state(play_state),
           debug_drawer(debug_drawer),
           ball_sense(ball_sense),
           min_dist_from_ball(min_dist_from_ball),
@@ -96,6 +98,11 @@ struct PlanRequest {
     int8_t priority;
 
     /**
+     * the current PlayState
+     */
+    PlayState play_state;
+
+    /**
      * Allows debug drawing in the world. If this is nullptr, no debug drawing
      * should be performed.
      */
@@ -103,7 +110,6 @@ struct PlanRequest {
 
     // Whether the robot has a ball
     bool ball_sense = false;
-
     /**
      * How far away to stay from the ball, if the MotionCommand chooses to avoid the ball.
      */

--- a/soccer/src/soccer/planning/planner_for_robot.cpp
+++ b/soccer/src/soccer/planning/planner_for_robot.cpp
@@ -205,6 +205,7 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
                        robot_trajectories_,
                        static_cast<unsigned int>(robot_id_),
                        world_state,
+                       play_state,
                        intent.priority,
                        &debug_draw_,
                        had_break_beam_,

--- a/soccer/src/soccer/planning/tests/planner_test.cpp
+++ b/soccer/src/soccer/planning/tests/planner_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "game_state.hpp"
 #include "planning/instant.hpp"
 #include "planning/planner/collect_path_planner.hpp"
 #include "planning/planner/motion_command.hpp"
@@ -47,6 +48,7 @@ TEST(Planning, path_target_random) {
         }
 
         LinearMotionInstant goal = random_instant(&gen).linear_motion();
+        PlayState play_state = PlayState::halt();
         PlanRequest request{start,
                             MotionCommand{"path_target", goal},
                             RobotConstraints{},
@@ -55,6 +57,7 @@ TEST(Planning, path_target_random) {
                             {},
                             0,
                             &world_state,
+                            play_state,
                             2,
                             nullptr};
         Trajectory path = planner.plan(std::move(request));
@@ -87,6 +90,7 @@ TEST(Planning, collect_basic) {
     world_state.ball.position = Point{1, 1};
     world_state.ball.velocity = Point{0, 0};
     world_state.ball.timestamp = RJ::now();
+    PlayState play_state = PlayState::halt();
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
                         MotionCommand{"collect"},
                         RobotConstraints{},
@@ -95,6 +99,7 @@ TEST(Planning, collect_basic) {
                         {},
                         0,
                         &world_state,
+                        play_state,
                         2,
                         nullptr};
     CollectPathPlanner planner;
@@ -109,6 +114,7 @@ TEST(Planning, collect_obstructed) {
     world_state.ball.timestamp = RJ::now();
     ShapeSet obstacles;
     obstacles.add(std::make_shared<Circle>(Point{.5, .5}, .2));
+    PlayState play_state = PlayState::halt();
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
                         MotionCommand{"collect"},
                         RobotConstraints{},
@@ -117,6 +123,7 @@ TEST(Planning, collect_obstructed) {
                         {},
                         0,
                         &world_state,
+                        play_state,
                         2,
                         nullptr};
     CollectPathPlanner planner;
@@ -134,6 +141,7 @@ TEST(Planning, collect_pointless_obs) {
     obstacles.add(std::make_shared<Circle>(Point{3, 3}, .2));
     obstacles.add(std::make_shared<Circle>(Point{-2, 3}, .2));
     obstacles.add(std::make_shared<Circle>(Point{0, 5}, .2));
+    PlayState play_state = PlayState::halt();
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
                         MotionCommand{"collect"},
                         RobotConstraints{},
@@ -142,6 +150,7 @@ TEST(Planning, collect_pointless_obs) {
                         {},
                         0,
                         &world_state,
+                        play_state,
                         2,
                         nullptr};
     CollectPathPlanner planner;
@@ -156,6 +165,7 @@ TEST(Planning, collect_moving_ball_quick) {
     world_state.ball.timestamp = RJ::now();
     ShapeSet obstacles;
     obstacles.add(std::make_shared<Circle>(Point{0, .5}, .2));
+    PlayState play_state = PlayState::halt();
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
                         MotionCommand{"collect"},
                         RobotConstraints{},
@@ -164,6 +174,7 @@ TEST(Planning, collect_moving_ball_quick) {
                         {},
                         0,
                         &world_state,
+                        play_state,
                         2,
                         nullptr};
     CollectPathPlanner planner;
@@ -178,6 +189,7 @@ TEST(Planning, collect_moving_ball_slow) {
     world_state.ball.timestamp = RJ::now();
     ShapeSet obstacles;
     obstacles.add(std::make_shared<Circle>(Point{-0.5, .5}, .2));
+    PlayState play_state = PlayState::halt();
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
                         MotionCommand{"collect"},
                         RobotConstraints{},
@@ -186,6 +198,7 @@ TEST(Planning, collect_moving_ball_slow) {
                         {},
                         0,
                         &world_state,
+                        play_state,
                         2,
                         nullptr};
     CollectPathPlanner planner;
@@ -200,6 +213,7 @@ TEST(Planning, collect_moving_ball_slow_2) {
     world_state.ball.timestamp = RJ::now();
     ShapeSet obstacles;
     obstacles.add(std::make_shared<Circle>(Point{0, .5}, .2));
+    PlayState play_state = PlayState::halt();
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
                         MotionCommand{"collect"},
                         RobotConstraints{},
@@ -208,6 +222,7 @@ TEST(Planning, collect_moving_ball_slow_2) {
                         {},
                         0,
                         &world_state,
+                        play_state,
                         2,
                         nullptr};
     CollectPathPlanner planner;
@@ -234,6 +249,7 @@ TEST(Planning, collect_random) {
                 Point{TestingUtils::random(&gen, -2.0, 2.0), TestingUtils::random(&gen, 0.5, 1.5)},
                 .2));
         }
+        PlayState play_state = PlayState::halt();
         PlanRequest request{RobotInstant{{}, {}, RJ::now()},
                             MotionCommand{"collect"},
                             RobotConstraints{},
@@ -242,6 +258,7 @@ TEST(Planning, collect_random) {
                             {},
                             0,
                             &world_state,
+                            play_state,
                             2,
                             nullptr};
         CollectPathPlanner planner;
@@ -265,6 +282,7 @@ TEST(Planning, settle_basic) {
     world_state.ball.timestamp = RJ::now();
     ShapeSet obstacles;
     obstacles.add(std::make_shared<Circle>(Point{.5, .5}, .2));
+    PlayState play_state = PlayState::halt();
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
                         MotionCommand{"settle"},
                         RobotConstraints{},
@@ -273,6 +291,7 @@ TEST(Planning, settle_basic) {
                         {},
                         0,
                         &world_state,
+                        play_state,
                         2,
                         nullptr};
     SettlePathPlanner planner;
@@ -289,6 +308,7 @@ TEST(Planning, settle_pointless_obs) {
     world_state.ball.timestamp = RJ::now();
     ShapeSet obstacles;
     obstacles.add(std::make_shared<Circle>(Point{-1, 1.0}, .2));
+    PlayState play_state = PlayState::halt();
     PlanRequest request{RobotInstant{{}, {}, RJ::now()},
                         MotionCommand{"settle"},
                         RobotConstraints{},
@@ -297,6 +317,7 @@ TEST(Planning, settle_pointless_obs) {
                         {},
                         0,
                         &world_state,
+                        play_state,
                         2,
                         nullptr};
     SettlePathPlanner planner;
@@ -324,6 +345,7 @@ TEST(Planning, settle_random) {
                 Point{TestingUtils::random(&gen, -2.0, 2.0), TestingUtils::random(&gen, .5, 1.5)},
                 .2));
         }
+        PlayState play_state = PlayState::halt();
         PlanRequest request{RobotInstant{{}, {}, RJ::now()},
                             MotionCommand{"settle"},
                             RobotConstraints{},
@@ -332,6 +354,7 @@ TEST(Planning, settle_random) {
                             {},
                             0,
                             &world_state,
+                            play_state,
                             2,
                             nullptr};
         SettlePathPlanner planner;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -29,8 +29,8 @@ Offense::State Offense::update_state() {
     double distance_to_ball = robot_position.dist_to(ball_position);
 
     if (current_state_ == IDLING) {
-        send_scorer_request();
-        next_state = SEARCHING;
+        // send_scorer_request();
+        next_state = AWAITING_SEND_PASS;
     } else if (current_state_ == SEARCHING) {
         if (scorer_) {
             next_state = STEALING;
@@ -77,6 +77,10 @@ Offense::State Offense::update_state() {
         if (check_is_done()) {
             next_state = IDLING;
         }
+    } else if (current_state_ == AWAITING_SEND_PASS) {
+        if (distance_to_ball < ball_lost_distance_) {
+            Position::broadcast_direct_pass_request();
+        }
     }
 
     return next_state;
@@ -94,7 +98,6 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
         intent.motion_command = empty_motion_cmd;
         return intent;
     } else if (current_state_ == PASSING) {
-        // attempt to pass the ball to the target robot
         rj_geometry::Point target_robot_pos =
             last_world_state_->get_robot(true, target_robot_id).pose.position();
         planning::LinearMotionInstant target{target_robot_pos};
@@ -174,6 +177,10 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
             planning::MotionCommand{"path_target", current_location_instant, face_ball};
         intent.motion_command = face_ball_cmd;
         return intent;
+    } else if (current_state_ == AWAITING_SEND_PASS) {
+        auto empty_motion_cmd = planning::MotionCommand{};
+        intent.motion_command = empty_motion_cmd;
+        return intent;
     }
 
     // should be impossible to reach, but this is an EmptyMotionCommand
@@ -205,6 +212,33 @@ communication::PosAgentResponseWrapper Offense::receive_communication_request(
                    std::get_if<communication::ResetScorerRequest>(&request.request)) {
         communication::Acknowledge response = receive_reset_scorer_request();
         comm_response.response = response;
+    } else if (const communication::PassRequest* pass_request =
+                   std::get_if<communication::PassRequest>(&request.request)) {
+        // If the robot recieves a PassRequest, only process it if we are oppen
+
+        rj_geometry::Point robot_position =
+            last_world_state_->get_robot(true, robot_id_).pose.position();
+        rj_geometry::Point from_robot_position =
+            last_world_state_->get_robot(true, pass_request->from_robot_id).pose.position();
+        rj_geometry::Segment pass_path{from_robot_position, robot_position};
+        double min_robot_dist = 10000;
+        float min_path_dist = 10000;
+
+        // Calculates the minimum distance from the current robot to all other robots
+        // Also calculates the minimum distance from another robot to the passing line
+        for (auto bot : last_world_state_->their_robots) {
+            rj_geometry::Point opp_pos = bot.pose.position();
+            min_robot_dist = std::min(min_robot_dist, robot_position.dist_to(opp_pos));
+            min_path_dist = std::min(min_path_dist, pass_path.dist_to(opp_pos));
+        }
+
+        // If the current robot is far enough away from other robots and there are no other robots
+        // in the passing line, process the request Currently, max_receive_distance is used to
+        // determine when we are open, but this may need to change
+        if (min_robot_dist > max_receive_distance && min_path_dist > max_receive_distance) {
+            communication::PassResponse response = Position::receive_pass_request(*pass_request);
+            comm_response.response = response;
+        }
     }
 
     return comm_response;

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -40,15 +40,16 @@ private:
     // TODO (Kevin): strategy design pattern for BallHandler/Receiver
 
     enum State {
-        IDLING,          // simply staying in place
-        SEARCHING,       // moving around on the field to get open
-        PASSING,         // physically kicking the ball towards another robot
-        PREPARING_SHOT,  // pivot around ball in preparation for shot
-        SHOOTING,        // physically kicking the ball towards the net
-        RECEIVING,       // physically intercepting the ball from a pass (gets possession)
-        STEALING,        // attempting to intercept the ball from the other team
-        FACING,          // turning to face the ball
-        SCORER,          // overrides everything and will attempt to steal the bal and shoot it
+        IDLING,              // simply staying in place
+        SEARCHING,           // moving around on the field to get open
+        PASSING,             // physically kicking the ball towards another robot
+        PREPARING_SHOT,      // pivot around ball in preparation for shot
+        SHOOTING,            // physically kicking the ball towards the net
+        RECEIVING,           // physically intercepting the ball from a pass (gets possession)
+        STEALING,            // attempting to intercept the ball from the other team
+        FACING,              // turning to face the ball
+        SCORER,              // overrides everything and will attempt to steal the bal and shoot it
+        AWAITING_SEND_PASS,  // is waiting to send a pass to someone else
     };
 
     State update_state();
@@ -60,6 +61,8 @@ private:
 
     bool scorer_ = false;
     bool last_scorer_ = false;
+
+    communication::PassResponse receive_pass_request(communication::PassRequest pass_request);
 
     /**
      * @brief Send request to the other robots to see if this robot should be the scorer

--- a/soccer/src/soccer/strategy/agent/position/position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/position.cpp
@@ -116,12 +116,12 @@ void Position::receive_communication_response(communication::AgentPosResponseWra
 communication::PosAgentResponseWrapper Position::receive_communication_request(
     communication::AgentPosRequestWrapper request) {
     communication::PosAgentResponseWrapper comm_response{};
-    if (const communication::PassRequest* pass_request =
-            std::get_if<communication::PassRequest>(&request.request)) {
-        communication::PassResponse pass_response = receive_pass_request(*pass_request);
-        comm_response.response = pass_response;
-    } else if (const communication::IncomingBallRequest* incoming_ball_request =
-                   std::get_if<communication::IncomingBallRequest>(&request.request)) {
+    // if (const communication::PassRequest* pass_request =
+    //         std::get_if<communication::PassRequest>(&request.request)) {
+    //     communication::PassResponse pass_response = receive_pass_request(*pass_request);
+    //     comm_response.response = pass_response;
+    if (const communication::IncomingBallRequest* incoming_ball_request =
+            std::get_if<communication::IncomingBallRequest>(&request.request)) {
         communication::Acknowledge incoming_pass_acknowledge =
             acknowledge_pass(*incoming_ball_request);
         comm_response.response = incoming_pass_acknowledge;
@@ -155,6 +155,19 @@ void Position::send_direct_pass_request(std::vector<u_int8_t> target_robots) {
     communication_request_ = communication_request;
 }
 
+void Position::broadcast_direct_pass_request() {
+    communication::PassRequest pass_request{};
+    communication::generate_uid(pass_request);
+    pass_request.direct = true;
+    pass_request.from_robot_id = robot_id_;
+
+    communication::PosAgentRequestWrapper communication_request{};
+    communication_request.request = pass_request;
+    communication_request.urgent = true;
+    communication_request.broadcast = true;
+    communication_request_ = communication_request;
+}
+
 communication::PassResponse Position::receive_pass_request(
     communication::PassRequest pass_request) {
     communication::PassResponse pass_response{};
@@ -162,7 +175,6 @@ communication::PassResponse Position::receive_pass_request(
 
     if (pass_request.direct) {
         // Handle direct pass request
-        // TODO: Make this rely on actually being open
         pass_response.direct_open = true;
     } else {
         // TODO: Handle indirect pass request

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -129,6 +129,8 @@ public:
      */
     void send_direct_pass_request(std::vector<u_int8_t> target_robots);
 
+    void broadcast_direct_pass_request();
+
     /**
      * @brief receives and handles a pass_request
      *

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -828,17 +828,23 @@ void MainWindow::on_actionStopBall_triggered() {
 }
 
 void MainWindow::on_actionResetField_triggered() {
-    const int NUM_COLS = 2;
-    const int ROBOTS_PER_COL = kRobotsPerTeam / NUM_COLS;
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(2, -1, 0), 0, false);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(2, -1, 0), 0, true);
 
-    for (size_t i = 0; i < kRobotsPerTeam; ++i) {
-        double x_pos = +2.5 - i / ROBOTS_PER_COL;
-        double y_pos = i % ROBOTS_PER_COL - ROBOTS_PER_COL / NUM_COLS;
-        auto pose = rj_geometry::Pose(x_pos, y_pos, 0);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(2, 0, 0), 1, false);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(2, 0, 0), 1, true);
 
-        _ui.fieldView->set_robot_pose(pose, i, false);
-        _ui.fieldView->set_robot_pose(pose, i, true);
-    }
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(2, 1, 0), 2, false);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(2, 1, 0), 2, true);
+
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(3, -1, 0), 3, false);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(3, -1, 0), 3, true);
+
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(3, 0, 0), 4, false);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(3, 0, 0), 4, true);
+
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(3, 1, 0), 5, false);
+    _ui.fieldView->set_robot_pose(rj_geometry::Pose(3, 1, 0), 5, true);
 
     _ui.fieldView->set_ball_position(rj_geometry::Point(0.0, 0.0));
     _ui.fieldView->set_ball_velocity(rj_geometry::Point(0.0, 0.0));


### PR DESCRIPTION
## Description
Implements position management automatically based on states of the game. Positions used to be static (3 defense, 2 offense, 1 goalie), but now they change dynamically.

## Associated / Resolved Issue
[ClickUp card](https://app.clickup.com/t/86aypjcg3)

## Steps to Test
Run in sim and move the ball to different halves. The positions of robots should change dynamically.

## Key Files to Review
 * robot_factory_postion.cpp

## Review Checklist

- [ ] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [ ] **Remove extra print statements**: Any print statements used for debugging should be removed
- [ ] **Tag reviewers**: Tag some people for review and ping them on Slack

## (Optional) Sub-issues (for drafts)
_Note: if you find yourself breaking this PR into many smaller features, it may make sense to break up the PR into logical units based on these features._
- [ ] Step 1
- [ ] Step 2
