### PR TITLE
ignore goalie in has_open_shot

### DIFF
--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -193,6 +193,9 @@ private:
     // Used to assume we are capable of manipulating the ball
     static constexpr double kOwnBallRadius{kRobotRadius + 0.1};
 
+    // Used to tell if an enemy is close enough to block a shot
+    static constexpr double kEnemyTooCloseRadius{kStealBallRadius};
+
     /* Utility functions for State or Task Calculation */
 
     /**


### PR DESCRIPTION
## Description
Taking the goalie into account makes us deny every shot. Let's assume corner shots can evade the goalie, and only take into account defenders. Important to shoot more.

## Associated / Resolved Issue
Resolves clickup card: https://app.clickup.com/t/86azgzx41 

## Steps to Test
### In sim:
1. Place goalie in opponents defense area
Result: Shot still taken
3. Place other defender in the way
Result: Pass instead

## Key Files to Review
offense.*pp

