### PR TITLE
Sim Alive Robots Publish

### DIFF
--- a/rj_constants/include/rj_constants/topic_names.hpp
+++ b/rj_constants/include/rj_constants/topic_names.hpp
@@ -69,7 +69,7 @@ static inline std::string trajectory_topic(int robot_id) {
 }  // namespace planning::topics
 
 namespace strategy::topics {
-    constexpr auto kAliveRobots("strategy/alive_robots");
+constexpr auto kAliveRobots("strategy/alive_robots");
 }  // namespace strategy::topics
 
 namespace control {

--- a/rj_constants/include/rj_constants/topic_names.hpp
+++ b/rj_constants/include/rj_constants/topic_names.hpp
@@ -69,6 +69,7 @@ static inline std::string trajectory_topic(int robot_id) {
 }  // namespace planning::topics
 
 namespace strategy::topics {
+    constexpr auto kAliveRobots("strategy/alive_robots");
 }  // namespace strategy::topics
 
 namespace control {

--- a/soccer/src/soccer/radio/radio.cpp
+++ b/soccer/src/soccer/radio/radio.cpp
@@ -39,7 +39,7 @@ Radio::Radio()
     }
 
     alive_robots_pub_ =
-        create_publisher<rj_msgs::msg::AliveRobots>("/alive_robots", rclcpp::QoS(1));
+        create_publisher<rj_msgs::msg::AliveRobots>(strategy::topics::kAliveRobots, rclcpp::QoS(1));
 
     tick_timer_ = create_wall_timer(tick_period_, [this]() { tick(); });
 }

--- a/soccer/src/soccer/radio/sim_radio.cpp
+++ b/soccer/src/soccer/radio/sim_radio.cpp
@@ -98,8 +98,8 @@ SimRadio::SimRadio(bool blue_team)
     for (uint8_t robot_id = 0; robot_id < 7; robot_id++) {
         alive_robots_[robot_id] = true;
     }
-    alive_robots_pub_ =
-        this->create_publisher<rj_msgs::msg::AliveRobots>(strategy::topics::kAliveRobots, rclcpp::QoS(1));
+    alive_robots_pub_ = this->create_publisher<rj_msgs::msg::AliveRobots>(
+        strategy::topics::kAliveRobots, rclcpp::QoS(1));
 
     alive_robots_timer_ = create_wall_timer(std::chrono::milliseconds(500), [this]() {
         rj_msgs::msg::AliveRobots alive_message{};

--- a/soccer/src/soccer/radio/sim_radio.cpp
+++ b/soccer/src/soccer/radio/sim_radio.cpp
@@ -95,7 +95,7 @@ SimRadio::SimRadio(bool blue_team)
     sim_control_endpoint_ = ip::udp::endpoint(address_, kSimCommandPort);
 
     // assume robots 0-6 are always alive in sim
-    for (uint8_t robot_id = 0; robot_id < 7; robot_id++) {
+    for (uint8_t robot_id = 0; robot_id <= 6; robot_id++) {
         alive_robots_[robot_id] = true;
     }
     alive_robots_pub_ = this->create_publisher<rj_msgs::msg::AliveRobots>(

--- a/soccer/src/soccer/radio/sim_radio.cpp
+++ b/soccer/src/soccer/radio/sim_radio.cpp
@@ -94,17 +94,19 @@ SimRadio::SimRadio(bool blue_team)
         ip::udp::endpoint(address_, blue_team_ ? kSimBlueCommandPort : kSimYellowCommandPort);
     sim_control_endpoint_ = ip::udp::endpoint(address_, kSimCommandPort);
 
+    // assume robots 0-6 are always alive in sim
+    for (uint8_t robot_id = 0; robot_id < 7; robot_id++) {
+        alive_robots_[robot_id] = true;
+    }
+    alive_robots_pub_ =
+        this->create_publisher<rj_msgs::msg::AliveRobots>(strategy::topics::kAliveRobots, rclcpp::QoS(1));
+
     alive_robots_timer_ = create_wall_timer(std::chrono::milliseconds(500), [this]() {
         rj_msgs::msg::AliveRobots alive_message{};
         alive_message.alive_robots = alive_robots_;
         publish_alive_robots(alive_message);
     });
 
-    for (uint8_t robot_id = 0; robot_id < kNumShells; robot_id++) {
-        alive_robots_[robot_id] = true;
-    }
-    alive_robots_pub_ =
-        this->create_publisher<rj_msgs::msg::AliveRobots>("strategy/alive_robots", rclcpp::QoS(1));
 
     buffer_.resize(1024);
     start_receive();

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -34,7 +34,7 @@ AgentActionClient::AgentActionClient(int r_id)
         [this](rj_msgs::msg::FieldDimensions::SharedPtr msg) { field_dimensions_callback(msg); });
 
     alive_robots_sub_ = create_subscription<rj_msgs::msg::AliveRobots>(
-        "strategy/alive_robots", 1,
+        ::strategy::topics::kAliveRobots, 1,
         [this](rj_msgs::msg::AliveRobots::SharedPtr msg) { alive_robots_callback(msg); });
 
     game_settings_sub_ = create_subscription<rj_msgs::msg::GameSettings>(


### PR DESCRIPTION
## Description
Publish robots 0-6 as alive in `sim_radio`.
Declare `strategy/alive_robots` as a global topic name for alive robots and make all radios use it.

## Steps to Test
1. Run sim.
2. `ros2 topic echo strategy/alive_robots`
