### PR TITLE
Accept referee commands from all physical interfaces

### DIFF
--- a/rj_common/include/rj_common/network.hpp
+++ b/rj_common/include/rj_common/network.hpp
@@ -37,32 +37,9 @@
  * In networking terms, the referee packets' source address should match
  * kRefereeSourceAddress, and same thing for SharedVisionAddress.
  *
- * The physical interface we expect to receive these packets from is defined
- * below.
  */
 static const std::string kRefereeSourceAddress = "224.5.23.1";
 static const std::string kSharedVisionSourceAddress = "224.5.23.2";
-
-/*
- * UPDATE (4/9/2023): these are no longer necessary. Both VisionReceiver and
- * ExternalReferee now simply join the multicast group and listen for their
- * respective source addresses above.
- *
- * These IP addresses are the interfaces (e.g. Ethernet plugged into this
- * laptop) where we expect ref/vision data to come from. They are (likely)
- * physical Ethernet links to the network, so this address won't show up in
- * Wireshark.
- *
- * When running sim, this should be localhost = 127.0.0.1.
- *
- * Run ifconfig to see list of interfaces on this computer, and pick the right
- * one (or try them all in worst-case).
- */
-
-static const std::string kRefereeInterface = "192.168.20.119";
-/* static const std::string kRefereeInterface = "172.0.0.1"; */
-static const std::string kVisionInterface =
-    kRefereeInterface;  // In all but rare cirucmstances, this should match kRefereeInterface.
 
 // The network address of the base station
 static const std::string kBaseStationAddress = "10.42.0.248";

--- a/soccer/src/soccer/referee/external_referee.cpp
+++ b/soccer/src/soccer/referee/external_referee.cpp
@@ -114,15 +114,15 @@ void ExternalReferee::setup_referee_multicast() {
         throw std::runtime_error("Failed to bind to shared referee port");
     }
 
-    // ExternalReferee will find any packets from kRefereeSourceAddress take
-    // them
-    SPDLOG_INFO("ExternalReferee joining kRefereeSourceAddress: {}", kRefereeSourceAddress);
+    // ExternalReferee will find any packets from kRefereeSourceAddress
     const boost::asio::ip::address_v4 multicast_address =
         boost::asio::ip::address::from_string(kRefereeSourceAddress).to_v4();
-    const boost::asio::ip::address_v4 multicast_interface =
-        boost::asio::ip::address::from_string(kRefereeInterface).to_v4();
-    asio_socket_.set_option(
-        boost::asio::ip::multicast::join_group(multicast_address, multicast_interface));
+
+    // Join the multicast group. Note that by choosing not to specify a physical interface address,
+    // the default "any" address is used, which means the socket will receive packets from any
+    // interface, as long as the packets are addressed to the multicast address.
+    // This was changed in March 2024.
+    asio_socket_.set_option(boost::asio::ip::multicast::join_group(multicast_address));
 }
 
 void ExternalReferee::update() { io_service_.poll(); }


### PR DESCRIPTION
## Description

Previously, an IP address for the external referee was specified. This would regularly be localhost when running ssl-game-controller on the same machine (i.e. for testing in sim), but at competitions this IP address would vary often. 

This forced us to first manually identify the physical IP address of the game controller, modify the constant, and then recompile. 

However, by default, boost/setsockopt allows us to listen on any/all physical interfaces (when binding to a multicast address). So, by simply removing this specification, we should be able to receive referee commands on any setup without any manual configuraiton.

Relevant paragraphs from the setsockopt docs: [1](https://arc.net/l/quote/rixrrtnz) and [2](https://arc.net/l/quote/ezlvtaia)

## Associated / Resolved Issue
Resolves [ClickUp card](https://app.clickup.com/t/863h9cq3v)

## Steps to Test
### Localhost external ref
1. Run ssl-game-controller
2. Run ER-Force `simulator-cli`
3. Run `make run-sim-ex`

**Expected result:** soccer responds to referee commands (note that behavior is irrelevant; ensure that commands are visible in the left panel of the UI)

## Steps to Test
### Networked external ref
1. Run ssl-game-controller on some other machine on the same network as your own
- Note: it is possible at comp that this machine is connected directly to yours via a link-layer switch and there may be no router assigning IP addresses.
3. Run ER-Force `simulator-cli`
4. Run `make run-sim-ex`

**Expected result:** soccer responds to referee commands (note that behavior is irrelevant; ensure that commands are visible in the left panel of the UI)

## Key Files to Review
 * `network.hpp`
 * `external_referee.cpp`


## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack
