### PR TITLE
Fixed issue with robots going into forbidden areas when stealing/receiving

### DIFF
--- a/soccer/src/soccer/planning/planner/collect_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/collect_path_planner.cpp
@@ -110,6 +110,9 @@ Trajectory CollectPathPlanner::plan(const PlanRequest& plan_request) {
     std::vector<DynamicObstacle> dynamic_obstacles;
     fill_obstacles(plan_request, &static_obstacles, &dynamic_obstacles, false);
 
+    //Return an empty trajectory if the ball is hitting static obstacles
+    //or it is in the goalie area.
+    //Check the robot for the same conditions.
     if (static_obstacles.hit(ball.position) ||
         static_obstacles.hit(start_instant.pose.position())) {
         return Trajectory{};
@@ -275,12 +278,6 @@ Trajectory CollectPathPlanner::fine_approach(
     motion_constraints_hit.max_speed =
         std::min(target_hit_vel.mag(), motion_constraints_hit.max_speed);
 
-    // Trajectory path_hit = CreatePath::simple(start_instant.linear_motion(), target_hit,
-    //                                          plan_request.constraints.mot, start_instant.stamp);
-    // Trajectory path_hit = CreatePath::rrt(start_instant.linear_motion(), target_hit,
-    // plan_request.constraints.mot,
-    //                                  start_instant.stamp, static_obstacles, dynamic_obstacles);
-
     Replanner::PlanParams params{start_instant,
                                  target_hit,
                                  static_obstacles,
@@ -374,9 +371,6 @@ Trajectory CollectPathPlanner::control(const PlanRequest& plan_request, RobotIns
     // Try to use the RRTPathPlanner to generate the path first
     // It reaches the target better for some reason
     std::vector<Point> start_end_points{start.position(), target.position};
-
-    // Trajectory path = CreatePath::rrt(start.linear_motion(), target, motion_constraints,
-    //                                   start.stamp, static_obstacles, dynamic_obstacles);
 
     Replanner::PlanParams params{start,
                                  target,

--- a/soccer/src/soccer/planning/planner/collect_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/collect_path_planner.cpp
@@ -14,6 +14,7 @@ using namespace rj_geometry;
 namespace planning {
 
 Trajectory CollectPathPlanner::plan(const PlanRequest& plan_request) {
+
     const auto state = plan_request.play_state.state();
     if (state == PlayState::Stop || state == PlayState::Halt) {
         // This planner automatically fails if the robot is prohibited from touching the ball.
@@ -110,6 +111,10 @@ Trajectory CollectPathPlanner::plan(const PlanRequest& plan_request) {
     std::vector<DynamicObstacle> dynamic_obstacles;
     fill_obstacles(plan_request, &static_obstacles, &dynamic_obstacles, false);
 
+    if (static_obstacles.hit(ball.position) || static_obstacles.hit(start_instant.pose.position())) {
+        return Trajectory{};
+    }
+
     switch (current_state_) {
         // Moves from the current location to the slow point of approach
         case CoarseApproach:
@@ -149,6 +154,7 @@ void CollectPathPlanner::check_solution_validity(BallState ball, RobotInstant st
 }
 
 void CollectPathPlanner::process_state_transition(BallState ball, RobotInstant start_instant) {
+    SPDLOG_INFO("Currently processing state transition.");
     // Do the transitions
     double dist = (start_instant.position() - ball.position).mag() - kRobotMouthRadius;
     double speed_diff = (start_instant.linear_velocity() - average_ball_vel_).mag() -
@@ -157,12 +163,14 @@ void CollectPathPlanner::process_state_transition(BallState ball, RobotInstant s
     // If we are in range to the slow dist
     if (dist < collect::PARAM_approach_dist_target + kRobotMouthRadius &&
         current_state_ == CoarseApproach) {
+        SPDLOG_INFO("Switching to FineApproach");
         current_state_ = FineApproach;
     }
 
     // If the ball gets knocked far away, go back to CoarseApproach
     if (dist > collect::PARAM_approach_dist_target + kRobotMouthRadius &&
         current_state_ == FineApproach) {
+        SPDLOG_INFO("Switching from FineApproach to CoarseApproach");
         current_state_ = CoarseApproach;
     }
 
@@ -171,6 +179,7 @@ void CollectPathPlanner::process_state_transition(BallState ball, RobotInstant s
     // TODO(#1518): Check for ball sense?
     if (dist < collect::PARAM_dist_cutoff_to_control &&
         speed_diff < collect::PARAM_vel_cutoff_to_control && current_state_ == FineApproach) {
+        SPDLOG_INFO("Switching from FineApproach to Control");
         current_state_ = Control;
     }
 }
@@ -179,6 +188,7 @@ Trajectory CollectPathPlanner::coarse_approach(
     const PlanRequest& plan_request, RobotInstant start,
     const rj_geometry::ShapeSet& static_obstacles,
     const std::vector<DynamicObstacle>& dynamic_obstacles) {
+    SPDLOG_INFO("In Coarse Approach");
     BallState ball = plan_request.world_state->ball;
 
     // There are two paths that get combined together
@@ -227,6 +237,7 @@ Trajectory CollectPathPlanner::coarse_approach(
                                            start.linear_motion(), start.heading(), nullptr))));
     }
 
+    SPDLOG_INFO("Leaving coarse_approach");
     // Build a path from now to the slow point
     coarse_path.set_debug_text("coarse");
 
@@ -235,8 +246,9 @@ Trajectory CollectPathPlanner::coarse_approach(
 
 Trajectory CollectPathPlanner::fine_approach(
     const PlanRequest& plan_request, RobotInstant start_instant,
-    const rj_geometry::ShapeSet& /* static_obstacles */,
-    const std::vector<DynamicObstacle>& /* dynamic_obstacles */) {
+    const rj_geometry::ShapeSet&  static_obstacles,
+    const std::vector<DynamicObstacle>& dynamic_obstacles) {
+    SPDLOG_INFO("In Fine Approach");
     BallState ball = plan_request.world_state->ball;
     RobotConstraints robot_constraints_hit = plan_request.constraints;
     MotionConstraints& motion_constraints_hit = robot_constraints_hit.mot;
@@ -270,8 +282,18 @@ Trajectory CollectPathPlanner::fine_approach(
     motion_constraints_hit.max_speed =
         std::min(target_hit_vel.mag(), motion_constraints_hit.max_speed);
 
-    Trajectory path_hit = CreatePath::simple(start_instant.linear_motion(), target_hit,
-                                             plan_request.constraints.mot, start_instant.stamp);
+    // Trajectory path_hit = CreatePath::simple(start_instant.linear_motion(), target_hit,
+    //                                          plan_request.constraints.mot, start_instant.stamp);
+    //Trajectory path_hit = CreatePath::rrt(start_instant.linear_motion(), target_hit, plan_request.constraints.mot,
+    //                                  start_instant.stamp, static_obstacles, dynamic_obstacles);
+
+    Replanner::PlanParams params{start_instant,
+                                target_hit,
+                                static_obstacles,
+                                dynamic_obstacles,
+                                plan_request.constraints,
+                                AngleFns::face_point(ball.position)};
+    Trajectory path_hit = Replanner::create_plan(params, previous_);
 
     path_hit.set_debug_text("fine");
     plan_angles(&path_hit, start_instant, AngleFns::face_point(ball.position),
@@ -293,6 +315,7 @@ Trajectory CollectPathPlanner::control(const PlanRequest& plan_request, RobotIns
                                        const Trajectory& /* partial_path */,
                                        const rj_geometry::ShapeSet& static_obstacles,
                                        const std::vector<DynamicObstacle>& dynamic_obstacles) {
+    SPDLOG_INFO("In Control Mode");
     BallState ball = plan_request.world_state->ball;
     RobotConstraints robot_constraints = plan_request.constraints;
     MotionConstraints& motion_constraints = robot_constraints.mot;
@@ -300,6 +323,7 @@ Trajectory CollectPathPlanner::control(const PlanRequest& plan_request, RobotIns
     // Only plan the path once and run through it
     // Otherwise it will basically push the ball across the field
     if (control_path_created_ && !previous_.empty()) {
+        SPDLOG_INFO("If statement at beginning of method");
         return previous_;
     }
 
@@ -318,8 +342,10 @@ Trajectory CollectPathPlanner::control(const PlanRequest& plan_request, RobotIns
 
     double velocity_scale = collect::PARAM_velocity_control_scale;
 
+    SPDLOG_INFO("Outside 332 IF statement");
     // Moving at us
     if (average_ball_vel_.angle_between((ball.position - start.position())) > 3.14 / 2) {
+        SPDLOG_INFO("Line 332 IF statement");
         current_speed = collect::PARAM_touch_delta_speed;
         velocity_scale = 0;
     }
@@ -358,21 +384,35 @@ Trajectory CollectPathPlanner::control(const PlanRequest& plan_request, RobotIns
     // Try to use the RRTPathPlanner to generate the path first
     // It reaches the target better for some reason
     std::vector<Point> start_end_points{start.position(), target.position};
-    Trajectory path = CreatePath::rrt(start.linear_motion(), target, motion_constraints,
-                                      start.stamp, static_obstacles, dynamic_obstacles);
 
+    // Trajectory path = CreatePath::rrt(start.linear_motion(), target, motion_constraints,
+    //                                   start.stamp, static_obstacles, dynamic_obstacles);
+
+    Replanner::PlanParams params{start,
+                                 target,
+                                 static_obstacles,
+                                 dynamic_obstacles,
+                                 plan_request.constraints,
+                                 AngleFns::face_point(ball.position)};
+
+    Trajectory path = Replanner::create_plan(params, previous_);
+
+    SPDLOG_INFO("Outside Line 376 IF statement");
     if (plan_request.debug_drawer != nullptr) {
+        SPDLOG_INFO("In Line 376 IF Statement");
         plan_request.debug_drawer->draw_segment(
             Segment(start.position(), start.position() + (target.position - start.position()) * 10),
             QColor(255, 255, 255));
     }
 
     if (path.empty()) {
+        SPDLOG_INFO("///////////// path.empty invoked 1/////////////");
         return Trajectory{};
     }
 
     path.set_debug_text("stopping");
 
+    SPDLOG_INFO("!!!!!!!!!CONTROL MODE ALMOST OVER BOIIIIII!!!!!!!!!");
     // Make sure that when the path ends, we don't end up spinning around
     // because we hit go past the ball position at the time of path creation
     Point face_pt = start.position() + 10 * (target.position - start.position()).norm();
@@ -380,12 +420,14 @@ Trajectory CollectPathPlanner::control(const PlanRequest& plan_request, RobotIns
     plan_angles(&path, start, AngleFns::face_point(face_pt), robot_constraints.rot);
 
     if (plan_request.debug_drawer != nullptr) {
+        SPDLOG_INFO("Inside IF statement at end of Control");
         plan_request.debug_drawer->draw_segment(
             Segment(start.position(),
                     start.position() + Point::direction(AngleFns::face_point(face_pt)(
                                            start.linear_motion(), start.heading(), nullptr))));
     }
 
+    SPDLOG_INFO("!!!!!!!End of Control Mode!!!!!!");
     path.stamp(RJ::now());
     return path;
 }
@@ -393,6 +435,7 @@ Trajectory CollectPathPlanner::control(const PlanRequest& plan_request, RobotIns
 Trajectory CollectPathPlanner::invalid(const PlanRequest& plan_request,
                                        const rj_geometry::ShapeSet& static_obstacles,
                                        const std::vector<DynamicObstacle>& dynamic_obstacles) {
+    SPDLOG_INFO("In Invalid Mode");
     current_state_ = CoarseApproach;
 
     // Stop movement until next frame since it's the safest option
@@ -410,6 +453,7 @@ Trajectory CollectPathPlanner::invalid(const PlanRequest& plan_request,
 }
 
 void CollectPathPlanner::reset() {
+    SPDLOG_INFO("///////// Resetting everything //////////");
     previous_ = Trajectory();
     current_state_ = CollectPathPathPlannerStates::CoarseApproach;
     average_ball_vel_initialized_ = false;

--- a/soccer/src/soccer/planning/planner/collect_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/collect_path_planner.cpp
@@ -110,9 +110,9 @@ Trajectory CollectPathPlanner::plan(const PlanRequest& plan_request) {
     std::vector<DynamicObstacle> dynamic_obstacles;
     fill_obstacles(plan_request, &static_obstacles, &dynamic_obstacles, false);
 
-    //Return an empty trajectory if the ball is hitting static obstacles
-    //or it is in the goalie area.
-    //Check the robot for the same conditions.
+    // Return an empty trajectory if the ball is hitting static obstacles
+    // or it is in the goalie area.
+    // Check the robot for the same conditions.
     if (static_obstacles.hit(ball.position) ||
         static_obstacles.hit(start_instant.pose.position())) {
         return Trajectory{};

--- a/soccer/src/soccer/planning/planner/collect_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/collect_path_planner.cpp
@@ -14,7 +14,6 @@ using namespace rj_geometry;
 namespace planning {
 
 Trajectory CollectPathPlanner::plan(const PlanRequest& plan_request) {
-
     const auto state = plan_request.play_state.state();
     if (state == PlayState::Stop || state == PlayState::Halt) {
         // This planner automatically fails if the robot is prohibited from touching the ball.
@@ -111,7 +110,8 @@ Trajectory CollectPathPlanner::plan(const PlanRequest& plan_request) {
     std::vector<DynamicObstacle> dynamic_obstacles;
     fill_obstacles(plan_request, &static_obstacles, &dynamic_obstacles, false);
 
-    if (static_obstacles.hit(ball.position) || static_obstacles.hit(start_instant.pose.position())) {
+    if (static_obstacles.hit(ball.position) ||
+        static_obstacles.hit(start_instant.pose.position())) {
         return Trajectory{};
     }
 
@@ -240,7 +240,7 @@ Trajectory CollectPathPlanner::coarse_approach(
 
 Trajectory CollectPathPlanner::fine_approach(
     const PlanRequest& plan_request, RobotInstant start_instant,
-    const rj_geometry::ShapeSet&  static_obstacles,
+    const rj_geometry::ShapeSet& static_obstacles,
     const std::vector<DynamicObstacle>& dynamic_obstacles) {
     BallState ball = plan_request.world_state->ball;
     RobotConstraints robot_constraints_hit = plan_request.constraints;
@@ -277,15 +277,16 @@ Trajectory CollectPathPlanner::fine_approach(
 
     // Trajectory path_hit = CreatePath::simple(start_instant.linear_motion(), target_hit,
     //                                          plan_request.constraints.mot, start_instant.stamp);
-    //Trajectory path_hit = CreatePath::rrt(start_instant.linear_motion(), target_hit, plan_request.constraints.mot,
+    // Trajectory path_hit = CreatePath::rrt(start_instant.linear_motion(), target_hit,
+    // plan_request.constraints.mot,
     //                                  start_instant.stamp, static_obstacles, dynamic_obstacles);
 
     Replanner::PlanParams params{start_instant,
-                                target_hit,
-                                static_obstacles,
-                                dynamic_obstacles,
-                                plan_request.constraints,
-                                AngleFns::face_point(ball.position)};
+                                 target_hit,
+                                 static_obstacles,
+                                 dynamic_obstacles,
+                                 plan_request.constraints,
+                                 AngleFns::face_point(ball.position)};
     Trajectory path_hit = Replanner::create_plan(params, previous_);
 
     path_hit.set_debug_text("fine");

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -15,7 +15,6 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
         if (current_state_ == SEEKING) {
             broadcast_seeker_request(rj_geometry::Point{}, false);
         }
-
     }
 
     current_state_ = new_state;
@@ -519,7 +518,7 @@ double Offense::distance_from_their_robots(rj_geometry::Point tail, rj_geometry:
 }
 
 bool Offense::can_steal_ball() const {
-    //Ball in red zone or not
+    // Ball in red zone or not
     if (ball_in_red()) {
         return false;
     }
@@ -588,10 +587,8 @@ rj_geometry::Point Offense::calculate_best_shot() const {
 bool Offense::ball_in_red() const {
     auto& ball_pos = last_world_state_->ball.position;
     return (field_dimensions_.our_defense_area().contains_point(ball_pos) ||
-        field_dimensions_.their_defense_area().contains_point(ball_pos) ||
-        !field_dimensions_.field_rect().contains_point(ball_pos)); 
-    
-    
+            field_dimensions_.their_defense_area().contains_point(ball_pos) ||
+            !field_dimensions_.field_rect().contains_point(ball_pos));
 }
 void Offense::broadcast_seeker_request(rj_geometry::Point seeking_point, bool adding) {
     communication::SeekerRequest seeker_request{};

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -567,7 +567,7 @@ rj_geometry::Point Offense::calculate_best_shot() const {
     return best_shot;
 }
 
-//Checks whether ball is out of range for stealing/receiving
+// Checks whether ball is out of range for stealing/receiving
 bool Offense::ball_in_red(WorldState* last_world_state_) {
     auto& ball_pos = last_world_state_->ball.position;
     if (field_dimensions_.their_defense_area().contains_point(ball_pos) ||

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -102,7 +102,7 @@ Offense::State Offense::next_state() {
 
         case STEALING: {
             if (ball_in_red(last_world_state_)) {
-                return SEEKING;
+                return SEEKING_START;
             }
 
             // Go to possession if successful
@@ -135,7 +135,7 @@ Offense::State Offense::next_state() {
             }
 
             if (ball_in_red(last_world_state_)) {
-                return SEEKING;
+                return SEEKING_START;
             }
 
             // If we failed to get it in time
@@ -570,8 +570,9 @@ rj_geometry::Point Offense::calculate_best_shot() const {
 
 bool Offense::ball_in_red(WorldState* last_world_state_) {
     auto& ball_pos = last_world_state_->ball.position;
-    if ((ball_pos.x() >= -1 && ball_pos.x() <= 1)
-        && ((ball_pos.y() >= 8 && ball_pos.y() <= 9) || (ball_pos.y() >= 0 && ball_pos.y() <= 1))) {
+    if (field_dimensions_.their_defense_area().contains_point(ball_pos)
+        || field_dimensions_.our_defense_area().contains_point(ball_pos)
+        || !field_dimensions_.field_rect().contains_point(ball_pos)) {
         return true;
     }
     return false;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -570,9 +570,8 @@ rj_geometry::Point Offense::calculate_best_shot() const {
 //Checks whether ball is out of range for stealing/receiving
 bool Offense::ball_in_red(WorldState* last_world_state_) {
     auto& ball_pos = last_world_state_->ball.position;
-    if (field_dimensions_.their_defense_area().contains_point(ball_pos) ||
-        field_dimensions_.our_defense_area().contains_point(ball_pos) ||
-        !field_dimensions_.field_rect().contains_point(ball_pos)) {
+    if ((ball_pos.x() >= -1 && ball_pos.x() <= 1) &&
+        ((ball_pos.y() >= 8 && ball_pos.y() <= 9) || (ball_pos.y() >= 0 && ball_pos.y() <= 1))) {
         return true;
     }
     return false;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -10,7 +10,6 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
 
     if (current_state_ != new_state) {
         reset_timeout();
-        SPDLOG_INFO("Robot {}: now {}", robot_id_, state_to_name(current_state_));
     }
 
     current_state_ = new_state;
@@ -37,7 +36,7 @@ Offense::State Offense::next_state() {
 
         case SEEKING: {
             // If the ball seems "stealable", we should switch to STEALING
-            if (can_steal_ball() && !ball_in_goal(last_world_state_)) {
+            if (can_steal_ball() && !ball_in_red(last_world_state_)) {
                 return STEALING;
             }
 
@@ -102,7 +101,7 @@ Offense::State Offense::next_state() {
         }
 
         case STEALING: {
-            if (ball_in_goal(last_world_state_)) {
+            if (ball_in_red(last_world_state_)) {
                 return SEEKING;
             }
 
@@ -135,7 +134,7 @@ Offense::State Offense::next_state() {
                 return POSSESSION_START;
             }
 
-            if (ball_in_goal(last_world_state_)) {
+            if (ball_in_red(last_world_state_)) {
                 return SEEKING;
             }
 
@@ -569,7 +568,7 @@ rj_geometry::Point Offense::calculate_best_shot() const {
     return best_shot;
 }
 
-bool Offense::ball_in_goal(WorldState* last_world_state_) {
+bool Offense::ball_in_red(WorldState* last_world_state_) {
     auto& ball_pos = last_world_state_->ball.position;
     if ((ball_pos.x() >= -1 && ball_pos.x() <= 1)
         && ((ball_pos.y() >= 8 && ball_pos.y() <= 9) || (ball_pos.y() >= 0 && ball_pos.y() <= 1))) {

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -570,8 +570,9 @@ rj_geometry::Point Offense::calculate_best_shot() const {
 // Checks whether ball is out of range for stealing/receiving
 bool Offense::ball_in_red(WorldState* last_world_state_) {
     auto& ball_pos = last_world_state_->ball.position;
-    if ((ball_pos.x() >= -1 && ball_pos.x() <= 1) &&
-        ((ball_pos.y() >= 8 && ball_pos.y() <= 9) || (ball_pos.y() >= 0 && ball_pos.y() <= 1))) {
+    if (field_dimensions_.our_defense_area().contains_point(ball_pos) ||
+        field_dimensions_.their_defense_area().contains_point(ball_pos) ||
+        !field_dimensions.field_rect().contains_point(ball_pos)) {
         return true;
     }
     return false;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -506,7 +506,6 @@ double Offense::distance_from_their_robots(rj_geometry::Point tail, rj_geometry:
 }
 
 bool Offense::can_steal_ball() const {
-    
     // Ball location
     rj_geometry::Point ball_position = this->last_world_state_->ball.position;
 
@@ -570,9 +569,9 @@ rj_geometry::Point Offense::calculate_best_shot() const {
 
 bool Offense::ball_in_red(WorldState* last_world_state_) {
     auto& ball_pos = last_world_state_->ball.position;
-    if (field_dimensions_.their_defense_area().contains_point(ball_pos)
-        || field_dimensions_.our_defense_area().contains_point(ball_pos)
-        || !field_dimensions_.field_rect().contains_point(ball_pos)) {
+    if (field_dimensions_.their_defense_area().contains_point(ball_pos) ||
+        field_dimensions_.our_defense_area().contains_point(ball_pos) ||
+        !field_dimensions_.field_rect().contains_point(ball_pos)) {
         return true;
     }
     return false;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -36,7 +36,7 @@ Offense::State Offense::next_state() {
 
         case SEEKING: {
             // If the ball seems "stealable", we should switch to STEALING
-            if (can_steal_ball() && !ball_in_red(last_world_state_)) {
+            if (can_steal_ball()) {
                 return STEALING;
             }
 
@@ -101,10 +101,6 @@ Offense::State Offense::next_state() {
         }
 
         case STEALING: {
-            if (ball_in_red(last_world_state_)) {
-                return SEEKING_START;
-            }
-
             // Go to possession if successful
             if (check_is_done()) {
                 return POSSESSION_START;
@@ -134,8 +130,8 @@ Offense::State Offense::next_state() {
                 return POSSESSION_START;
             }
 
-            if (ball_in_red(last_world_state_)) {
-                return SEEKING_START;
+            if (ball_in_red()) {
+                return DEFAULT;
             }
 
             // If we failed to get it in time
@@ -506,6 +502,10 @@ double Offense::distance_from_their_robots(rj_geometry::Point tail, rj_geometry:
 }
 
 bool Offense::can_steal_ball() const {
+    //Ball in red zone or not
+    if (ball_in_red()) {
+        return false;
+    }
     // Ball location
     rj_geometry::Point ball_position = this->last_world_state_->ball.position;
 
@@ -568,13 +568,12 @@ rj_geometry::Point Offense::calculate_best_shot() const {
 }
 
 // Checks whether ball is out of range for stealing/receiving
-bool Offense::ball_in_red(WorldState* last_world_state_) {
+bool Offense::ball_in_red() const {
     auto& ball_pos = last_world_state_->ball.position;
-    if (field_dimensions_.our_defense_area().contains_point(ball_pos) ||
+    return (field_dimensions_.our_defense_area().contains_point(ball_pos) ||
         field_dimensions_.their_defense_area().contains_point(ball_pos) ||
-        !field_dimensions_.field_rect().contains_point(ball_pos)) {
-        return true;
-    }
-    return false;
+        !field_dimensions_.field_rect().contains_point(ball_pos)); 
+    
+    
 }
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -37,7 +37,7 @@ Offense::State Offense::next_state() {
 
         case SEEKING: {
             // If the ball seems "stealable", we should switch to STEALING
-            if (can_steal_ball()) {
+            if (can_steal_ball() && !ball_in_goal(last_world_state_)) {
                 return STEALING;
             }
 
@@ -102,6 +102,10 @@ Offense::State Offense::next_state() {
         }
 
         case STEALING: {
+            if (ball_in_goal(last_world_state_)) {
+                return SEEKING;
+            }
+
             // Go to possession if successful
             if (check_is_done()) {
                 return POSSESSION_START;
@@ -129,6 +133,10 @@ Offense::State Offense::next_state() {
             // If we got it, cool, we have it!
             if (check_is_done() && distance_to_ball() < kOwnBallRadius) {
                 return POSSESSION_START;
+            }
+
+            if (ball_in_goal(last_world_state_)) {
+                return SEEKING;
             }
 
             // If we failed to get it in time
@@ -499,6 +507,7 @@ double Offense::distance_from_their_robots(rj_geometry::Point tail, rj_geometry:
 }
 
 bool Offense::can_steal_ball() const {
+    
     // Ball location
     rj_geometry::Point ball_position = this->last_world_state_->ball.position;
 
@@ -558,5 +567,14 @@ rj_geometry::Point Offense::calculate_best_shot() const {
         curr_point = curr_point + increment;
     }
     return best_shot;
+}
+
+bool Offense::ball_in_goal(WorldState* last_world_state_) {
+    auto& ball_pos = last_world_state_->ball.position;
+    if ((ball_pos.x() >= -1 && ball_pos.x() <= 1)
+        && ((ball_pos.y() >= 8 && ball_pos.y() <= 9) || (ball_pos.y() >= 0 && ball_pos.y() <= 1))) {
+        return true;
+    }
+    return false;
 }
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -572,7 +572,7 @@ bool Offense::ball_in_red(WorldState* last_world_state_) {
     auto& ball_pos = last_world_state_->ball.position;
     if (field_dimensions_.our_defense_area().contains_point(ball_pos) ||
         field_dimensions_.their_defense_area().contains_point(ball_pos) ||
-        !field_dimensions.field_rect().contains_point(ball_pos)) {
+        !field_dimensions_.field_rect().contains_point(ball_pos)) {
         return true;
     }
     return false;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -567,6 +567,7 @@ rj_geometry::Point Offense::calculate_best_shot() const {
     return best_shot;
 }
 
+//Checks whether ball is out of range for stealing/receiving
 bool Offense::ball_in_red(WorldState* last_world_state_) {
     auto& ball_pos = last_world_state_->ball.position;
     if (field_dimensions_.their_defense_area().contains_point(ball_pos) ||

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -232,7 +232,10 @@ private:
      */
     rj_geometry::Point calculate_best_shot() const;
 
-    bool ball_in_goal(WorldState* last_world_state_);
+    /**
+     * @return whether the ball is in an area that non-goalies cannot reach.
+    */
+    bool ball_in_red(WorldState* last_world_state_);
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -231,6 +231,8 @@ private:
      * @return the target (within the goal) that would be the most clear shot
      */
     rj_geometry::Point calculate_best_shot() const;
+
+    bool ball_in_goal(WorldState* last_world_state_);
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -234,7 +234,7 @@ private:
 
     /**
      * @return whether the ball is in an area that non-goalies cannot reach.
-    */
+     */
     bool ball_in_red(WorldState* last_world_state_);
 };
 

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -235,7 +235,7 @@ private:
     /**
      * @return whether the ball is in an area that non-goalies cannot reach.
      */
-    bool ball_in_red(WorldState* last_world_state_);
+    bool ball_in_red() const;
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -233,7 +233,6 @@ private:
      */
     rj_geometry::Point calculate_best_shot() const;
 
-
     /**
      * @return whether the ball is in an area that non-goalies cannot reach.
      */
@@ -242,7 +241,6 @@ private:
     void broadcast_seeker_request(rj_geometry::Point seeking_point, bool adding);
 
     std::unordered_map<int, rj_geometry::Point> seeker_points_;
-
 };
 
 }  // namespace strategy


### PR DESCRIPTION
## Description
Describe your pull request.
Title.
## Associated / Resolved Issue
Resolves # or [ClickUp card](link-to-clickup-card)
86ayq6wkp
## Design Documents
[Link](link-to-design-doc)

## Steps to Test
### Test Case 1: Ball going into goal area 
1. Step 1: Start a match and set the ball with velocity going through the goal area
2. Step 2: Observe the robots going out of stealing/receiving mode and into seeking mode. Should happen whenever the ball is in the red
3. Step 3: When the ball leaves the red, they should continue chasing the ball

**Expected result:**See steps 2 and 3

## Key Files to Review
Group 1: Position
 * File 1: Offense.cpp, offense.hpp
 * File 2

Group 2: planning
 * File 3: collect_path_planner
 * File 4

## Review Checklist

- [ ] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [ ] **Remove extra print statements**: Any print statements used for debugging should be removed
- [ ] **Tag reviewers**: Tag some people for review and ping them on Slack

## (Optional) Sub-issues (for drafts)
_Note: if you find yourself breaking this PR into many smaller features, it may make sense to break up the PR into logical units based on these features._
- [ ] Step 1
- [ ] Step 2
