### PR TITLE
Solo offense

### DIFF
--- a/control
+++ b/control
@@ -1,0 +1,12 @@
+max_acceleration: 1.0
+max_angular_velocity: 5.0
+max_velocity: 1.0
+rotation_kd: 0.0
+rotation_ki: 0.0
+rotation_kp: 0.0
+rotation_windup: 0
+translation_kd: 0.25
+translation_ki: 0.0005
+translation_kp: 2.0
+translation_windup: 0
+use_sim_time: false

--- a/soccer/src/soccer/CMakeLists.txt
+++ b/soccer/src/soccer/CMakeLists.txt
@@ -80,6 +80,7 @@ set(ROBOCUP_LIB_SRC
     strategy/agent/position/robot_factory_position.cpp
     strategy/agent/position/goalie.cpp
     strategy/agent/position/offense.cpp
+    strategy/agent/position/line.cpp
     strategy/agent/position/idle.cpp
     strategy/agent/position/defense.cpp
     strategy/agent/position/waller.cpp

--- a/soccer/src/soccer/CMakeLists.txt
+++ b/soccer/src/soccer/CMakeLists.txt
@@ -91,6 +91,7 @@ set(ROBOCUP_LIB_SRC
     strategy/agent/position/penalty_non_kicker.cpp
     strategy/agent/position/smartidling.cpp
     strategy/agent/position/pivot_test.cpp
+    strategy/agent/position/solo_offense.cpp
 
         )
 

--- a/soccer/src/soccer/planning/planner/line_pivot_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/line_pivot_path_planner.cpp
@@ -51,7 +51,7 @@ LinePivotPathPlanner::State LinePivotPathPlanner::next_state(const PlanRequest& 
     double vel = plan_request.world_state->get_robot(true, static_cast<int>(plan_request.shell_id))
                      .velocity.linear()
                      .mag();
-    if (current_state_ == LINE && (target_point.dist_to(current_point) < 0.3) && (vel < 0.3)) {
+    if (current_state_ == LINE && (target_point.dist_to(current_point) < 0.3) && (vel < 0.3) && (!plan_request.play_state.is_stop())) {
         return PIVOT;
     }
     if (current_state_ == PIVOT && (pivot_point.dist_to(current_point) > (dist_from_point * 5))) {

--- a/soccer/src/soccer/planning/planner/line_pivot_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/line_pivot_path_planner.cpp
@@ -51,7 +51,8 @@ LinePivotPathPlanner::State LinePivotPathPlanner::next_state(const PlanRequest& 
     double vel = plan_request.world_state->get_robot(true, static_cast<int>(plan_request.shell_id))
                      .velocity.linear()
                      .mag();
-    if (current_state_ == LINE && (target_point.dist_to(current_point) < 0.3) && (vel < 0.3) && (!plan_request.play_state.is_stop())) {
+    if (current_state_ == LINE && (target_point.dist_to(current_point) < 0.3) && (vel < 0.3) &&
+        (!plan_request.play_state.is_stop())) {
         return PIVOT;
     }
     if (current_state_ == PIVOT && (pivot_point.dist_to(current_point) > (dist_from_point * 5))) {

--- a/soccer/src/soccer/radio/radio.cpp
+++ b/soccer/src/soccer/radio/radio.cpp
@@ -49,6 +49,8 @@ void Radio::publish_robot_status(int robot_id, const rj_msgs::msg::RobotStatus& 
 }
 
 void Radio::publish_alive_robots(const rj_msgs::msg::AliveRobots& alive_robots) {
+    // SPDLOG_INFO("publishing alive robots {}", alive_robots);
+    SPDLOG_INFO("publishing alive robots");
     alive_robots_pub_->publish(alive_robots);
 }
 

--- a/soccer/src/soccer/strategy/agent/position/line.cpp
+++ b/soccer/src/soccer/strategy/agent/position/line.cpp
@@ -1,0 +1,35 @@
+#include "line.hpp"
+
+namespace strategy {
+std::optional<RobotIntent> Line::derived_get_task(RobotIntent intent) {
+    if (check_is_done()) {
+        forward_ = !forward_;
+    }
+
+    if (forward_) {
+        auto motion_command = planning::MotionCommand{
+            "path_target",
+            planning::LinearMotionInstant{
+                rj_geometry::Point{
+                    field_dimensions_.center_field_loc().x() - 1.0,
+                    field_dimensions_.center_field_loc().y() - 1.0 + robot_id_ * 0.75},
+                rj_geometry::Point{0.0, 0.0}},
+            planning::FacePoint{rj_geometry::Point{0.0,0.0}}, true};
+
+        intent.motion_command = motion_command;
+    } else {
+        auto motion_command = planning::MotionCommand{
+            "path_target",
+            planning::LinearMotionInstant{
+                rj_geometry::Point{
+                    field_dimensions_.center_field_loc().x() + 1.0,
+                    field_dimensions_.center_field_loc().y() - 1.0 + robot_id_ * 0.75},
+                rj_geometry::Point{0.0, 0.0}},
+            planning::FacePoint{rj_geometry::Point{0.0,0.0}}, true};
+
+        intent.motion_command = motion_command;
+    }
+
+    return intent;
+}
+}  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/line.hpp
+++ b/soccer/src/soccer/strategy/agent/position/line.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "position.hpp"
+#include <spdlog/spdlog.h>
+#include "rclcpp/rclcpp.hpp"
+
+
+namespace strategy {
+    class Line : public Position {
+
+        public: 
+
+        Line(int r_id) : Position{r_id, "line"} {}
+        Line(const Position& other) : Position{other} {
+            position_name_ = "Line";
+        }
+        ~Line() = default;
+        Line(const Line&) = default;
+        Line(Line&&) = default;
+        Line& operator=(const Line&) = default;
+        Line& operator=(Line&&) = default;
+
+
+        std::string get_current_state() override {
+            return "Line";
+        }
+
+        private:
+
+        std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
+
+        bool forward_ = true;
+    };
+}

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -15,7 +15,7 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
     if (current_state_ != new_state) {
         reset_timeout();
 
-        SPDLOG_INFO("Robot {}: now {}", robot_id_, state_to_name(current_state_));
+        // SPDLOG_INFO("Robot {}: now {}", robot_id_, state_to_name(current_state_));
         if (current_state_ == SEEKING) {
             broadcast_seeker_request(rj_geometry::Point{}, false);
         }

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -250,10 +250,10 @@ void RobotFactoryPosition::set_default_position() {
                                field_dimensions_.center_field_loc().y() - kBallDiameter) {
         // Offensive mode
         // Closest 2 robots on defense, rest on offense
-        if (i <= 1) {
+        if (i <= 3) {
             set_current_position<Defense>();
         } else {
-            set_current_position<Offense>();
+            set_current_position<SoloOffense>();
         }
     } else {
         // Defensive mode
@@ -261,7 +261,9 @@ void RobotFactoryPosition::set_default_position() {
         if (i <= 3) {
             set_current_position<Defense>();
         } else {
-            set_current_position<Offense>();
+            if (current_position_->get_name() != "Offense") {
+                current_position_ = std::make_unique<Offense>(robot_id_);
+            }
         }
     }
 }

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include "idle.hpp"
+#include "line.hpp"
 #include "penalty_non_kicker.hpp"
 
 namespace strategy {
@@ -17,15 +18,13 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id) : Position(r_id, "RobotFact
     }
 }
 
-std::optional<RobotIntent> RobotFactoryPosition::derived_get_task([
-    [maybe_unused]] RobotIntent intent) {
+std::optional<RobotIntent> RobotFactoryPosition::derived_get_task(
+    [[maybe_unused]] RobotIntent intent) {
     if (robot_id_ == goalie_id_) {
-        set_current_position<Goalie>();
+        set_current_position<Line>();
         return current_position_->get_task(*last_world_state_, field_dimensions_,
                                            current_play_state_);
     }
-
-    
 
     // Update our state
     process_play_state();

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -261,7 +261,7 @@ void RobotFactoryPosition::set_default_position() {
         if (i <= 3) {
             set_current_position<Defense>();
         } else {
-            set_current_position<Offense>();
+            set_current_position<SoloOffense>();
         }
     }
 }

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -25,6 +25,8 @@ std::optional<RobotIntent> RobotFactoryPosition::derived_get_task([
                                            current_play_state_);
     }
 
+    
+
     // Update our state
     process_play_state();
 

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -261,9 +261,7 @@ void RobotFactoryPosition::set_default_position() {
         if (i <= 3) {
             set_current_position<Defense>();
         } else {
-            if (current_position_->get_name() != "Offense") {
-                current_position_ = std::make_unique<Offense>(robot_id_);
-            }
+            set_current_position<Offense>();
         }
     }
 }

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
@@ -24,8 +24,9 @@
 #include "strategy/agent/position/penalty_non_kicker.hpp"
 #include "strategy/agent/position/penalty_player.hpp"
 #include "strategy/agent/position/pivot_test.hpp"
-#include "strategy/agent/position/solo_offense.hpp"
+#include "strategy/agent/position/position.hpp"
 #include "strategy/agent/position/smartidling.hpp"
+#include "strategy/agent/position/solo_offense.hpp"
 
 namespace strategy {
 

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
@@ -24,6 +24,7 @@
 #include "strategy/agent/position/penalty_non_kicker.hpp"
 #include "strategy/agent/position/penalty_player.hpp"
 #include "strategy/agent/position/pivot_test.hpp"
+#include "strategy/agent/position/solo_offense.hpp"
 #include "strategy/agent/position/position.hpp"
 #include "strategy/agent/position/smartidling.hpp"
 

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
@@ -25,7 +25,6 @@
 #include "strategy/agent/position/penalty_player.hpp"
 #include "strategy/agent/position/pivot_test.hpp"
 #include "strategy/agent/position/solo_offense.hpp"
-#include "strategy/agent/position/position.hpp"
 #include "strategy/agent/position/smartidling.hpp"
 
 namespace strategy {

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
@@ -60,12 +60,15 @@ SoloOffense::State SoloOffense::next_state() {
 }
 
 std::optional<RobotIntent> SoloOffense::state_to_task(RobotIntent intent) {
-   
     switch (current_state_) {
         case MARKER: {
-            auto marker_target_pos = last_world_state_->get_robot(false, marking_id_).pose.position();
-            auto target = marker_target_pos + (field_dimensions_.our_goal_loc() - marker_target_pos).normalized(kRobotRadius * 5); 
-            auto mark_cmd = planning::MotionCommand{"path_target", planning::LinearMotionInstant{target}, planning::FaceBall{}, true};
+            auto marker_target_pos =
+                last_world_state_->get_robot(false, marking_id_).pose.position();
+            auto target =
+                marker_target_pos +
+                (field_dimensions_.our_goal_loc() - marker_target_pos).normalized(kRobotRadius * 5);
+            auto mark_cmd = planning::MotionCommand{
+                "path_target", planning::LinearMotionInstant{target}, planning::FaceBall{}, true};
             intent.motion_command = mark_cmd;
 
             return intent;
@@ -93,9 +96,6 @@ std::optional<RobotIntent> SoloOffense::state_to_task(RobotIntent intent) {
     return intent;
 }
 
-
-
-
 rj_geometry::Point SoloOffense::calculate_best_shot() const {
     // Goal location
     rj_geometry::Point their_goal_pos = field_dimensions_.their_goal_loc();
@@ -120,7 +120,8 @@ rj_geometry::Point SoloOffense::calculate_best_shot() const {
     return best_shot;
 }
 
-double SoloOffense::distance_from_their_robots(rj_geometry::Point tail, rj_geometry::Point head) const {
+double SoloOffense::distance_from_their_robots(rj_geometry::Point tail,
+                                               rj_geometry::Point head) const {
     rj_geometry::Point vec = head - tail;
     auto& their_robots = this->last_world_state_->their_robots;
 

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
@@ -1,0 +1,146 @@
+#include "solo_offense.hpp"
+
+namespace strategy {
+
+SoloOffense::SoloOffense(int r_id) : Position{r_id, "SoloOffense"} {}
+
+std::optional<RobotIntent> SoloOffense::derived_get_task(RobotIntent intent) {
+    // Get next state, and if different, reset clock
+    State new_state = next_state();
+    if (new_state != current_state_) {
+        SPDLOG_INFO("New State: {}", std::to_string(static_cast<int>(new_state)));
+    }
+    current_state_ = new_state;
+
+    // Calculate task based on state
+    return state_to_task(intent);
+}
+
+std::string SoloOffense::get_current_state() {
+    return std::string{"Solo Offense"} + std::to_string(static_cast<int>(current_state_));
+}
+
+SoloOffense::State SoloOffense::next_state() {
+    // handle transitions between current state
+    double closest_dist = std::numeric_limits<double>::infinity();
+    auto current_point = last_world_state_->ball.position;
+
+    for (int i = 0; i < 6; i++) {
+        RobotState robot = last_world_state_->get_robot(false, i);
+        rj_geometry::Point opp_pos = robot.pose.position();
+        auto robot_dist = opp_pos.dist_to(current_point);
+        if (robot_dist < closest_dist) {
+            marking_id_ = i;
+            closest_dist = robot_dist;
+        }
+    }
+
+    // SPDLOG_INFO("Closest dist: {}, i-{}", closest_dist,  marking_id_);
+
+    if (closest_dist < (0.5)) {
+        return MARKER;
+    }
+    switch (current_state_) {
+        case MARKER: {
+            return TO_BALL;
+        }
+        case TO_BALL: {
+            if (check_is_done()) {
+                target_ = calculate_best_shot();
+                return KICK;
+            }
+        }
+        case KICK: {
+            if (check_is_done()) {
+                return TO_BALL;
+            }
+        }
+    }
+    return current_state_;
+}
+
+std::optional<RobotIntent> SoloOffense::state_to_task(RobotIntent intent) {
+   
+    switch (current_state_) {
+        case MARKER: {
+            auto marker_target_pos = last_world_state_->get_robot(false, marking_id_).pose.position();
+            auto target = marker_target_pos + (field_dimensions_.our_goal_loc() - marker_target_pos).normalized(kRobotRadius * 5); 
+            auto mark_cmd = planning::MotionCommand{"path_target", planning::LinearMotionInstant{target}, planning::FaceBall{}, true};
+            intent.motion_command = mark_cmd;
+
+            return intent;
+        }
+        case TO_BALL: {
+            planning::LinearMotionInstant target{field_dimensions_.their_goal_loc()};
+            auto pivot_cmd = planning::MotionCommand{"line_pivot", target, planning::FaceTarget{},
+                                                     false, last_world_state_->ball.position};
+            pivot_cmd.pivot_radius = kRobotRadius * 2.5;
+            intent.motion_command = pivot_cmd;
+            return intent;
+        }
+        case KICK: {
+            auto line_kick_cmd =
+                planning::MotionCommand{"line_kick", planning::LinearMotionInstant{target_}};
+
+            intent.motion_command = line_kick_cmd;
+            intent.shoot_mode = RobotIntent::ShootMode::KICK;
+            intent.trigger_mode = RobotIntent::TriggerMode::ON_BREAK_BEAM;
+            intent.kick_speed = 4.0;
+
+            return intent;
+        }
+    }
+    return intent;
+}
+
+
+
+
+rj_geometry::Point SoloOffense::calculate_best_shot() const {
+    // Goal location
+    rj_geometry::Point their_goal_pos = field_dimensions_.their_goal_loc();
+    double goal_width = field_dimensions_.goal_width();  // 1.0 meters
+
+    // Ball location
+    rj_geometry::Point ball_position = this->last_world_state_->ball.position;
+
+    rj_geometry::Point best_shot = their_goal_pos;
+    double best_distance = -1.0;
+    rj_geometry::Point increment(0.05, 0);
+    rj_geometry::Point curr_point =
+        their_goal_pos - rj_geometry::Point(goal_width / 2.0, 0) + increment;
+    for (int i = 0; i < 19; i++) {
+        double distance = distance_from_their_robots(ball_position, curr_point);
+        if (distance > best_distance) {
+            best_distance = distance;
+            best_shot = curr_point;
+        }
+        curr_point = curr_point + increment;
+    }
+    return best_shot;
+}
+
+double SoloOffense::distance_from_their_robots(rj_geometry::Point tail, rj_geometry::Point head) const {
+    rj_geometry::Point vec = head - tail;
+    auto& their_robots = this->last_world_state_->their_robots;
+
+    double min_angle = -0.5;
+    for (auto enemy : their_robots) {
+        rj_geometry::Point enemy_vec = enemy.pose.position() - tail;
+        if (enemy_vec.dot(vec) < 0) {
+            continue;
+        }
+        auto projection = (enemy_vec.dot(vec) / vec.dot(vec));
+        enemy_vec = enemy_vec - (projection)*vec;
+        double distance = enemy_vec.mag();
+        if (distance < (kRobotRadius + kBallRadius)) {
+            return -1.0;
+        }
+        double angle = distance / projection;
+        if ((min_angle < 0) || (angle < min_angle)) {
+            min_angle = angle;
+        }
+    }
+    return min_angle;
+}
+}  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
@@ -2,6 +2,10 @@
 
 namespace strategy {
 
+SoloOffense::SoloOffense(const Position& other) : Position{other} {
+    position_name_ = "SoloOffense";
+}
+
 SoloOffense::SoloOffense(int r_id) : Position{r_id, "SoloOffense"} {}
 
 std::optional<RobotIntent> SoloOffense::derived_get_task(RobotIntent intent) {

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.hpp
@@ -22,6 +22,7 @@ namespace strategy {
 
 class SoloOffense : public Position {
 public:
+    SoloOffense(const Position& other);
     SoloOffense(int r_id);
     ~SoloOffense() override = default;
     SoloOffense(const SoloOffense& other) = default;

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <chrono>
+#include <cmath>
+#include <string>
+#include <unordered_map>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <spdlog/spdlog.h>
+
+#include <rj_msgs/action/robot_move.hpp>
+
+#include "planning/instant.hpp"
+#include "position.hpp"
+#include "rj_common/time.hpp"
+#include "rj_constants/constants.hpp"
+#include "rj_geometry/geometry_conversions.hpp"
+#include "rj_geometry/point.hpp"
+
+namespace strategy {
+
+class SoloOffense : public Position {
+public:
+    SoloOffense(int r_id);
+    ~SoloOffense() override = default;
+    SoloOffense(const SoloOffense& other) = default;
+    SoloOffense(SoloOffense&& other) = default;
+
+    std::string get_current_state() override;
+
+private:
+    /**
+     * @brief Overriden from Position. Calls next_state and then state_to_task on each tick.
+     */
+    std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
+
+    enum State { TO_BALL, KICK, MARKER };
+
+    State current_state_ = TO_BALL;
+
+    rj_geometry::Point target_;
+
+    int marking_id_;
+
+    /**
+     * @return what the state should be right now. called on each get_task tick
+     */
+    State next_state();
+
+    /**
+     * @return the task to execute. called on each get_task tick AFTER next_state()
+     */
+    std::optional<RobotIntent> state_to_task(RobotIntent intent);
+
+    rj_geometry::Point calculate_best_shot() const;
+    double distance_from_their_robots(rj_geometry::Point tail, rj_geometry::Point head) const;
+};
+
+}  // namespace strategy


### PR DESCRIPTION
## Description
Due to Comp 2024 limitation of shoot-only offense, this PR creates a 'Solo Offense' Position that assigns one robot to constantly follow the ball, either playing defense on another robot that has the ball or taking a shot toward the opposition goal.

Dependent on #2240, probably needs to be rebased once that is merged into ros2. 


## Steps to Test
1. Force one robot to be SoloOffense through RobotFactory Position
2. make run-sim

**Expected result:**???
The robot should track the ball and go for shots if the ball is not in possession by the opposing team.

## Key Files to Review
 * solo_offense.cpp
 * solo_offense.hpp

## Review Checklist

- [ ] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [ ] **Remove extra print statements**: Any print statements used for debugging should be removed
- [ ] **Tag reviewers**: Tag some people for review and ping them on Slack

## (Optional) Sub-issues (for drafts)
_Note: if you find yourself breaking this PR into many smaller features, it may make sense to break up the PR into logical units based on these features._
- [ ] Step 1
- [ ] Step 2
