### PR TITLE
Position Override created to allow position testing

### DIFF
--- a/rj_msgs/CMakeLists.txt
+++ b/rj_msgs/CMakeLists.txt
@@ -52,6 +52,7 @@ rosidl_generate_interfaces(
   msg/TeamInfo.msg
   msg/Trajectory.msg
   msg/WorldState.msg
+  msg/OverridePosition.msg
 
   # Communication
   msg/AgentRequest.msg

--- a/rj_msgs/msg/OverridePosition.msg
+++ b/rj_msgs/msg/OverridePosition.msg
@@ -1,0 +1,6 @@
+# Contains two unsigned ints - The robot ID to override and the position
+# to set for that ID, based on the enum OverridingPositions,
+# which is contained in soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
+
+uint32 robot_id
+uint32 overriding_position

--- a/rj_msgs/msg/OverridePosition.msg
+++ b/rj_msgs/msg/OverridePosition.msg
@@ -1,4 +1,4 @@
-# Contains two unsigned ints - The robot ID to override and the position
+# Contains unsigned int overriding_position -  the position
 # to set for that ID, based on the enum OverridingPositions,
 # which is contained in soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
 

--- a/rj_msgs/msg/OverridePosition.msg
+++ b/rj_msgs/msg/OverridePosition.msg
@@ -2,5 +2,4 @@
 # to set for that ID, based on the enum OverridingPositions,
 # which is contained in soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
 
-uint32 robot_id
 uint32 overriding_position

--- a/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
+++ b/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
@@ -3,26 +3,26 @@
 #include <string>
 #include <vector>
 
-namespace Strategy
-{
-    /*
-        OverridingPositions refers to the positions that can be manually set in the UI.
-        Normally, all robots are set to Auto. If you want to add a new position, add a new value
-        to this enum before LENGTH, add a string to the overriding_position_labels vector in main_window.hpp,
-        and add a case to the check_for_position_override method in RobotFactoryPosition.
-    */
-    enum OverridingPositions {
-        AUTO,
-        OFFENSE,
-        DEFENSE,
-        FREE_KICKER,
-        PENALTY_PLAYER,
-        PENALTY_NON_KICKER,
-        SOLO_OFFENSE,
-        SMART_IDLE,
-        ZONER,
-        IDLE,
-        LENGTH, //Do not remove
-    };
+namespace Strategy {
+/*
+    OverridingPositions refers to the positions that can be manually set in the UI.
+    Normally, all robots are set to Auto. If you want to add a new position, add a new value
+    to this enum before LENGTH, add a string to the overriding_position_labels vector in
+   main_window.hpp, and add a case to the check_for_position_override method in
+   RobotFactoryPosition.
+*/
+enum OverridingPositions {
+    AUTO,
+    OFFENSE,
+    DEFENSE,
+    FREE_KICKER,
+    PENALTY_PLAYER,
+    PENALTY_NON_KICKER,
+    SOLO_OFFENSE,
+    SMART_IDLE,
+    ZONER,
+    IDLE,
+    LENGTH,  // Do not remove
+};
 
-} // namespace Strategy
+}  // namespace Strategy

--- a/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
+++ b/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace Strategy
+{
+    enum OverridingPositions {
+        AUTO = 0,
+        OFFENSE = 1,
+        DEFENSE = 2,
+        GOAL_KICKER = 3,
+        MARKER = 4,
+        PENALTY_PLAYER = 5,
+        SEEKER = 6,
+        WALLER = 7,
+    };
+} // namespace Strategy

--- a/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
+++ b/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
@@ -1,4 +1,7 @@
 #pragma once
+#include <map>
+#include <vector>
+#include <string>
 
 namespace Strategy
 {
@@ -6,10 +9,13 @@ namespace Strategy
         AUTO = 0,
         OFFENSE = 1,
         DEFENSE = 2,
-        GOAL_KICKER = 3,
-        MARKER = 4,
-        PENALTY_PLAYER = 5,
-        SEEKER = 6,
-        WALLER = 7,
+        FREE_KICKER = 3,
+        PENALTY_PLAYER = 4,
+        PENALTY_NON_KICKER = 5,
+        SOLO_OFFENSE = 6,
+        SMART_IDLE = 7,
+        ZONER = 8,
+        IDLE = 9,
     };
+
 } // namespace Strategy

--- a/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
+++ b/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
@@ -1,21 +1,28 @@
 #pragma once
 #include <map>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace Strategy
 {
+    /*
+        OverridingPositions refers to the positions that can be manually set in the UI.
+        Normally, all robots are set to Auto. If you want to add a new position, add a new value
+        to this enum before LENGTH, add a string to the overriding_position_labels vector in main_window.hpp,
+        and add a case to the check_for_position_override method in RobotFactoryPosition.
+    */
     enum OverridingPositions {
-        AUTO = 0,
-        OFFENSE = 1,
-        DEFENSE = 2,
-        FREE_KICKER = 3,
-        PENALTY_PLAYER = 4,
-        PENALTY_NON_KICKER = 5,
-        SOLO_OFFENSE = 6,
-        SMART_IDLE = 7,
-        ZONER = 8,
-        IDLE = 9,
+        AUTO,
+        OFFENSE,
+        DEFENSE,
+        FREE_KICKER,
+        PENALTY_PLAYER,
+        PENALTY_NON_KICKER,
+        SOLO_OFFENSE,
+        SMART_IDLE,
+        ZONER,
+        IDLE,
+        LENGTH, //Do not remove
     };
 
 } // namespace Strategy

--- a/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
+++ b/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
@@ -22,7 +22,8 @@ enum OverridingPositions {
     SMART_IDLE,
     ZONER,
     IDLE,
-    LENGTH,  // Do not remove - Placeholder to act as the "length" of the enum, or the number of elements it contains. Should always be at end of enum
+    LENGTH,  // Do not remove - Placeholder to act as the "length" of the enum, or the number of
+             // elements it contains. Should always be at end of enum
 };
 
 }  // namespace Strategy

--- a/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
+++ b/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
@@ -7,7 +7,7 @@ namespace Strategy {
 /*
     OverridingPositions refers to the positions that can be manually set in the UI.
     Normally, all robots are set to Auto. If you want to add a new position, add a new value
-    to this enum before LENGTH, add a string to the overriding_position_labels vector in
+    to this enum, add a string to the overriding_position_labels vector in
    main_window.hpp, and add a case to the check_for_position_override method in
    RobotFactoryPosition.
 */
@@ -22,8 +22,6 @@ enum OverridingPositions {
     SMART_IDLE,
     ZONER,
     IDLE,
-    LENGTH,  // Do not remove - Placeholder to act as the "length" of the enum, or the number of
-             // elements it contains. Should always be at end of enum
 };
 
 }  // namespace Strategy

--- a/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
+++ b/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
@@ -8,7 +8,7 @@ namespace Strategy {
     OverridingPositions refers to the positions that can be manually set in the UI.
     Normally, all robots are set to Auto. If you want to add a new position, add a new value
     to this enum, add a string to the overriding_position_labels vector in
-   main_window.hpp, and add a case to the check_for_position_override method in
+   main_window.hpp, and add a case to the set_position_override_if_requested method in
    RobotFactoryPosition.
 */
 enum OverridingPositions {

--- a/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
+++ b/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
@@ -22,7 +22,7 @@ enum OverridingPositions {
     SMART_IDLE,
     ZONER,
     IDLE,
-    LENGTH,  // Do not remove
+    LENGTH,  // Do not remove - Placeholder to act as the "length" of the enum, or the number of elements it contains. Should always be at end of enum
 };
 
 }  // namespace Strategy

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -18,7 +18,7 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id) : Position(r_id, "RobotFact
 
     std::string node_name{"robot_factory_position_"};
     _node = std::make_shared<rclcpp::Node>(node_name.append(std::to_string(robot_id_)));
-    test_play_sub_ = _node->create_subscription<rj_msgs::msg::OverridePosition>(
+    override_play_sub_ = _node->create_subscription<rj_msgs::msg::OverridePosition>(
         "override_position_for_robot", 1,
         [this](const rj_msgs::msg::OverridePosition::SharedPtr msg) { test_play_callback(msg); });
     _executor.add_node(_node);
@@ -127,11 +127,6 @@ void RobotFactoryPosition::handle_ready() {
 }
 
 void RobotFactoryPosition::update_position() {
-    // if (test_play_position_ == Strategy::OverridingPositions::OFFENSE) {
-    //  SPDLOG_INFO("OFFENSE SELECTED");
-    // set_current_position<Offense>();
-    // return;
-    //}
     bool manual_position_set = check_for_position_override();
     if (manual_position_set) return;
 
@@ -358,17 +353,17 @@ void RobotFactoryPosition::test_play_callback(
     const rj_msgs::msg::OverridePosition::SharedPtr message) {
     if (message->robot_id == this->robot_id_ &&
         message->overriding_position < Strategy::OverridingPositions::LENGTH) {
-        test_play_position_ =
+        override_play_position_ =
             static_cast<Strategy::OverridingPositions>(message->overriding_position);
     }
 }
 
 /**
- * Checks test_play_position_, which automatically updates when an override is set.
+ * Checks override_play_position_, which automatically updates when an override is set.
  * If it is anything but auto, set the current position to that position and return true.
  */
 bool RobotFactoryPosition::check_for_position_override() {
-    switch (test_play_position_) {
+    switch (override_play_position_) {
         case Strategy::OverridingPositions::OFFENSE: {
             set_current_position<Offense>();
             return true;

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -16,11 +16,11 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id) : Position(r_id, "RobotFact
         current_position_ = std::make_unique<Defense>(robot_id_);
     }
 
-    std::string node_name {"robot_factory_position_"};
+    std::string node_name{"robot_factory_position_"};
     _node = std::make_shared<rclcpp::Node>(node_name.append(std::to_string(robot_id_)));
     test_play_sub_ = _node->create_subscription<rj_msgs::msg::OverridePosition>(
-        "override_position_for_robot", 1, [this](const rj_msgs::msg::OverridePosition::SharedPtr msg){test_play_callback(msg);}
-    );
+        "override_position_for_robot", 1,
+        [this](const rj_msgs::msg::OverridePosition::SharedPtr msg) { test_play_callback(msg); });
     _executor.add_node(_node);
     _executor_thread = std::thread([this]() { _executor.spin(); });
 }
@@ -127,10 +127,10 @@ void RobotFactoryPosition::handle_ready() {
 }
 
 void RobotFactoryPosition::update_position() {
-    //if (test_play_position_ == Strategy::OverridingPositions::OFFENSE) {
-      //  SPDLOG_INFO("OFFENSE SELECTED");
-        //set_current_position<Offense>();
-        //return;
+    // if (test_play_position_ == Strategy::OverridingPositions::OFFENSE) {
+    //  SPDLOG_INFO("OFFENSE SELECTED");
+    // set_current_position<Offense>();
+    // return;
     //}
     bool manual_position_set = check_for_position_override();
     if (manual_position_set) return;
@@ -354,18 +354,20 @@ std::string RobotFactoryPosition::get_current_state() {
     return current_position_->get_current_state();
 }
 
-void RobotFactoryPosition::test_play_callback(const rj_msgs::msg::OverridePosition::SharedPtr message) {
-    if (message->robot_id == this->robot_id_ && message->overriding_position < Strategy::OverridingPositions::LENGTH) {
-        test_play_position_ = static_cast<Strategy::OverridingPositions>(message->overriding_position);
+void RobotFactoryPosition::test_play_callback(
+    const rj_msgs::msg::OverridePosition::SharedPtr message) {
+    if (message->robot_id == this->robot_id_ &&
+        message->overriding_position < Strategy::OverridingPositions::LENGTH) {
+        test_play_position_ =
+            static_cast<Strategy::OverridingPositions>(message->overriding_position);
     }
 }
 
 /**
  * Checks test_play_position_, which automatically updates when an override is set.
  * If it is anything but auto, set the current position to that position and return true.
-*/
+ */
 bool RobotFactoryPosition::check_for_position_override() {
-
     switch (test_play_position_) {
         case Strategy::OverridingPositions::OFFENSE: {
             set_current_position<Offense>();
@@ -398,7 +400,7 @@ bool RobotFactoryPosition::check_for_position_override() {
         case Strategy::OverridingPositions::ZONER: {
             set_current_position<Zoner>();
             return true;
-        } 
+        }
         case Strategy::OverridingPositions::IDLE: {
             set_current_position<Idle>();
             return true;

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -15,6 +15,14 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id) : Position(r_id, "RobotFact
     } else {
         current_position_ = std::make_unique<Defense>(robot_id_);
     }
+
+    std::string node_name {"robot_factory_position_"};
+    _node = std::make_shared<rclcpp::Node>(node_name.append(std::to_string(robot_id_)));
+    test_play_sub_ = _node->create_subscription<rj_msgs::msg::OverridePosition>(
+        "override_position_for_robot", 1, [this](const rj_msgs::msg::OverridePosition::SharedPtr msg){test_play_callback(msg);}
+    );
+    _executor.add_node(_node);
+    _executor_thread = std::thread([this]() { _executor.spin(); });
 }
 
 std::optional<RobotIntent> RobotFactoryPosition::derived_get_task([
@@ -119,6 +127,14 @@ void RobotFactoryPosition::handle_ready() {
 }
 
 void RobotFactoryPosition::update_position() {
+    //if (test_play_position_ == Strategy::OverridingPositions::OFFENSE) {
+      //  SPDLOG_INFO("OFFENSE SELECTED");
+        //set_current_position<Offense>();
+        //return;
+    //}
+    bool manual_position_set = check_for_position_override();
+    if (manual_position_set) return;
+
     switch (current_play_state_.state()) {
         case PlayState::State::Playing: {
             // We just became regular playing.
@@ -336,6 +352,61 @@ void RobotFactoryPosition::revive() { current_position_->revive(); }
 
 std::string RobotFactoryPosition::get_current_state() {
     return current_position_->get_current_state();
+}
+
+void RobotFactoryPosition::test_play_callback(const rj_msgs::msg::OverridePosition::SharedPtr message) {
+    if (message->robot_id == this->robot_id_) {
+        test_play_position_ = static_cast<Strategy::OverridingPositions>(message->overriding_position);
+    }
+}
+
+/**
+ * Checks test_play_position_, which automatically updates when an override is set.
+ * If it is anything but auto, set the current position to that position and return true.
+*/
+bool RobotFactoryPosition::check_for_position_override() {
+
+    switch (test_play_position_) {
+        case Strategy::OverridingPositions::OFFENSE: {
+            set_current_position<Offense>();
+            return true;
+        }
+        case Strategy::OverridingPositions::DEFENSE: {
+            set_current_position<Defense>();
+            return true;
+        }
+        case Strategy::OverridingPositions::FREE_KICKER: {
+            set_current_position<FreeKicker>();
+            return true;
+        }
+        case Strategy::OverridingPositions::PENALTY_PLAYER: {
+            set_current_position<PenaltyPlayer>();
+            return true;
+        }
+        case Strategy::OverridingPositions::PENALTY_NON_KICKER: {
+            set_current_position<PenaltyNonKicker>();
+            return true;
+        }
+        case Strategy::OverridingPositions::SMART_IDLE: {
+            set_current_position<SmartIdle>();
+            return true;
+        }
+        case Strategy::OverridingPositions::SOLO_OFFENSE: {
+            set_current_position<SoloOffense>();
+            return true;
+        }
+        case Strategy::OverridingPositions::ZONER: {
+            set_current_position<Zoner>();
+            return true;
+        } 
+        case Strategy::OverridingPositions::IDLE: {
+            set_current_position<Idle>();
+            return true;
+        }
+        default: {
+            return false;
+        }
+    }
 }
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -355,7 +355,7 @@ std::string RobotFactoryPosition::get_current_state() {
 }
 
 void RobotFactoryPosition::test_play_callback(const rj_msgs::msg::OverridePosition::SharedPtr message) {
-    if (message->robot_id == this->robot_id_) {
+    if (message->robot_id == this->robot_id_ && message->overriding_position < Strategy::OverridingPositions::LENGTH) {
         test_play_position_ = static_cast<Strategy::OverridingPositions>(message->overriding_position);
     }
 }

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -129,8 +129,8 @@ void RobotFactoryPosition::handle_ready() {
 void RobotFactoryPosition::update_position() {
     bool manual_position_set = check_for_position_override();
     if (manual_position_set) {
-        return
-    };
+        return;
+    }
 
     switch (current_play_state_.state()) {
         case PlayState::State::Playing: {

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -128,7 +128,9 @@ void RobotFactoryPosition::handle_ready() {
 
 void RobotFactoryPosition::update_position() {
     bool manual_position_set = check_for_position_override();
-    if (manual_position_set) return;
+    if (manual_position_set) {
+        return
+    };
 
     switch (current_play_state_.state()) {
         case PlayState::State::Playing: {

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -353,7 +353,8 @@ std::string RobotFactoryPosition::get_current_state() {
 
 void RobotFactoryPosition::test_play_callback(
     const rj_msgs::msg::OverridePosition::SharedPtr message) {
-    override_play_position_ = static_cast<Strategy::OverridingPositions>(message->overriding_position);
+    override_play_position_ =
+        static_cast<Strategy::OverridingPositions>(message->overriding_position);
 }
 
 /**

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -19,7 +19,7 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id) : Position(r_id, "RobotFact
     std::string node_name{"robot_factory_position_"};
     _node = std::make_shared<rclcpp::Node>(node_name.append(std::to_string(robot_id_)));
     override_play_sub_ = _node->create_subscription<rj_msgs::msg::OverridePosition>(
-        "override_position_for_robot", 1,
+        "override_position_for_robot_" + std::to_string(robot_id_), 1,
         [this](const rj_msgs::msg::OverridePosition::SharedPtr msg) { test_play_callback(msg); });
     _executor.add_node(_node);
     _executor_thread = std::thread([this]() { _executor.spin(); });
@@ -353,10 +353,7 @@ std::string RobotFactoryPosition::get_current_state() {
 
 void RobotFactoryPosition::test_play_callback(
     const rj_msgs::msg::OverridePosition::SharedPtr message) {
-    if (message->robot_id == this->robot_id_) {
-        override_play_position_ =
-            static_cast<Strategy::OverridingPositions>(message->overriding_position);
-    }
+    override_play_position_ = static_cast<Strategy::OverridingPositions>(message->overriding_position);
 }
 
 /**

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -19,7 +19,7 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id) : Position(r_id, "RobotFact
     std::string node_name{"robot_factory_position_"};
     _node = std::make_shared<rclcpp::Node>(node_name.append(std::to_string(robot_id_)));
     override_play_sub_ = _node->create_subscription<rj_msgs::msg::OverridePosition>(
-        "override_position_for_robot_" + std::to_string(robot_id_), 1,
+        "override_position/robot_" + std::to_string(robot_id_), 1,
         [this](const rj_msgs::msg::OverridePosition::SharedPtr msg) { test_play_callback(msg); });
     _executor.add_node(_node);
     _executor_thread = std::thread([this]() { _executor.spin(); });

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -127,7 +127,7 @@ void RobotFactoryPosition::handle_ready() {
 }
 
 void RobotFactoryPosition::update_position() {
-    bool manual_position_set = check_for_position_override();
+    bool manual_position_set = set_position_override_if_requested();
     if (manual_position_set) {
         return;
     }
@@ -361,7 +361,7 @@ void RobotFactoryPosition::test_play_callback(
  * Checks override_play_position_, which automatically updates when an override is set.
  * If it is anything but auto, set the current position to that position and return true.
  */
-bool RobotFactoryPosition::check_for_position_override() {
+bool RobotFactoryPosition::set_position_override_if_requested() {
     switch (override_play_position_) {
         case Strategy::OverridingPositions::OFFENSE: {
             set_current_position<Offense>();

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -351,8 +351,7 @@ std::string RobotFactoryPosition::get_current_state() {
 
 void RobotFactoryPosition::test_play_callback(
     const rj_msgs::msg::OverridePosition::SharedPtr message) {
-    if (message->robot_id == this->robot_id_ &&
-        message->overriding_position < Strategy::OverridingPositions::LENGTH) {
+    if (message->robot_id == this->robot_id_) {
         override_play_position_ =
             static_cast<Strategy::OverridingPositions>(message->overriding_position);
     }

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
@@ -113,11 +113,11 @@ private:
     std::unique_ptr<Position> current_position_;
 
     // subscription for test mode - Allows position overriding
-    rclcpp::Subscription<rj_msgs::msg::OverridePosition>::SharedPtr test_play_sub_;
+    rclcpp::Subscription<rj_msgs::msg::OverridePosition>::SharedPtr override_play_sub_;
     rclcpp::executors::SingleThreadedExecutor _executor;
     std::thread _executor_thread;
     void test_play_callback(const rj_msgs::msg::OverridePosition::SharedPtr message);
-    Strategy::OverridingPositions test_play_position_{Strategy::OverridingPositions::AUTO};
+    Strategy::OverridingPositions override_play_position_{Strategy::OverridingPositions::AUTO};
     rclcpp::Node::SharedPtr _node;
 
     std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
@@ -10,9 +10,9 @@
 #include <rj_msgs/action/robot_move.hpp>
 
 #include "game_state.hpp"
+#include "overriding_positions.hpp"
 #include "planning/instant.hpp"
 #include "position.hpp"
-#include "overriding_positions.hpp"
 #include "rj_common/field_dimensions.hpp"
 #include "rj_common/time.hpp"
 #include "rj_constants/constants.hpp"
@@ -112,12 +112,12 @@ public:
 private:
     std::unique_ptr<Position> current_position_;
 
-    //subscription for test mode - Allows position overriding
+    // subscription for test mode - Allows position overriding
     rclcpp::Subscription<rj_msgs::msg::OverridePosition>::SharedPtr test_play_sub_;
     rclcpp::executors::SingleThreadedExecutor _executor;
     std::thread _executor_thread;
     void test_play_callback(const rj_msgs::msg::OverridePosition::SharedPtr message);
-    Strategy::OverridingPositions test_play_position_ {Strategy::OverridingPositions::AUTO};
+    Strategy::OverridingPositions test_play_position_{Strategy::OverridingPositions::AUTO};
     rclcpp::Node::SharedPtr _node;
 
     std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
@@ -12,15 +12,18 @@
 #include "game_state.hpp"
 #include "planning/instant.hpp"
 #include "position.hpp"
+#include "overriding_positions.hpp"
 #include "rj_common/field_dimensions.hpp"
 #include "rj_common/time.hpp"
 #include "rj_constants/constants.hpp"
 #include "rj_geometry/geometry_conversions.hpp"
+#include "rj_msgs/msg/override_position.hpp"
 #include "strategy/agent/position/defense.hpp"
 #include "strategy/agent/position/free_kicker.hpp"
 #include "strategy/agent/position/goal_kicker.hpp"
 #include "strategy/agent/position/goalie.hpp"
 #include "strategy/agent/position/offense.hpp"
+#include "strategy/agent/position/overriding_positions.hpp"
 #include "strategy/agent/position/penalty_non_kicker.hpp"
 #include "strategy/agent/position/penalty_player.hpp"
 #include "strategy/agent/position/pivot_test.hpp"
@@ -109,6 +112,14 @@ public:
 private:
     std::unique_ptr<Position> current_position_;
 
+    //subscription for test mode - Allows position overriding
+    rclcpp::Subscription<rj_msgs::msg::OverridePosition>::SharedPtr test_play_sub_;
+    rclcpp::executors::SingleThreadedExecutor _executor;
+    std::thread _executor_thread;
+    void test_play_callback(const rj_msgs::msg::OverridePosition::SharedPtr message);
+    Strategy::OverridingPositions test_play_position_ {Strategy::OverridingPositions::AUTO};
+    rclcpp::Node::SharedPtr _node;
+
     std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
 
     bool am_closest_kicker();
@@ -153,6 +164,8 @@ private:
             current_position_ = std::make_unique<Pos>(*current_position_);
         }
     }
+
+    bool check_for_position_override();
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
@@ -166,7 +166,7 @@ private:
         }
     }
 
-    bool check_for_position_override();
+    bool set_position_override_if_requested();
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
@@ -123,7 +123,7 @@ std::optional<RobotIntent> SoloOffense::state_to_task(RobotIntent intent) {
             planning::LinearMotionInstant target{calculate_best_shot()};
             // planning::LinearMotionInstant target{last_world_state_->ball.position};
             auto kick_cmd =
-                planning::MotionCommand{"path_target", target, planning::FaceTarget{}, true};
+                planning::MotionCommand{"line_kick", target, planning::FaceTarget{}, true};
             intent.motion_command = kick_cmd;
             intent.shoot_mode = RobotIntent::ShootMode::KICK;
             intent.trigger_mode = RobotIntent::TriggerMode::ON_BREAK_BEAM;

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -17,6 +17,7 @@
 
 #include <rj_common/qt_utils.hpp>
 #include <rj_constants/topic_names.hpp>
+#include <rj_msgs/msg/override_position.hpp>
 #include <rj_protos/grSim_Packet.pb.h>
 #include <rj_protos/grSim_Replacement.pb.h>
 #include <ui/style_sheet_manager.hpp>
@@ -49,6 +50,7 @@ void calcMinimumWidth(QWidget* widget, const QString& text) {
     widget->setMinimumWidth(rect.width());
 }
 
+// TODO: Set up the UI objects and bind them to methods
 MainWindow::MainWindow(Processor* processor, bool has_external_ref, QWidget* parent)
     : QMainWindow(parent),
       _updateCount(0),
@@ -185,8 +187,17 @@ MainWindow::MainWindow(Processor* processor, bool has_external_ref, QWidget* par
     _set_game_settings = _node->create_client<rj_msgs::srv::SetGameSettings>(
         config_server::topics::kGameSettingsSrv);
 
+    test_play_pub_ = _node->create_publisher<rj_msgs::msg::OverridePosition>(
+        "override_position_for_robot", 1);
+
     _executor.add_node(_node);
     _executor_thread = std::thread([this]() { _executor.spin(); });
+
+    // Connect up all the test position buttons and dropdowns to their listeners
+    for (int i = 0; i < kNumShells; ++i) {
+        robot_pos_selectors[i] = findChild<QComboBox*>(QString::fromStdString("robotPosition_" + std::to_string(i)));
+        position_reset_buttons[i] = findChild<QPushButton*>(QString::fromStdString("positionReset_" + std::to_string(i)));
+    }
 }
 
 void MainWindow::initialize() {
@@ -196,6 +207,7 @@ void MainWindow::initialize() {
     } else {
         _ui.actionTeamYellow->trigger();
     }
+
 
     logFileChanged();
 
@@ -1033,6 +1045,15 @@ void MainWindow::on_actionUse_Multiple_Joysticks_toggled(bool value) {
 
 void MainWindow::on_goalieID_currentIndexChanged(int value) {
     update_cache(_game_settings.request_goalie_id, value - 1, &_game_settings_valid);
+        //This is a convoluted scheme to figure out who the goalie is
+    //May not be necessary later
+    QString goalieNum = _ui.goalieID->currentText();
+    bool goalieNumIsInt {false};
+    int goalieInt = goalieNum.toInt(&goalieNumIsInt);
+    if (goalieNumIsInt)
+        setGoalieDropdown(goalieInt);
+    else 
+        setGoalieDropdown(-1);
 }
 
 ////////////////
@@ -1146,3 +1167,145 @@ void MainWindow::updateDebugLayers(const LogFrame& frame) {
         _ui.debugLayers->sortItems();
     }
 }
+
+/**
+ * The following methods are event listeners for the manual position assignments.
+ * TODO: implement all of these
+ */
+void MainWindow::on_positionReset_0_clicked() { onResetButtonClicked(0); }
+
+void MainWindow::on_positionReset_1_clicked() { onResetButtonClicked(1); }
+
+void MainWindow::on_positionReset_2_clicked() { onResetButtonClicked(2); }
+
+void MainWindow::on_positionReset_3_clicked() { onResetButtonClicked(3); }
+
+void MainWindow::on_positionReset_4_clicked() { onResetButtonClicked(4); }
+
+void MainWindow::on_positionReset_5_clicked() { onResetButtonClicked(5); }
+
+void MainWindow::on_positionReset_6_clicked() { onResetButtonClicked(6); }
+
+void MainWindow::on_positionReset_7_clicked() { onResetButtonClicked(7); }
+
+void MainWindow::on_positionReset_8_clicked() { onResetButtonClicked(8); }
+
+void MainWindow::on_positionReset_9_clicked() { onResetButtonClicked(9); }
+
+void MainWindow::on_positionReset_10_clicked() { onResetButtonClicked(10); }
+
+void MainWindow::on_positionReset_11_clicked() { onResetButtonClicked(11); }
+
+void MainWindow::on_positionReset_12_clicked() { onResetButtonClicked(12); }
+
+void MainWindow::on_positionReset_13_clicked() { onResetButtonClicked(13); }
+
+void MainWindow::on_positionReset_14_clicked() { onResetButtonClicked(14); }
+
+void MainWindow::on_positionReset_15_clicked() { onResetButtonClicked(15); }
+
+void MainWindow::on_robotPosition_0_currentIndexChanged(int value) {
+    onPositionDropdownChanged(0, value);
+}
+
+void MainWindow::on_robotPosition_1_currentIndexChanged(int value) {
+    onPositionDropdownChanged(1, value);
+}
+
+void MainWindow::on_robotPosition_2_currentIndexChanged(int value) {
+    onPositionDropdownChanged(2, value);
+}
+
+void MainWindow::on_robotPosition_3_currentIndexChanged(int value) {
+    onPositionDropdownChanged(3, value);
+}
+
+void MainWindow::on_robotPosition_4_currentIndexChanged(int value) {
+    onPositionDropdownChanged(4, value);
+}
+
+void MainWindow::on_robotPosition_5_currentIndexChanged(int value) {
+    onPositionDropdownChanged(5, value);
+}
+
+void MainWindow::on_robotPosition_6_currentIndexChanged(int value) {
+    onPositionDropdownChanged(6, value);
+}
+
+void MainWindow::on_robotPosition_7_currentIndexChanged(int value) {
+    onPositionDropdownChanged(7, value);
+}
+
+void MainWindow::on_robotPosition_8_currentIndexChanged(int value) {
+    onPositionDropdownChanged(8, value);
+}
+
+void MainWindow::on_robotPosition_9_currentIndexChanged(int value) {
+    onPositionDropdownChanged(9, value);
+}
+
+void MainWindow::on_robotPosition_10_currentIndexChanged(int value) {
+    onPositionDropdownChanged(10, value);
+}
+
+void MainWindow::on_robotPosition_11_currentIndexChanged(int value) {
+    onPositionDropdownChanged(11, value);
+}
+
+void MainWindow::on_robotPosition_12_currentIndexChanged(int value) {
+    onPositionDropdownChanged(12, value);
+}
+
+void MainWindow::on_robotPosition_13_currentIndexChanged(int value) {
+    onPositionDropdownChanged(13, value);
+}
+
+void MainWindow::on_robotPosition_14_currentIndexChanged(int value) {
+    onPositionDropdownChanged(14, value);
+}
+
+void MainWindow::on_robotPosition_15_currentIndexChanged(int value) {
+    onPositionDropdownChanged(15, value);
+}
+
+void MainWindow::onResetButtonClicked(int robot) {
+    rj_msgs::msg::OverridePosition message;
+    message.robot_id = robot;
+    message.overriding_position = 0;
+
+    test_play_pub_->publish(message);
+    position_reset_buttons.at(robot)->setEnabled(false);
+    robot_pos_selectors.at(robot)->setCurrentIndex(0);
+}
+
+void MainWindow::onPositionDropdownChanged(int robot, int position_number) {
+    //This is a convoluted scheme to figure out who the goalie is
+    //May not be necessary later
+    QString goalieNum = _ui.goalieID->currentText();
+    bool goalieNumIsInt {false};
+    int goalieInt = goalieNum.toInt(&goalieNumIsInt);
+    if (!goalieNumIsInt || goalieInt != robot) {
+        rj_msgs::msg::OverridePosition message;
+        message.robot_id = robot;
+        message.overriding_position = position_number;
+
+        test_play_pub_->publish(message);
+        if (position_number != 0) {
+            position_reset_buttons.at(robot)->setEnabled(true);
+        } else {
+            position_reset_buttons.at(robot)->setEnabled(false);
+        }
+    }
+}
+
+void MainWindow::setGoalieDropdown(int robot) {
+    for (int i = 0; i < robot_pos_selectors.size(); ++i) {
+        if (i != robot) {
+            robot_pos_selectors.at(i)->setEnabled(true);
+        } else {
+            robot_pos_selectors.at(i)->setCurrentIndex(0);
+            robot_pos_selectors.at(i)->setEnabled(false);
+        }
+    }
+}
+

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -208,6 +208,12 @@ void MainWindow::initialize() {
         _ui.actionTeamYellow->trigger();
     }
 
+    for (int i = 0; i < kNumShells; i++) {
+        robot_pos_selectors[i]->clear();
+        for (int j = 0; j < overriding_position_labels.size(); j++) {
+            robot_pos_selectors[i]->addItem(QString::fromStdString(overriding_position_labels[j]));
+        }
+    }
 
     logFileChanged();
 

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -208,12 +208,7 @@ void MainWindow::initialize() {
         _ui.actionTeamYellow->trigger();
     }
 
-    for (int i = 0; i < kNumShells; i++) {
-        robot_pos_selectors[i]->clear();
-        for (int j = 0; j < overriding_position_labels.size(); j++) {
-            robot_pos_selectors[i]->addItem(QString::fromStdString(overriding_position_labels[j]));
-        }
-    }
+    populate_override_position_dropdowns();
 
     logFileChanged();
 
@@ -1311,6 +1306,15 @@ void MainWindow::setGoalieDropdown(int robot) {
         } else {
             robot_pos_selectors.at(i)->setCurrentIndex(0);
             robot_pos_selectors.at(i)->setEnabled(false);
+        }
+    }
+}
+
+void MainWindow::populate_override_position_dropdowns() {
+    for (int i = 0; i < kNumShells; i++) {
+        robot_pos_selectors[i]->clear();
+        for (int j = 0; j < overriding_position_labels.size(); j++) {
+            robot_pos_selectors[i]->addItem(QString::fromStdString(overriding_position_labels[j]));
         }
     }
 }

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -187,16 +187,18 @@ MainWindow::MainWindow(Processor* processor, bool has_external_ref, QWidget* par
     _set_game_settings = _node->create_client<rj_msgs::srv::SetGameSettings>(
         config_server::topics::kGameSettingsSrv);
 
-    test_play_pub_ = _node->create_publisher<rj_msgs::msg::OverridePosition>(
-        "override_position_for_robot", 1);
+    test_play_pub_ =
+        _node->create_publisher<rj_msgs::msg::OverridePosition>("override_position_for_robot", 1);
 
     _executor.add_node(_node);
     _executor_thread = std::thread([this]() { _executor.spin(); });
 
     // Connect up all the test position buttons and dropdowns to their listeners
     for (int i = 0; i < kNumShells; ++i) {
-        robot_pos_selectors[i] = findChild<QComboBox*>(QString::fromStdString("robotPosition_" + std::to_string(i)));
-        position_reset_buttons[i] = findChild<QPushButton*>(QString::fromStdString("positionReset_" + std::to_string(i)));
+        robot_pos_selectors[i] =
+            findChild<QComboBox*>(QString::fromStdString("robotPosition_" + std::to_string(i)));
+        position_reset_buttons[i] =
+            findChild<QPushButton*>(QString::fromStdString("positionReset_" + std::to_string(i)));
     }
 }
 
@@ -1046,14 +1048,14 @@ void MainWindow::on_actionUse_Multiple_Joysticks_toggled(bool value) {
 
 void MainWindow::on_goalieID_currentIndexChanged(int value) {
     update_cache(_game_settings.request_goalie_id, value - 1, &_game_settings_valid);
-        //This is a convoluted scheme to figure out who the goalie is
-    //May not be necessary later
+    // This is a convoluted scheme to figure out who the goalie is
+    // May not be necessary later
     QString goalieNum = _ui.goalieID->currentText();
-    bool goalieNumIsInt {false};
+    bool goalieNumIsInt{false};
     int goalieInt = goalieNum.toInt(&goalieNumIsInt);
     if (goalieNumIsInt)
         setGoalieDropdown(goalieInt);
-    else 
+    else
         setGoalieDropdown(-1);
 }
 
@@ -1280,10 +1282,10 @@ void MainWindow::onResetButtonClicked(int robot) {
 }
 
 void MainWindow::onPositionDropdownChanged(int robot, int position_number) {
-    //This is a convoluted scheme to figure out who the goalie is
-    //May not be necessary later
+    // This is a convoluted scheme to figure out who the goalie is
+    // May not be necessary later
     QString goalieNum = _ui.goalieID->currentText();
-    bool goalieNumIsInt {false};
+    bool goalieNumIsInt{false};
     int goalieInt = goalieNum.toInt(&goalieNumIsInt);
     if (!goalieNumIsInt || goalieInt != robot) {
         rj_msgs::msg::OverridePosition message;
@@ -1306,6 +1308,7 @@ void MainWindow::setGoalieDropdown(int robot) {
         } else {
             robot_pos_selectors.at(i)->setCurrentIndex(0);
             robot_pos_selectors.at(i)->setEnabled(false);
+            onResetButtonClicked(i);
         }
     }
 }
@@ -1318,4 +1321,3 @@ void MainWindow::populate_override_position_dropdowns() {
         }
     }
 }
-

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -52,7 +52,6 @@ void calcMinimumWidth(QWidget* widget, const QString& text) {
     widget->setMinimumWidth(rect.width());
 }
 
-// TODO: Set up the UI objects and bind them to methods
 MainWindow::MainWindow(Processor* processor, bool has_external_ref, QWidget* parent)
     : QMainWindow(parent),
       _updateCount(0),

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -1053,10 +1053,11 @@ void MainWindow::on_goalieID_currentIndexChanged(int value) {
     bool goalieNumIsInt{false};
     int goalieInt = goalieNum.toInt(&goalieNumIsInt);
     current_goalie_num_ = goalieInt;
-    if (goalieNumIsInt)
+    if (goalieNumIsInt) {
         setGoalieDropdown(goalieInt);
-    else
+    } else {
         setGoalieDropdown(-1);
+    }
 }
 
 ////////////////

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -1050,7 +1050,7 @@ void MainWindow::on_actionUse_Multiple_Joysticks_toggled(bool value) {
 void MainWindow::on_goalieID_currentIndexChanged(int value) {
     update_cache(_game_settings.request_goalie_id, value - 1, &_game_settings_valid);
     QString goalieNum = _ui.goalieID->currentText();
-    bool goalieNumIsInt{false};
+    bool goalieNumIsInt{false}; // TODO: Better type conversion? - QT5 Requires bool in its toInt.
     int goalieInt = goalieNum.toInt(&goalieNumIsInt);
     current_goalie_num_ = goalieInt;
     if (goalieNumIsInt) {

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -190,9 +190,8 @@ MainWindow::MainWindow(Processor* processor, bool has_external_ref, QWidget* par
 
     // Publishers to signal when a manual position override is occurring
     for (int i = 0; i < 16; ++i) {
-        override_play_pubs_.push_back(
-            _node->create_publisher<rj_msgs::msg::OverridePosition>("override_position_for_robot_" + std::to_string(i), 1)
-        );
+        override_play_pubs_.push_back(_node->create_publisher<rj_msgs::msg::OverridePosition>(
+            "override_position_for_robot_" + std::to_string(i), 1));
     }
 
     _executor.add_node(_node);
@@ -1054,7 +1053,7 @@ void MainWindow::on_actionUse_Multiple_Joysticks_toggled(bool value) {
 void MainWindow::on_goalieID_currentIndexChanged(int value) {
     update_cache(_game_settings.request_goalie_id, value - 1, &_game_settings_valid);
     QString goalieNum = _ui.goalieID->currentText();
-    bool goalieNumIsInt{false}; // TODO: Better type conversion? - QT5 Requires bool in its toInt.
+    bool goalieNumIsInt{false};  // TODO: Better type conversion? - QT5 Requires bool in its toInt.
     int goalieInt = goalieNum.toInt(&goalieNumIsInt);
     current_goalie_num_ = goalieInt;
     if (goalieNumIsInt) {

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -1176,7 +1176,7 @@ void MainWindow::updateDebugLayers(const LogFrame& frame) {
  * The following methods are event listeners for the manual position assignments.
  * In the QT5 event handling system, these methods are automatically connected to the
  * QObject with the relevant name due to their naming scheme and their labels as Q_SLOT functions.
- * 
+ *
  * For this reason, all of these methods are REQUIRED by the UI - Consolidating them into one method
  * produces unnecessary complications.
  */
@@ -1211,7 +1211,6 @@ void MainWindow::on_positionReset_13_clicked() { onResetButtonClicked(13); }
 void MainWindow::on_positionReset_14_clicked() { onResetButtonClicked(14); }
 
 void MainWindow::on_positionReset_15_clicked() { onResetButtonClicked(15); }
-
 
 void MainWindow::on_robotPosition_0_currentIndexChanged(int value) {
     onPositionDropdownChanged(0, value);

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -191,7 +191,7 @@ MainWindow::MainWindow(Processor* processor, bool has_external_ref, QWidget* par
     // Publishers to signal when a manual position override is occurring
     for (int i = 0; i < 16; ++i) {
         override_play_pubs_.push_back(_node->create_publisher<rj_msgs::msg::OverridePosition>(
-            "override_position_for_robot_" + std::to_string(i), 1));
+            "override_position/robot_" + std::to_string(i), 1));
     }
 
     _executor.add_node(_node);

--- a/soccer/src/soccer/ui/main_window.cpp
+++ b/soccer/src/soccer/ui/main_window.cpp
@@ -188,8 +188,12 @@ MainWindow::MainWindow(Processor* processor, bool has_external_ref, QWidget* par
     _set_game_settings = _node->create_client<rj_msgs::srv::SetGameSettings>(
         config_server::topics::kGameSettingsSrv);
 
-    override_play_pub_ =
-        _node->create_publisher<rj_msgs::msg::OverridePosition>("override_position_for_robot", 1);
+    // Publishers to signal when a manual position override is occurring
+    for (int i = 0; i < 16; ++i) {
+        override_play_pubs_.push_back(
+            _node->create_publisher<rj_msgs::msg::OverridePosition>("override_position_for_robot_" + std::to_string(i), 1)
+        );
+    }
 
     _executor.add_node(_node);
     _executor_thread = std::thread([this]() { _executor.spin(); });
@@ -1278,10 +1282,9 @@ void MainWindow::on_robotPosition_15_currentIndexChanged(int value) {
 
 void MainWindow::onResetButtonClicked(int robot) {
     rj_msgs::msg::OverridePosition message;
-    message.robot_id = robot;
     message.overriding_position = 0;
 
-    override_play_pub_->publish(message);
+    override_play_pubs_.at(robot)->publish(message);
     position_reset_buttons.at(robot)->setEnabled(false);
     robot_pos_selectors.at(robot)->setCurrentIndex(0);
 }
@@ -1289,10 +1292,9 @@ void MainWindow::onResetButtonClicked(int robot) {
 void MainWindow::onPositionDropdownChanged(int robot, int position_number) {
     if (current_goalie_num_ != robot) {
         rj_msgs::msg::OverridePosition message;
-        message.robot_id = robot;
         message.overriding_position = position_number;
 
-        override_play_pub_->publish(message);
+        override_play_pubs_.at(robot)->publish(message);
         if (position_number != 0) {
             position_reset_buttons.at(robot)->setEnabled(true);
         } else {

--- a/soccer/src/soccer/ui/main_window.hpp
+++ b/soccer/src/soccer/ui/main_window.hpp
@@ -198,6 +198,7 @@ private Q_SLOTS:
     void on_positionReset_13_clicked();
     void on_positionReset_14_clicked();
     void on_positionReset_15_clicked();
+    
 
 Q_SIGNALS:
     // signal used to let widgets that we're viewing a different log frame now
@@ -220,6 +221,8 @@ private:
 
     Processor* const _processor;
     bool _has_external_ref;
+
+    int current_goalie_num_ {0};
 
     // Log history, copied from Logger.
     // This is used by other controls to get log data without having to copy it
@@ -249,7 +252,6 @@ private:
      * Callback when a reset button is clicked
      */
     void onResetButtonClicked(int robot);
-    // TODO: Add a publisher and a subscriber to implement these
 
     // Tree items that are not in LogFrame
     QTreeWidgetItem* _frameNumberItem{};
@@ -296,7 +298,7 @@ private:
     rclcpp::Node::SharedPtr _node;
     rclcpp::Client<rj_msgs::srv::QuickCommands>::SharedPtr _quick_commands_srv;
     rclcpp::Client<rj_msgs::srv::SetGameSettings>::SharedPtr _set_game_settings;
-    rclcpp::Publisher<rj_msgs::msg::OverridePosition>::SharedPtr test_play_pub_;
+    rclcpp::Publisher<rj_msgs::msg::OverridePosition>::SharedPtr override_play_pub_;
     rclcpp::executors::SingleThreadedExecutor _executor;
     std::thread _executor_thread;
 

--- a/soccer/src/soccer/ui/main_window.hpp
+++ b/soccer/src/soccer/ui/main_window.hpp
@@ -314,7 +314,16 @@ private:
     rj_msgs::msg::GameSettings _game_settings;
     bool _game_settings_valid = false;
 
-    // sets robot override position when a dropdown is clicked
-
-    // Resets the position of the given robot
+    std::vector<std::string> overriding_position_labels {
+        "Auto",
+        "Offense",
+        "Defense",
+        "Free Kicker",
+        "Penalty Player",
+        "Penalty Non-Kicker",
+        "Solo Offense",
+        "Smart Idle",
+        "Zoner",
+        "Idle"
+    };
 };

--- a/soccer/src/soccer/ui/main_window.hpp
+++ b/soccer/src/soccer/ui/main_window.hpp
@@ -326,4 +326,6 @@ private:
         "Zoner",
         "Idle"
     };
+
+    void populate_override_position_dropdowns();
 };

--- a/soccer/src/soccer/ui/main_window.hpp
+++ b/soccer/src/soccer/ui/main_window.hpp
@@ -6,6 +6,7 @@
 #include <QComboBox>
 #include <QMainWindow>
 #include <QPushButton>
+#include <QComboBox>
 #include <QTime>
 #include <QTimer>
 #include <QtGui/QStandardItemModel>
@@ -15,10 +16,12 @@
 #include <rj_msgs/srv/quick_commands.hpp>
 #include <rj_msgs/srv/quick_restart.hpp>
 #include <rj_msgs/srv/set_game_settings.hpp>
+#include <rj_msgs/msg/override_position.hpp>
 
 #include "field_view.hpp"
 #include "game_state.hpp"
 #include "processor.hpp"
+#include "strategy/agent/position/overriding_positions.hpp"
 #include "ui_MainWindow.h"
 
 #include "rc-fshare/rtp.hpp"
@@ -77,8 +80,6 @@ public:
     QTimer updateTimer;
 
     void setUseRefChecked(bool use_ref);
-
-    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr test_play_pub_;
 
 private Q_SLOTS:
     void addLayer(int i, const QString& name, bool checked);
@@ -164,6 +165,41 @@ private Q_SLOTS:
     void on_fastBlue_clicked();
     void on_fastYellow_clicked();
 
+    // Robot Position Dropdowns and Reset Buttons
+    void on_robotPosition_0_currentIndexChanged(int value);
+    void on_robotPosition_1_currentIndexChanged(int value);
+    void on_robotPosition_2_currentIndexChanged(int value);
+    void on_robotPosition_3_currentIndexChanged(int value);
+    void on_robotPosition_4_currentIndexChanged(int value);
+    void on_robotPosition_5_currentIndexChanged(int value);
+    void on_robotPosition_6_currentIndexChanged(int value);
+    void on_robotPosition_7_currentIndexChanged(int value);
+    void on_robotPosition_8_currentIndexChanged(int value);
+    void on_robotPosition_9_currentIndexChanged(int value);
+    void on_robotPosition_10_currentIndexChanged(int value);
+    void on_robotPosition_11_currentIndexChanged(int value);
+    void on_robotPosition_12_currentIndexChanged(int value);
+    void on_robotPosition_13_currentIndexChanged(int value);
+    void on_robotPosition_14_currentIndexChanged(int value);
+    void on_robotPosition_15_currentIndexChanged(int value);
+
+    void on_positionReset_0_clicked();
+    void on_positionReset_1_clicked();
+    void on_positionReset_2_clicked();
+    void on_positionReset_3_clicked();
+    void on_positionReset_4_clicked();
+    void on_positionReset_5_clicked();
+    void on_positionReset_6_clicked();
+    void on_positionReset_7_clicked();
+    void on_positionReset_8_clicked();
+    void on_positionReset_9_clicked();
+    void on_positionReset_10_clicked();
+    void on_positionReset_11_clicked();
+    void on_positionReset_12_clicked();
+    void on_positionReset_13_clicked();
+    void on_positionReset_14_clicked();
+    void on_positionReset_15_clicked();
+
 Q_SIGNALS:
     // signal used to let widgets that we're viewing a different log frame now
     int historyLocationChanged(int value);
@@ -195,6 +231,26 @@ private:
     // This is used specificially via StripChart and ProtobufTree
     // To export a larger amount of data.
     std::vector<std::shared_ptr<Packet::LogFrame>> _longHistory{};
+
+    // Arrays containing dropdown and reset button UI objects
+    std::array<QComboBox*, kNumShells> robot_pos_selectors{};
+    std::array<QPushButton*, kNumShells> position_reset_buttons{};
+
+    // Methods to update positions and broadcast those changes
+    /*
+     * Sets which dropdown represents the goalie — disabling it and ensuring the previous goalie
+     * dropdown is re-enabled.
+     */
+    void setGoalieDropdown(int robot);
+    /*
+     * Callback when a dropdown is changed (whether by user or program)
+     */
+    void onPositionDropdownChanged(int robot, int position_number);
+    /*
+     * Callback when a reset button is clicked
+     */
+    void onResetButtonClicked(int robot);
+    // TODO: Add a publisher and a subscriber to implement these
 
     // Tree items that are not in LogFrame
     QTreeWidgetItem* _frameNumberItem{};
@@ -241,6 +297,7 @@ private:
     rclcpp::Node::SharedPtr _node;
     rclcpp::Client<rj_msgs::srv::QuickCommands>::SharedPtr _quick_commands_srv;
     rclcpp::Client<rj_msgs::srv::SetGameSettings>::SharedPtr _set_game_settings;
+    rclcpp::Publisher<rj_msgs::msg::OverridePosition>::SharedPtr test_play_pub_;
     rclcpp::executors::SingleThreadedExecutor _executor;
     std::thread _executor_thread;
 
@@ -256,4 +313,8 @@ private:
 
     rj_msgs::msg::GameSettings _game_settings;
     bool _game_settings_valid = false;
+
+    // sets robot override position when a dropdown is clicked
+
+    // Resets the position of the given robot
 };

--- a/soccer/src/soccer/ui/main_window.hpp
+++ b/soccer/src/soccer/ui/main_window.hpp
@@ -6,17 +6,16 @@
 #include <QComboBox>
 #include <QMainWindow>
 #include <QPushButton>
-#include <QComboBox>
 #include <QTime>
 #include <QTimer>
 #include <QtGui/QStandardItemModel>
 #include <rclcpp/rclcpp.hpp>
 
 #include <rj_convert/ros_convert.hpp>
+#include <rj_msgs/msg/override_position.hpp>
 #include <rj_msgs/srv/quick_commands.hpp>
 #include <rj_msgs/srv/quick_restart.hpp>
 #include <rj_msgs/srv/set_game_settings.hpp>
-#include <rj_msgs/msg/override_position.hpp>
 
 #include "field_view.hpp"
 #include "game_state.hpp"
@@ -314,18 +313,11 @@ private:
     rj_msgs::msg::GameSettings _game_settings;
     bool _game_settings_valid = false;
 
-    std::vector<std::string> overriding_position_labels {
-        "Auto",
-        "Offense",
-        "Defense",
-        "Free Kicker",
-        "Penalty Player",
-        "Penalty Non-Kicker",
-        "Solo Offense",
-        "Smart Idle",
-        "Zoner",
-        "Idle"
-    };
+    std::vector<std::string> overriding_position_labels{"Auto",           "Offense",
+                                                        "Defense",        "Free Kicker",
+                                                        "Penalty Player", "Penalty Non-Kicker",
+                                                        "Solo Offense",   "Smart Idle",
+                                                        "Zoner",          "Idle"};
 
     void populate_override_position_dropdowns();
 };

--- a/soccer/src/soccer/ui/main_window.hpp
+++ b/soccer/src/soccer/ui/main_window.hpp
@@ -198,7 +198,6 @@ private Q_SLOTS:
     void on_positionReset_13_clicked();
     void on_positionReset_14_clicked();
     void on_positionReset_15_clicked();
-    
 
 Q_SIGNALS:
     // signal used to let widgets that we're viewing a different log frame now
@@ -222,7 +221,7 @@ private:
     Processor* const _processor;
     bool _has_external_ref;
 
-    int current_goalie_num_ {0};
+    int current_goalie_num_{0};
 
     // Log history, copied from Logger.
     // This is used by other controls to get log data without having to copy it

--- a/soccer/src/soccer/ui/main_window.hpp
+++ b/soccer/src/soccer/ui/main_window.hpp
@@ -297,7 +297,7 @@ private:
     rclcpp::Node::SharedPtr _node;
     rclcpp::Client<rj_msgs::srv::QuickCommands>::SharedPtr _quick_commands_srv;
     rclcpp::Client<rj_msgs::srv::SetGameSettings>::SharedPtr _set_game_settings;
-    rclcpp::Publisher<rj_msgs::msg::OverridePosition>::SharedPtr override_play_pub_;
+    std::vector<rclcpp::Publisher<rj_msgs::msg::OverridePosition>::SharedPtr> override_play_pubs_ {};
     rclcpp::executors::SingleThreadedExecutor _executor;
     std::thread _executor_thread;
 

--- a/soccer/src/soccer/ui/main_window.hpp
+++ b/soccer/src/soccer/ui/main_window.hpp
@@ -297,7 +297,7 @@ private:
     rclcpp::Node::SharedPtr _node;
     rclcpp::Client<rj_msgs::srv::QuickCommands>::SharedPtr _quick_commands_srv;
     rclcpp::Client<rj_msgs::srv::SetGameSettings>::SharedPtr _set_game_settings;
-    std::vector<rclcpp::Publisher<rj_msgs::msg::OverridePosition>::SharedPtr> override_play_pubs_ {};
+    std::vector<rclcpp::Publisher<rj_msgs::msg::OverridePosition>::SharedPtr> override_play_pubs_{};
     rclcpp::executors::SingleThreadedExecutor _executor;
     std::thread _executor_thread;
 

--- a/soccer/src/soccer/ui/qt/MainWindow.ui
+++ b/soccer/src/soccer/ui/qt/MainWindow.ui
@@ -1962,6 +1962,1171 @@
            </item>
           </layout>
          </widget>
+         <widget class="QWidget" name="positionsTab">
+          <attribute name="title">
+           <string>Positions</string>
+          </attribute>
+          <widget class="QWidget" name="gridLayoutWidget">
+           <property name="geometry">
+            <rect>
+             <x>-11</x>
+             <y>-1</y>
+             <width>371</width>
+             <height>671</height>
+            </rect>
+           </property>
+           <layout class="QGridLayout" name="positions_gridLayout" rowstretch="0" columnstretch="0,0,0,0" rowminimumheight="0">
+            <property name="leftMargin">
+             <number>11</number>
+            </property>
+            <property name="topMargin">
+             <number>11</number>
+            </property>
+            <property name="rightMargin">
+             <number>11</number>
+            </property>
+            <property name="bottomMargin">
+             <number>11</number>
+            </property>
+            <item row="0" column="1">
+             <widget class="QLabel" name="positionsLabel_0">
+              <property name="text">
+               <string>Robot 0</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QComboBox" name="robotPosition_0">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="QPushButton" name="positionReset_0">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="1" column="1">
+             <widget class="QLabel" name="positionsLabel_1">
+              <property name="text">
+               <string>Robot 1</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QComboBox" name="robotPosition_1">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="1" column="3">
+             <widget class="QPushButton" name="positionReset_1">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="2" column="1">
+             <widget class="QLabel" name="positionsLabel_2">
+              <property name="text">
+               <string>Robot 2</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="2">
+             <widget class="QComboBox" name="robotPosition_2">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="2" column="3">
+             <widget class="QPushButton" name="positionReset_2">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="3" column="1">
+             <widget class="QLabel" name="positionsLabel_3">
+              <property name="text">
+               <string>Robot 3</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="2">
+             <widget class="QComboBox" name="robotPosition_3">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="3" column="3">
+             <widget class="QPushButton" name="positionReset_3">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="4" column="1">
+             <widget class="QLabel" name="positionsLabel_4">
+              <property name="text">
+               <string>Robot 4</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="2">
+             <widget class="QComboBox" name="robotPosition_4">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="4" column="3">
+             <widget class="QPushButton" name="positionReset_4">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="5" column="1">
+             <widget class="QLabel" name="positionsLabel_5">
+              <property name="text">
+               <string>Robot 5</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="2">
+             <widget class="QComboBox" name="robotPosition_5">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="5" column="3">
+             <widget class="QPushButton" name="positionReset_5">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="6" column="1">
+             <widget class="QLabel" name="positionsLabel_6">
+              <property name="text">
+               <string>Robot 6</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="2">
+             <widget class="QComboBox" name="robotPosition_6">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="6" column="3">
+             <widget class="QPushButton" name="positionReset_6">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="7" column="1">
+             <widget class="QLabel" name="positionsLabel_7">
+              <property name="text">
+               <string>Robot 7</string>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="2">
+             <widget class="QComboBox" name="robotPosition_7">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="7" column="3">
+             <widget class="QPushButton" name="positionReset_7">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="8" column="1">
+             <widget class="QLabel" name="positionsLabel_8">
+              <property name="text">
+               <string>Robot 8</string>
+              </property>
+             </widget>
+            </item>
+            <item row="8" column="2">
+             <widget class="QComboBox" name="robotPosition_8">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="8" column="3">
+             <widget class="QPushButton" name="positionReset_8">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="9" column="1">
+             <widget class="QLabel" name="positionsLabel_9">
+              <property name="text">
+               <string>Robot 9</string>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="2">
+             <widget class="QComboBox" name="robotPosition_9">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="9" column="3">
+             <widget class="QPushButton" name="positionReset_9">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="10" column="1">
+             <widget class="QLabel" name="positionsLabel_10">
+              <property name="text">
+               <string>Robot 10</string>
+              </property>
+             </widget>
+            </item>
+            <item row="10" column="2">
+             <widget class="QComboBox" name="robotPosition_10">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="10" column="3">
+             <widget class="QPushButton" name="positionReset_10">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="11" column="1">
+             <widget class="QLabel" name="positionsLabel_11">
+              <property name="text">
+               <string>Robot 11</string>
+              </property>
+             </widget>
+            </item>
+            <item row="11" column="2">
+             <widget class="QComboBox" name="robotPosition_11">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="11" column="3">
+             <widget class="QPushButton" name="positionReset_11">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="12" column="1">
+             <widget class="QLabel" name="positionsLabel_12">
+              <property name="text">
+               <string>Robot 12</string>
+              </property>
+             </widget>
+            </item>
+            <item row="12" column="2">
+             <widget class="QComboBox" name="robotPosition_12">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="12" column="3">
+             <widget class="QPushButton" name="positionReset_12">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="13" column="1">
+             <widget class="QLabel" name="positionsLabel_13">
+              <property name="text">
+               <string>Robot 13</string>
+              </property>
+             </widget>
+            </item>
+            <item row="13" column="2">
+             <widget class="QComboBox" name="robotPosition_13">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="13" column="3">
+             <widget class="QPushButton" name="positionReset_13">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="14" column="1">
+             <widget class="QLabel" name="positionsLabel_14">
+              <property name="text">
+               <string>Robot 14</string>
+              </property>
+             </widget>
+            </item>
+            <item row="14" column="2">
+             <widget class="QComboBox" name="robotPosition_14">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="14" column="3">
+             <widget class="QPushButton" name="positionReset_14">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+            <item row="15" column="1">
+             <widget class="QLabel" name="positionsLabel_15">
+              <property name="text">
+               <string>Robot 15</string>
+              </property>
+             </widget>
+            </item>
+            <item row="15" column="2">
+             <widget class="QComboBox" name="robotPosition_15">
+              <property name="currentText">
+               <string>Auto</string>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <item>
+               <property name="text">
+                <string>Auto</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Offense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Defense</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Goal Kicker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Marker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Penalty Player</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Seeker</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Waller</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="15" column="3">
+             <widget class="QPushButton" name="positionReset_15">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+
+           </layout>
+          </widget>
+         </widget>
         </widget>
        </widget>
       </item>


### PR DESCRIPTION
## Description
Describe your pull request.
Created a way to override a robot's current position for testing purposes.

## Associated / Resolved Issue
Resolves # or [ClickUp card](link-to-clickup-card)

## Design Documents
[Link](link-to-design-doc)

## Steps to Test
### Test Case 1
1. Step 1 - Run the stack, and under the tab Positions on the right of the main window, set any robot to any position other than auto
2. Step 2 - Hit the reset button for that robot
3. Step 3 - Change the goalie number
4. Step 4 - Set any robot to any position other than auto, then set the goalie number to that robot

**Expected result:**???
1. The robot selected should start behaving consistent with the position selected
2. The robot should go back to whatever its default position is
3. The robot moving out of "Goalie" status should change to Auto, and the robot selected should become a goalie.
4. The robot should start by changing its position, then  when it becomes the Goalie, the previous goalie should become auto, the UI should allow you to select that robot's position, and the UI should switch the new goalie's override to "Auto" and gray out the combo box so you can no longer change that robot's position.

## Key Files to Review
Group 1 - namespace strategy
 * File 1 robot_factory_position.hpp and cpp
 * File 2 overriding_positions.hpp

Group 2 - UI
 * File 3 main_window.cpp
 * File 4 MainWindow.ui

## Review Checklist

- [ ] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [ ] **Remove extra print statements**: Any print statements used for debugging should be removed
- [ ] **Tag reviewers**: Tag some people for review and ping them on Slack

## (Optional) Sub-issues (for drafts)
_Note: if you find yourself breaking this PR into many smaller features, it may make sense to break up the PR into logical units based on these features._
- [ ] Step 1
- [ ] Step 2
