### PR TITLE
add ros env vars to source script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 
 # build directories
 /build
-/install
 /gmon.out
 *.swp
 /.settings

--- a/install/env.sh
+++ b/install/env.sh
@@ -1,0 +1,5 @@
+# Here are some useful environment variables for setting up a consistent ROS environment 
+# some information on this can be found here: https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html 
+export ROS_DOMAIN_ID=19 # this is a random number, it's just important to keep it consistent across shells 
+export ROS_LOCALHOST_ONLY=1 # for our stack specifically, this is quite helpful. 
+

--- a/makefile
+++ b/makefile
@@ -72,11 +72,11 @@ run-sim:
 # run our stack with default flags
 # TODO: actually name our software stack something
 run-our-stack:
-	ROS_LOCALHOST_ONLY=1 ros2 launch rj_robocup soccer.launch.py run_sim:=True
+	ros2 launch rj_robocup soccer.launch.py run_sim:=True
 
 # run sim with external referee (SSL Game Controller)
 run-sim-external:
-	ROS_LOCALHOST_ONLY=1 ros2 launch rj_robocup soccer.launch.py run_sim:=True use_internal_ref:=False
+	ros2 launch rj_robocup soccer.launch.py run_sim:=True use_internal_ref:=False
 
 run-sim-ex: run-sim-external
 
@@ -95,7 +95,7 @@ run-manual:
 
 # same as run-real, with different server port
 run-alt-real:
-	ROS_DOMAIN_ID=2 ros2 launch rj_robocup soccer.launch.py run_sim:=False use_sim_radio:=False server_port:=25564 use_internal_ref:=False team_name:=AltRoboJackets team_flag:=-b
+	ros2 launch rj_robocup soccer.launch.py run_sim:=False use_sim_radio:=False server_port:=25564 use_internal_ref:=False team_name:=AltRoboJackets team_flag:=-b
 
 # run sim2play (requires external referee)
 run-sim2play:

--- a/source.bash
+++ b/source.bash
@@ -9,3 +9,6 @@ if [[ $SHELL == *"zsh"* ]]; then
     source /opt/ros/humble/setup.zsh
     source install/setup.zsh
 fi
+
+source install/env.sh
+


### PR DESCRIPTION
## Description
ROS2 enviornment was messed up -- `ros2 topic list` would not result in anything in a new terminal. I identified that ros expects certain env vars to be the same in all shells that are talking about the "same" ros processes

## Associated / Resolved Issue
Resolves [ClickUp card](https://app.clickup.com/t/86b2ca857)

## Steps to Test
### Test Case 1
1. Ideally on a fresh install
2. make run-sim in one terminal
3. source && ros2 topic list in another terminal

**Expected result:** you see all the topics

## Key Files to Review
 * env.sh has the new envs
 * do you like where I put the source command? (source.bash)
 
## Questions
* should we think about our naming convention with .zsh .bash etc?
* source.bash is pretty shell-agnostic

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack

