### PR TITLE
Escape obstacle fix

### DIFF
--- a/soccer/src/soccer/planning/planner/escape_obstacles_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/escape_obstacles_path_planner.cpp
@@ -43,7 +43,8 @@ Trajectory EscapeObstaclesPathPlanner::plan(const PlanRequest& plan_request) {
     path_obstacles.add(std::make_shared<rj_geometry::Circle>(ball));
 
     auto result = CreatePath::intermediate(start_instant.linear_motion(), goal, motion_constraints,
-                                  start_instant.stamp, path_obstacles, {}, plan_request.field_dimensions, plan_request.shell_id);
+                                           start_instant.stamp, path_obstacles, {},
+                                           plan_request.field_dimensions, plan_request.shell_id);
     plan_angles(&result, start_instant, AngleFns::tangent, plan_request.constraints.rot);
     result.set_debug_text("[ESCAPE " + std::to_string(plan_request.shell_id) + "]");
 

--- a/soccer/src/soccer/planning/planner/escape_obstacles_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/escape_obstacles_path_planner.cpp
@@ -42,6 +42,8 @@ Trajectory EscapeObstaclesPathPlanner::plan(const PlanRequest& plan_request) {
     plan_angles(&result, start_instant, AngleFns::tangent, plan_request.constraints.rot);
     result.set_debug_text("[ESCAPE " + std::to_string(plan_request.shell_id) + "]");
 
+    
+
     previous_target_ = unblocked;
 
     result.stamp(RJ::now());
@@ -69,6 +71,19 @@ Point EscapeObstaclesPathPlanner::find_non_blocked_goal(Point goal, std::optiona
             // if the new point is not blocked, it becomes the new goal
             if (new_node && !obstacles.hit(new_node->state())) {
                 new_goal = new_node->state();
+                
+                bool isBallOnPath(Point ball) {
+                    double xval = new_goal.x();
+                    double yval = new_goal.y();
+                    double xvalRobot = plan_request.world_state->get_robot(true, plan_request.shell_id).pose.position().x();
+                    double yvalRobot = plan_request.world_state->get_robot(true, plan_request.shell_id).pose.position().y();
+                    double slope = (yval - yvalRobot) / (xval - xvalRobot);
+                    double y = slope * (ball.x() - xval) + yval;
+                    if (y == ball.y())
+                        return true;
+                    else 
+                        return false;
+                }
                 break;
             }
         }
@@ -85,7 +100,7 @@ Point EscapeObstaclesPathPlanner::find_non_blocked_goal(Point goal, std::optiona
             return *prev_goal;
         }
     }
-
+    plan_request.world_state->ball.position();
     return goal;
 }
 

--- a/soccer/src/soccer/planning/planner/escape_obstacles_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/escape_obstacles_path_planner.cpp
@@ -37,12 +37,15 @@ Trajectory EscapeObstaclesPathPlanner::plan(const PlanRequest& plan_request) {
     std::optional<Point> opt_prev_pt;
 
     LinearMotionInstant goal{unblocked, Point()};
-    auto result = CreatePath::simple(start_instant.linear_motion(), goal, motion_constraints,
-                                     start_instant.stamp);
+
+    rj_geometry::ShapeSet path_obstacles;
+    rj_geometry::Circle ball{plan_request.world_state->ball.position, kBallRadius};
+    path_obstacles.add(std::make_shared<rj_geometry::Circle>(ball));
+
+    auto result = CreatePath::intermediate(start_instant.linear_motion(), goal, motion_constraints,
+                                  start_instant.stamp, path_obstacles, {}, plan_request.field_dimensions, plan_request.shell_id);
     plan_angles(&result, start_instant, AngleFns::tangent, plan_request.constraints.rot);
     result.set_debug_text("[ESCAPE " + std::to_string(plan_request.shell_id) + "]");
-
-    
 
     previous_target_ = unblocked;
 
@@ -71,19 +74,6 @@ Point EscapeObstaclesPathPlanner::find_non_blocked_goal(Point goal, std::optiona
             // if the new point is not blocked, it becomes the new goal
             if (new_node && !obstacles.hit(new_node->state())) {
                 new_goal = new_node->state();
-                
-                bool isBallOnPath(Point ball) {
-                    double xval = new_goal.x();
-                    double yval = new_goal.y();
-                    double xvalRobot = plan_request.world_state->get_robot(true, plan_request.shell_id).pose.position().x();
-                    double yvalRobot = plan_request.world_state->get_robot(true, plan_request.shell_id).pose.position().y();
-                    double slope = (yval - yvalRobot) / (xval - xvalRobot);
-                    double y = slope * (ball.x() - xval) + yval;
-                    if (y == ball.y())
-                        return true;
-                    else 
-                        return false;
-                }
                 break;
             }
         }
@@ -100,7 +90,6 @@ Point EscapeObstaclesPathPlanner::find_non_blocked_goal(Point goal, std::optiona
             return *prev_goal;
         }
     }
-    plan_request.world_state->ball.position();
     return goal;
 }
 


### PR DESCRIPTION
## Description
When the robot is in the escape obstacles planner, the path it plans may hit the ball, causing us to get a penalty. This PR fixes this issue and prevents the robot from hitting the ball when escaping.

## Associated / Resolved Issue
Resolves [ClickUp card](https://app.clickup.com/t/86b1vtyfp)

## Steps to Test
1. Halt the game
2. Sandwich the robot between the ball and corner boundary (slight gap)
3. Stop the game

**Expected result:** Robot should escape obstacles without running into ball.
