### PR TITLE
Fixing up docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,8 +7,8 @@ import sphinx.application
 # -- Project information -----------------------------------------------------
 
 project = "RJ RC Software"
-copyright = "2022, Kevin Fu"
-author = "Oswin So"
+copyright = "2022, RoboJackets"
+author = "RoboJackets RoboCup Project"
 
 # The short X.Y version
 version = ""

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ extensions = [
 # (Python-only auto-api generation)
 # https://github.com/readthedocs/sphinx-autoapi
 autoapi_type = "python"
-autoapi_dirs = ["../../rj_gameplay"]
+autoapi_dirs = ["."]
 
 # -- Breathe Configuration ---------------------------------------------------
 breathe_projects = {}
@@ -62,7 +62,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -135,7 +135,7 @@ against the team's repository.
     pull request.
 
 Pull Requests (PR)
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 Pull requests are how we are able to review each others changes to the master
 branch. It helps you communicate your changes to ``ros2``. You can choose to
 create a pull request that is ready for review or draft a pull request. Draft

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -204,7 +204,7 @@ tab.) The binary will output a message saying it has launched the UI at a
 specific URL--click that link to open the UI. 
 
 Using external referee in an M1 Mac (ARM64 architecture)
---------------------------------------------------
+----------------------------------------------------------
 The SSL game controller repo only provides the AMD64 release, which will not work with ARM64 architectures.
 We will need to compile the ssl-game-controller from the source ourselves.
 

--- a/docs/source/fieldcomp_operation.rst
+++ b/docs/source/fieldcomp_operation.rst
@@ -48,6 +48,7 @@ first terminal where you launched soccer.
 
 For keyboard control, keep focus on the small black window (as in, you should
 click on that window if you can't see it).
+
  - WASD to move
  - QE to pivot
  - K to kick

--- a/docs/source/our_stack.rst
+++ b/docs/source/our_stack.rst
@@ -83,7 +83,7 @@ is a good start, and looking
 through the ``planning`` folder will give you more information about this topic.
 
 main.cpp & Processor
----------
+---------------------
 main.cpp is located in ``soccer/src/soccer/``. It is the entry point of soccer
 and starts the processor and the ui. It also takes in configuration values
 that may have been provided by the launch file (such as initial team color)

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -394,6 +394,7 @@ You can find the team color by subscribing to the relevant topic (this should
 become obvious after looking at the list of topics). To "pick a fruit", publish
 a standard `String Msg`_ 
 to a new topic ``/team_fruit``.
+
  * When our team color is yellow, publish "banana" to ``/team_fruit``.
  * When our team color is blue, publish "blueberries" to ``/team_fruit``.
 


### PR DESCRIPTION
## Description
RTD builds have been failing for last several commits. This PR fixes the bug and resolves some of the warnings.

## Associated / Resolved Issue
Resolves [ClickUp card](https://app.clickup.com/t/86b3muj5u)

## Steps to Test
1. Create Python env and activate
2. `pip install --upgrade --no-cache-dir pip setuptools`
3. `pip install --upgrade --no-cache-dir sphinx`
4. `pip install --exists-action=w --no-cache-dir -r docs/requirements.txt`
5. `cd docs/source`
6. `python -m sphinx -T -b html -d _build/doctrees -D language=en . html`
7. Open RTD from `html` folder

**Expected result:** Docs should be updated and working
![Screenshot 2025-01-23 at 11 17 16 AM](https://github.com/user-attachments/assets/f4652bbb-866a-4768-92ab-7d1d7de1886b)
^Updated installation docs
