### PR TITLE
Added autoref to the docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,6 +10,13 @@ ENV DISPLAY=:1
 ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 
+# Warn and exit if build arguments are not given
+RUN if [ -z TARGETARCH] then \
+    echo "****************************** ERROR ******************************"; \
+    echo "No target architecture was given. TARGETARCH is a required argument."; \
+    exit 1; \
+    fi
+
 # Update the package list and install necessary packages, including the missing ones
 RUN apt-get update && \
     apt-get install -y \
@@ -67,6 +74,14 @@ RUN git clone https://github.com/robotics-erlangen/framework.git /root/framework
     mkdir build && cd build && \
     cmake .. && \
     make simulator-cli
+
+# Clone, build ER-Force's autoref
+RUN git clone https://github.com/robotics-erlangen/autoref.git /root/autoref && \
+    cd /root/autoref && \
+    git submodule update --init && \
+    mkdir build && cd build && \
+    cmake .. && \
+    make
 
 # Use bash to source the ROS2 setup file and run make perf
 RUN bash -c "source /opt/ros/humble/setup.bash && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,12 +10,6 @@ ENV DISPLAY=:1
 ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 
-# Warn and exit if build arguments are not given
-RUN if [ -z TARGETARCH] then \
-    echo "****************************** ERROR ******************************"; \
-    echo "No target architecture was given. TARGETARCH is a required argument."; \
-    exit 1; \
-    fi
 
 # Update the package list and install necessary packages, including the missing ones
 RUN apt-get update && \


### PR DESCRIPTION
## Description
Describe your pull request.
Added autoref to docker.
## Associated / Resolved Issue
Resolves # or [ClickUp card](link-to-clickup-card)

## Design Documents
[Link](link-to-design-doc)

## Steps to Test
1. Run a manual docker build from the branch. The file is Dockerfile.dev so the command should be:
docker build -t <name of build> -f Dockerfile.dev --build-arg TARGETARCH=amd64 .
2. After it finishes building, run it with commands similar to those in our docker hub site.
3. Note that the autoref is in a directory by the same name in the root directory, and the binaries should be stored in a folder called "build" within that directory.
4. After it starts up, log into it through vnc and run simulator-cli, the external ref (again using the commands listed on docker hub), then autoref, then our stack using run-sim-ex
5. The autoref should give occasional feedback about the game state.
### Test Case 1
1. Step 1
6. Step 2
7. Step 3

**Expected result:**???

## Key Files to Review
Group 1
 * File 1
 * File 2

Group 2
 * File 3
 * File 4

## Review Checklist

- [ ] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [ ] **Remove extra print statements**: Any print statements used for debugging should be removed
- [ ] **Tag reviewers**: Tag some people for review and ping them on Slack

## (Optional) Sub-issues (for drafts)
_Note: if you find yourself breaking this PR into many smaller features, it may make sense to break up the PR into logical units based on these features._
- [ ] Step 1
- [ ] Step 2
