### PR TITLE
Fix Angle Planning Crash

### DIFF
--- a/soccer/src/soccer/planning/primitives/angle_planning.hpp
+++ b/soccer/src/soccer/planning/primitives/angle_planning.hpp
@@ -69,6 +69,9 @@ inline AngleFunction face_point(const rj_geometry::Point point) {
                Eigen::Vector2d* jacobian) -> double {
 	
         if ((instant.position - point).mag() < kRobotRadius) {
+            if (jacobian != nullptr) {
+                *jacobian = Eigen::Vector2d::Zero();
+            }
             return previous_angle;
         }
 


### PR DESCRIPTION
Fix the bug with angle planning crashing by setting jacobian to 0 if the robot is at the point it wants to turn to.