### PR TITLE
fix custom ros2 message types

### DIFF
--- a/install/setup.bash
+++ b/install/setup.bash
@@ -34,12 +34,13 @@ _pythonpath_add() {
 # No direct replacement for the command exists, and in Ubuntu 22.04,
 # this script will produce a warning about this. We may need to find a
 # replacement library in the future.
-_PYTHON_LIB_PATH=$(python3 -c "import sysconfig; print(sysconfig.get_path('purelib'))")
-_pythonpath_add "${_PYTHON_LIB_PATH}"
-unset _PYTHON_LIB_PATH
+# _PYTHON_LIB_PATH=$(python3 -c "import sysconfig; print(sysconfig.get_path('purelib'))")
+_pythonpath_add "${_INSTALL_PATH}/local/lib/python3.10/dist-packages"
+# unset _PYTHON_LIB_PATH
 
 _path_add "${_INSTALL_PATH}/bin"
 _ld_library_path_add "${_INSTALL_PATH}/lib"
+echo "${_INSTALL_PATH}"
 _ament_prefix_path_add "${_INSTALL_PATH}"
 
 unset _pathadd

--- a/install/setup.bash
+++ b/install/setup.bash
@@ -40,7 +40,6 @@ _pythonpath_add "${_INSTALL_PATH}/local/lib/python3.10/dist-packages"
 
 _path_add "${_INSTALL_PATH}/bin"
 _ld_library_path_add "${_INSTALL_PATH}/lib"
-echo "${_INSTALL_PATH}"
 _ament_prefix_path_add "${_INSTALL_PATH}"
 
 unset _pathadd

--- a/install/setup.zsh
+++ b/install/setup.zsh
@@ -30,9 +30,9 @@ _pythonpath_add() {
     fi
 }
 
-_PYTHON_LIB_PATH=$(python3 -c "import sysconfig; print(sysconfig.get_path('purelib'))")
-_pythonpath_add "${_PYTHON_LIB_PATH}"
-unset _PYTHON_LIB_PATH
+# _PYTHON_LIB_PATH=$(python3 -c "import sysconfig; print(sysconfig.get_path('purelib'))")
+_pythonpath_add "${_INSTALL_PATH}/local/lib/python3.10/dist-packages"
+# unset _PYTHON_LIB_PATH
 
 _path_add "${_INSTALL_PATH}/bin"
 _ld_library_path_add "${_INSTALL_PATH}/lib"


### PR DESCRIPTION
## Description
previously, since the humble upgrade, `ros2 topic echo`, `ros2 service call`, and any other CLI command that requires knowledge of a custom type that we declare in `rj_msgs` did not work. Now, they do work, because I've fixed a broken part of the environment variables script.

## Associated / Resolved Issue
resolves [clickup card](https://app.clickup.com/t/86b45b57m)

## Steps to Test
### Test Case 1
1. make perf/debug/whatever
2. `. ./source.bash`
3. `ros2 topic echo /config/field_dimensions` (for example)

**Expected result**: output as usual, no warnings or errors


## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack
