### PR TITLE
Planner Manipulator

### DIFF
--- a/config/sim_params.yaml
+++ b/config/sim_params.yaml
@@ -47,7 +47,7 @@
   ros__parameters:
     collect:
       approach_accel_scale: 0.7
-      approach_dist_target: 0.5
+      approach_dist_target: 0.1
       ball_speed_approach_direction_cutoff: 0.1
       control_accel_scale: 0.5
       dist_cutoff_to_approach: 1.0

--- a/config/sim_params.yaml
+++ b/config/sim_params.yaml
@@ -47,7 +47,7 @@
   ros__parameters:
     collect:
       approach_accel_scale: 0.7
-      approach_dist_target: 0.04
+      approach_dist_target: 0.5
       ball_speed_approach_direction_cutoff: 0.1
       control_accel_scale: 0.5
       dist_cutoff_to_approach: 1.0

--- a/rj_msgs/msg/RobotIntent.msg
+++ b/rj_msgs/msg/RobotIntent.msg
@@ -3,14 +3,21 @@ uint8 robot_id
 uint8 SHOOT_MODE_KICK = 0
 uint8 SHOOT_MODE_CHIP = 1
 
+# Stand Down - Never Kick
+# Immediate - Instantly Kick
+# On Break Beam - Kick once break
+# At End - Signals Planner to Kick after it is finished (planners do not support this by default)
 uint8 TRIGGER_MODE_STAND_DOWN = 0
 uint8 TRIGGER_MODE_IMMEDIATE = 1
 uint8 TRIGGER_MODE_ON_BREAK_BEAM = 2
 uint8 TRIGGER_MODE_AT_END = 3
 
+# Off - Off throughout entire planner
+# On - On throughout entire planner
+# Default - Planner decides when to turn on dribbler
 uint8 DRIBBLER_MODE_OFF = 0
 uint8 DRIBBLER_MODE_ON = 1
-uint8 DRIBBLER_MODE_NEUTRAL = 2
+uint8 DRIBBLER_MODE_DEFAULT = 2
 
 MotionCommand motion_command
 

--- a/rj_msgs/msg/RobotIntent.msg
+++ b/rj_msgs/msg/RobotIntent.msg
@@ -6,6 +6,11 @@ uint8 SHOOT_MODE_CHIP = 1
 uint8 TRIGGER_MODE_STAND_DOWN = 0
 uint8 TRIGGER_MODE_IMMEDIATE = 1
 uint8 TRIGGER_MODE_ON_BREAK_BEAM = 2
+uint8 TRIGGER_MODE_AT_END = 3
+
+uint8 DRIBBLER_MODE_OFF = 0
+uint8 DRIBBLER_MODE_ON = 1
+uint8 DRIBBLER_MODE_NEUTRAL = 2
 
 MotionCommand motion_command
 
@@ -14,10 +19,8 @@ rj_geometry_msgs/ShapeSet local_obstacles
 
 uint8 shoot_mode
 uint8 trigger_mode
+uint8 dribbler_mode
 float32 kick_speed
-
-# In range [0, 1]
-float32 dribbler_speed
 
 bool is_active
 

--- a/soccer/src/soccer/logger.cpp
+++ b/soccer/src/soccer/logger.cpp
@@ -206,7 +206,7 @@ std::shared_ptr<Packet::LogFrame> Logger::create_log_frame(Context* context) {
         ConvertRx::status_to_proto(status, rx);
 
         Packet::Robot* tx = log_frame->mutable_radio_tx()->add_robots();
-        ConvertTx::to_proto(trajectory, intent, setpoint, shell, tx);
+        ConvertTx::to_proto(trajectory, intent, setpoint, static_cast<int>(shell), tx);
     }
 
     // Opponent robots

--- a/soccer/src/soccer/logger.cpp
+++ b/soccer/src/soccer/logger.cpp
@@ -198,14 +198,14 @@ std::shared_ptr<Packet::LogFrame> Logger::create_log_frame(Context* context) {
         if (RJ::now() - status.timestamp > RJ::Seconds(0.5)) {
             continue;
         }
-        const auto& intent = context->robot_intents.at(shell);
+        const auto& trajectory = context->trajectories.at(shell);
         const auto& setpoint = context->motion_setpoints.at(shell);
 
         RadioRx* rx = log_frame->add_radio_rx();
         ConvertRx::status_to_proto(status, rx);
 
         Packet::Robot* tx = log_frame->mutable_radio_tx()->add_robots();
-        ConvertTx::to_proto(intent, setpoint, shell, tx);
+        ConvertTx::to_proto(trajectory, setpoint, shell, tx);
     }
 
     // Opponent robots

--- a/soccer/src/soccer/logger.cpp
+++ b/soccer/src/soccer/logger.cpp
@@ -199,13 +199,14 @@ std::shared_ptr<Packet::LogFrame> Logger::create_log_frame(Context* context) {
             continue;
         }
         const auto& trajectory = context->trajectories.at(shell);
+        const auto& intent = context->robot_intents.at(shell);
         const auto& setpoint = context->motion_setpoints.at(shell);
 
         RadioRx* rx = log_frame->add_radio_rx();
         ConvertRx::status_to_proto(status, rx);
 
         Packet::Robot* tx = log_frame->mutable_radio_tx()->add_robots();
-        ConvertTx::to_proto(trajectory, setpoint, shell, tx);
+        ConvertTx::to_proto(trajectory, intent, setpoint, shell, tx);
     }
 
     // Opponent robots

--- a/soccer/src/soccer/planning/planner/collect_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/collect_path_planner.cpp
@@ -603,6 +603,7 @@ Trajectory CollectPathPlanner::dampen(const PlanRequest& plan_request, RobotInst
     plan_angles(&dampen_end, start_instant, AngleFns::face_point(face_pos),
                 plan_request.constraints.rot);
     dampen_end.stamp(RJ::now());
+    dampen_end.dribbler_speed = 255;
     return dampen_end;
 }
 
@@ -663,7 +664,11 @@ Trajectory CollectPathPlanner::fine_approach(
                     start_instant.position() +
                         Point::direction(AngleFns::face_point(ball.position)(
                             start_instant.linear_motion(), start_instant.heading(), nullptr))));
+        plan_request.debug_drawer->draw_text("Fine Approach", start_instant.position() + Point(.1, .1),
+                                             QColor(255, 255, 255));
     }
+
+    path_hit.dribbler_speed = 255;
 
     return path_hit;
 }

--- a/soccer/src/soccer/planning/planner/collect_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/collect_path_planner.cpp
@@ -664,8 +664,8 @@ Trajectory CollectPathPlanner::fine_approach(
                     start_instant.position() +
                         Point::direction(AngleFns::face_point(ball.position)(
                             start_instant.linear_motion(), start_instant.heading(), nullptr))));
-        plan_request.debug_drawer->draw_text("Fine Approach", start_instant.position() + Point(.1, .1),
-                                             QColor(255, 255, 255));
+        plan_request.debug_drawer->draw_text(
+            "Fine Approach", start_instant.position() + Point(.1, .1), QColor(255, 255, 255));
     }
 
     path_hit.dribbler_speed = 255;

--- a/soccer/src/soccer/planning/planner/plan_request.hpp
+++ b/soccer/src/soccer/planning/planner/plan_request.hpp
@@ -35,7 +35,7 @@ struct PlanRequest {
                 rj_drawing::RosDebugDrawer* debug_drawer = nullptr, bool ball_sense = false,
                 float min_dist_from_ball = 0, float kick_speed = 0,
                 RobotIntent::TriggerMode trigger_mode = RobotIntent::TriggerMode::STAND_DOWN,
-                RobotIntent::DribblerMode dribbler_mode = RobotIntent::DribblerMode::NEUTRAL)
+                RobotIntent::DribblerMode dribbler_mode = RobotIntent::DribblerMode::DEFAULT)
         : start(start),
           motion_command(command),  // NOLINT
           constraints(constraints),
@@ -134,7 +134,7 @@ struct PlanRequest {
     float kick_speed = 0;
 
     RobotIntent::TriggerMode trigger_mode = RobotIntent::TriggerMode::STAND_DOWN;
-    RobotIntent::DribblerMode dribbler_mode = RobotIntent::DribblerMode::NEUTRAL;
+    RobotIntent::DribblerMode dribbler_mode = RobotIntent::DribblerMode::DEFAULT;
 };
 
 /**

--- a/soccer/src/soccer/planning/planner/plan_request.hpp
+++ b/soccer/src/soccer/planning/planner/plan_request.hpp
@@ -16,6 +16,7 @@
 #include "planning/trajectory_collection.hpp"
 #include "ros_debug_drawer.hpp"
 #include "world_state.hpp"
+#include "robot_intent.hpp"
 
 namespace planning {
 
@@ -32,7 +33,9 @@ struct PlanRequest {
                 unsigned shell_id, const WorldState* world_state, PlayState play_state,
                 const FieldDimensions* field_dimensions, int8_t priority = 0,
                 rj_drawing::RosDebugDrawer* debug_drawer = nullptr, bool ball_sense = false,
-                float min_dist_from_ball = 0, float dribbler_speed = 0)
+                float min_dist_from_ball = 0, float kick_speed = 0,
+                RobotIntent::TriggerMode trigger_mode = RobotIntent::TriggerMode::STAND_DOWN,
+                RobotIntent::DribblerMode dribbler_mode = RobotIntent::DribblerMode::NEUTRAL)
         : start(start),
           motion_command(command),  // NOLINT
           constraints(constraints),
@@ -47,7 +50,9 @@ struct PlanRequest {
           debug_drawer(debug_drawer),
           ball_sense(ball_sense),
           min_dist_from_ball(min_dist_from_ball),
-          dribbler_speed(dribbler_speed) {}
+          kick_speed(kick_speed),
+          trigger_mode(trigger_mode),
+          dribbler_mode(dribbler_mode) {}
 
     /**
      * The robot's starting state.
@@ -124,9 +129,12 @@ struct PlanRequest {
     float min_dist_from_ball = 0;
 
     /**
-     * Dribbler Speed
+     * Kick Speed
      */
-    float dribbler_speed = 0;
+    float kick_speed = 0;
+
+    RobotIntent::TriggerMode trigger_mode = RobotIntent::TriggerMode::STAND_DOWN;
+    RobotIntent::DribblerMode dribbler_mode = RobotIntent::DribblerMode::NEUTRAL;
 };
 
 /**

--- a/soccer/src/soccer/planning/planner/plan_request.hpp
+++ b/soccer/src/soccer/planning/planner/plan_request.hpp
@@ -14,9 +14,9 @@
 #include "planning/instant.hpp"
 #include "planning/robot_constraints.hpp"
 #include "planning/trajectory_collection.hpp"
+#include "robot_intent.hpp"
 #include "ros_debug_drawer.hpp"
 #include "world_state.hpp"
-#include "robot_intent.hpp"
 
 namespace planning {
 

--- a/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
@@ -40,7 +40,8 @@ void RotatePathPlanner::update_state() {
                          : PIVOT;
 }
 
-// Assumes that we have called plan at least once while in the END state (this assumption should be always true given our current planning setup)
+// Assumes that we have called plan at least once while in the END state (this assumption should be
+// always true given our current planning setup)
 bool RotatePathPlanner::is_done() const { return current_state_ == END; }
 
 Trajectory RotatePathPlanner::pivot(const PlanRequest& request) {

--- a/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
@@ -35,13 +35,12 @@ void RotatePathPlanner::update_state() {
         return;
     }
     current_state_ = abs(cached_angle_change_.value()) <
-           degrees_to_radians(static_cast<float>(kIsDoneAngleChangeThresh)) ? 
-           KICK : PIVOT;
+                             degrees_to_radians(static_cast<float>(kIsDoneAngleChangeThresh))
+                         ? KICK
+                         : PIVOT;
 }
 
-bool RotatePathPlanner::is_done() const {
-    return current_state_ == KICK;
-}
+bool RotatePathPlanner::is_done() const { return current_state_ == KICK; }
 
 Trajectory RotatePathPlanner::pivot(const PlanRequest& request) {
     const RobotInstant& start_instant = request.start;
@@ -69,7 +68,7 @@ Trajectory RotatePathPlanner::pivot(const PlanRequest& request) {
     Trajectory path{};
 
     if (cached_target_angle_.has_value() &&
-     (*cached_target_angle_ - target_angle) < degrees_to_radians(kIsDoneAngleChangeThresh)) {
+        (*cached_target_angle_ - target_angle) < degrees_to_radians(kIsDoneAngleChangeThresh)) {
         if (cached_path_) {
             path = cached_path_.value();
         } else {

--- a/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
@@ -19,15 +19,28 @@ namespace planning {
 using namespace rj_geometry;
 
 Trajectory RotatePathPlanner::plan(const PlanRequest& request) {
-    return pivot(request);  // type is Trajectory
+    update_state();
+    switch (current_state_) {
+        case PIVOT:
+            return pivot(request);
+        case KICK:
+            return kick(request);
+    }
+    return {};
+}
+
+void RotatePathPlanner::update_state() {
+    if (!cached_angle_change_) {
+        current_state_ = PIVOT;
+        return;
+    }
+    current_state_ = abs(cached_angle_change_.value()) <
+           degrees_to_radians(static_cast<float>(kIsDoneAngleChangeThresh)) ? 
+           KICK : PIVOT;
 }
 
 bool RotatePathPlanner::is_done() const {
-    if (!cached_angle_change_) {
-        return false;
-    }
-    return abs(cached_angle_change_.value()) <
-           degrees_to_radians(static_cast<float>(kIsDoneAngleChangeThresh));
+    return current_state_ == KICK;
 }
 
 Trajectory RotatePathPlanner::pivot(const PlanRequest& request) {
@@ -55,7 +68,8 @@ Trajectory RotatePathPlanner::pivot(const PlanRequest& request) {
 
     Trajectory path{};
 
-    if (abs(*cached_target_angle_ - target_angle) < degrees_to_radians(kIsDoneAngleChangeThresh)) {
+    if (cached_target_angle_.has_value() &&
+     (*cached_target_angle_ - target_angle) < degrees_to_radians(kIsDoneAngleChangeThresh)) {
         if (cached_path_) {
             path = cached_path_.value();
         } else {
@@ -75,6 +89,17 @@ Trajectory RotatePathPlanner::pivot(const PlanRequest& request) {
     cached_target_angle_ = target_angle;
 
     return path;
+}
+
+Trajectory RotatePathPlanner::kick(const PlanRequest& request) {
+    auto trajectory = Trajectory{};
+    trajectory.append_instant(request.start);
+    trajectory.mark_angles_valid();
+    trajectory.stamp(RJ::now());
+    if (request.trigger_mode == RobotIntent::TriggerMode::AT_END) {
+        trajectory.trigger_mode = Trajectory::TriggerMode::ON_BREAK_BEAM;
+    }
+    return trajectory;
 }
 
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
@@ -23,8 +23,8 @@ Trajectory RotatePathPlanner::plan(const PlanRequest& request) {
     switch (current_state_) {
         case PIVOT:
             return pivot(request);
-        case KICK:
-            return kick(request);
+        case END:
+            return end(request);
     }
     return {};
 }
@@ -36,11 +36,12 @@ void RotatePathPlanner::update_state() {
     }
     current_state_ = abs(cached_angle_change_.value()) <
                              degrees_to_radians(static_cast<float>(kIsDoneAngleChangeThresh))
-                         ? KICK
+                         ? END
                          : PIVOT;
 }
 
-bool RotatePathPlanner::is_done() const { return current_state_ == KICK; }
+// Assumes that we have called plan at least once while in the END state (this assumption should be always true given our current planning setup)
+bool RotatePathPlanner::is_done() const { return current_state_ == END; }
 
 Trajectory RotatePathPlanner::pivot(const PlanRequest& request) {
     const RobotInstant& start_instant = request.start;
@@ -90,7 +91,7 @@ Trajectory RotatePathPlanner::pivot(const PlanRequest& request) {
     return path;
 }
 
-Trajectory RotatePathPlanner::kick(const PlanRequest& request) {
+Trajectory RotatePathPlanner::end(const PlanRequest& request) {
     auto trajectory = Trajectory{};
     trajectory.append_instant(request.start);
     trajectory.mark_angles_valid();

--- a/soccer/src/soccer/planning/planner/rotate_path_planner.hpp
+++ b/soccer/src/soccer/planning/planner/rotate_path_planner.hpp
@@ -41,10 +41,10 @@ private:
     PathTargetPathPlanner path_target_{};
 
     Trajectory pivot(const PlanRequest& request);
-    Trajectory kick(const PlanRequest& request);
+    Trajectory end(const PlanRequest& request);
     void update_state();
 
-    enum State { PIVOT, KICK };
+    enum State { PIVOT, END };
     RotatePathPlanner::State current_state_ = RotatePathPlanner::State::PIVOT;
 
     static constexpr double kIsDoneAngleChangeThresh{1.0};

--- a/soccer/src/soccer/planning/planner/rotate_path_planner.hpp
+++ b/soccer/src/soccer/planning/planner/rotate_path_planner.hpp
@@ -26,6 +26,7 @@ public:
     void reset() override {
         cached_target_angle_ = std::nullopt;
         cached_angle_change_ = std::nullopt;
+        current_state_ = PIVOT;
     }
     [[nodiscard]] bool is_done() const override;
 
@@ -40,6 +41,11 @@ private:
     PathTargetPathPlanner path_target_{};
 
     Trajectory pivot(const PlanRequest& request);
+    Trajectory kick(const PlanRequest& request);
+    void update_state();
+
+    enum State { PIVOT, KICK };
+    RotatePathPlanner::State current_state_ = RotatePathPlanner::State::PIVOT;
 
     static constexpr double kIsDoneAngleChangeThresh{1.0};
 };

--- a/soccer/src/soccer/planning/planner_for_robot.cpp
+++ b/soccer/src/soccer/planning/planner_for_robot.cpp
@@ -69,12 +69,17 @@ void PlannerForRobot::execute_intent(const RobotIntent& intent) {
         auto trajectory = safe_plan_for_robot(plan_request);
         trajectory_topic_->publish(rj_convert::convert_to_ros(trajectory));
 
+        if (intent.dribbler_mode != RobotIntent::DribblerMode::NEUTRAL) {
+            trajectory.dribbler_speed = 
+                (intent.dribbler_mode == RobotIntent::DribblerMode::ON) ? 1.0 : 0.0;
+        }
+
         // send the kick/dribble commands to the radio
         manipulator_pub_->publish(rj_msgs::build<rj_msgs::msg::ManipulatorSetpoint>()
-                                      .shoot_mode(intent.shoot_mode)
-                                      .trigger_mode(intent.trigger_mode)
-                                      .kick_speed(intent.kick_speed)
-                                      .dribbler_speed(plan_request.dribbler_speed));
+                                      .shoot_mode(trajectory.shoot_mode)
+                                      .trigger_mode(trajectory.trigger_mode)
+                                      .kick_speed(trajectory.kick_speed)
+                                      .dribbler_speed(trajectory.dribbler_speed));
 
         /*
         // TODO (PR #1970): fix TrajectoryCollection
@@ -120,6 +125,7 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
     float min_dist_from_ball{};
     float max_robot_speed{};
     float max_dribbler_speed{};
+    float max_kick_speed{};
 
     // Global Overrides
     switch (play_state.state()) {
@@ -127,11 +133,13 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
             min_dist_from_ball = 0;
             max_robot_speed = 0;
             max_dribbler_speed = 0;
+            max_kick_speed = 0;
             break;
         case PlayState::State::Stop:
             min_dist_from_ball = 0.5;
             max_robot_speed = 1.5;
             max_dribbler_speed = 0;
+            max_kick_speed = 0;
             break;
         case PlayState::State::Setup:
             // TODO(jacksherling): this is a hacky solution for us to stop kicking the ball by
@@ -139,6 +147,7 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
             min_dist_from_ball = 0.2;
             max_robot_speed = 10.0;
             max_dribbler_speed = 255;
+            max_kick_speed = 6.5;
             break;
         case PlayState::State::Playing:
         default:
@@ -148,6 +157,7 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
             // number instead.
             max_robot_speed = 10.0;
             max_dribbler_speed = 255;
+            max_kick_speed = 6.5;
             break;
     }
 
@@ -205,8 +215,7 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
         constraints.mot.max_speed = max_robot_speed;
     }
 
-    float dribble_speed =
-        std::min(static_cast<float>(intent.dribbler_speed), static_cast<float>(max_dribbler_speed));
+    float kick_speed = min(intent.kick_speed, max_kick_speed);
 
     return PlanRequest{start,
                        motion_command,
@@ -222,7 +231,9 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
                        &debug_draw_,
                        had_break_beam_,
                        min_dist_from_ball,
-                       dribble_speed};
+                       kick_speed,
+                       intent.trigger_mode,
+                       intent.dribbler_mode};
 }
 
 Trajectory PlannerForRobot::unsafe_plan_for_robot(const planning::PlanRequest& request) {
@@ -260,6 +271,7 @@ Trajectory PlannerForRobot::safe_plan_for_robot(const planning::PlanRequest& req
     Trajectory trajectory;
     try {
         trajectory = unsafe_plan_for_robot(request);
+        SPDLOG_INFO("Dribbler {} Speed: {}", robot_id_, trajectory.dribbler_speed);
     } catch (std::runtime_error exception) {
         // SPDLOG_WARN("PlannerForRobot {} error caught: {}", robot_id_, exception.what());
         // SPDLOG_WARN("PlannerForRobot {}: Defaulting to EscapeObstaclesPathPlanner", robot_id_);

--- a/soccer/src/soccer/planning/planner_for_robot.cpp
+++ b/soccer/src/soccer/planning/planner_for_robot.cpp
@@ -73,7 +73,7 @@ void PlannerForRobot::execute_intent(const RobotIntent& intent) {
             trajectory.dribbler_speed =
                 (intent.dribbler_mode == RobotIntent::DribblerMode::ON) ? 255.0 : 0.0;
         }
-        
+
         switch (intent.trigger_mode) {
             case RobotIntent::TriggerMode::STAND_DOWN:
                 trajectory.trigger_mode = planning::Trajectory::TriggerMode::STAND_DOWN;

--- a/soccer/src/soccer/planning/planner_for_robot.cpp
+++ b/soccer/src/soccer/planning/planner_for_robot.cpp
@@ -71,14 +71,28 @@ void PlannerForRobot::execute_intent(const RobotIntent& intent) {
 
         if (intent.dribbler_mode != RobotIntent::DribblerMode::NEUTRAL) {
             trajectory.dribbler_speed = 
-                (intent.dribbler_mode == RobotIntent::DribblerMode::ON) ? 1.0 : 0.0;
+                (intent.dribbler_mode == RobotIntent::DribblerMode::ON) ? 255.0 : 0.0;
         }
-
+        
+        if (intent.trigger_mode != RobotIntent::TriggerMode::AT_END) {
+            switch (intent.trigger_mode) {
+                case RobotIntent::TriggerMode::STAND_DOWN:
+                    trajectory.trigger_mode = planning::Trajectory::TriggerMode::STAND_DOWN;
+                    break;
+                case RobotIntent::TriggerMode::IMMEDIATE:
+                    trajectory.trigger_mode = planning::Trajectory::TriggerMode::IMMEDIATE;
+                    break;
+                case RobotIntent::TriggerMode::ON_BREAK_BEAM:
+                    trajectory.trigger_mode = planning::Trajectory::TriggerMode::ON_BREAK_BEAM;
+                    break;
+            }
+        }
+        
         // send the kick/dribble commands to the radio
         manipulator_pub_->publish(rj_msgs::build<rj_msgs::msg::ManipulatorSetpoint>()
                                       .shoot_mode(trajectory.shoot_mode)
                                       .trigger_mode(trajectory.trigger_mode)
-                                      .kick_speed(trajectory.kick_speed)
+                                      .kick_speed(intent.kick_speed)
                                       .dribbler_speed(trajectory.dribbler_speed));
 
         /*
@@ -271,9 +285,8 @@ Trajectory PlannerForRobot::safe_plan_for_robot(const planning::PlanRequest& req
     Trajectory trajectory;
     try {
         trajectory = unsafe_plan_for_robot(request);
-        SPDLOG_INFO("Dribbler {} Speed: {}", robot_id_, trajectory.dribbler_speed);
     } catch (std::runtime_error exception) {
-        // SPDLOG_WARN("PlannerForRobot {} error caught: {}", robot_id_, exception.what());
+        SPDLOG_WARN("PlannerForRobot {} error caught: {}", robot_id_, exception.what());
         // SPDLOG_WARN("PlannerForRobot {}: Defaulting to EscapeObstaclesPathPlanner", robot_id_);
 
         current_path_planner_ = default_path_planner_.get();
@@ -314,7 +327,11 @@ bool PlannerForRobot::is_done() const {
         return false;
     }
 
-    return current_path_planner_->is_done();
+    if (current_path_planner_->is_done()) {
+        current_path_planner_->reset();
+        return true;
+    }
+    return false;
 }
 
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner_for_robot.cpp
+++ b/soccer/src/soccer/planning/planner_for_robot.cpp
@@ -73,19 +73,19 @@ void PlannerForRobot::execute_intent(const RobotIntent& intent) {
             trajectory.dribbler_speed =
                 (intent.dribbler_mode == RobotIntent::DribblerMode::ON) ? 255.0 : 0.0;
         }
-
-        if (intent.trigger_mode != RobotIntent::TriggerMode::AT_END) {
-            switch (intent.trigger_mode) {
-                case RobotIntent::TriggerMode::STAND_DOWN:
-                    trajectory.trigger_mode = planning::Trajectory::TriggerMode::STAND_DOWN;
-                    break;
-                case RobotIntent::TriggerMode::IMMEDIATE:
-                    trajectory.trigger_mode = planning::Trajectory::TriggerMode::IMMEDIATE;
-                    break;
-                case RobotIntent::TriggerMode::ON_BREAK_BEAM:
-                    trajectory.trigger_mode = planning::Trajectory::TriggerMode::ON_BREAK_BEAM;
-                    break;
-            }
+        
+        switch (intent.trigger_mode) {
+            case RobotIntent::TriggerMode::STAND_DOWN:
+                trajectory.trigger_mode = planning::Trajectory::TriggerMode::STAND_DOWN;
+                break;
+            case RobotIntent::TriggerMode::IMMEDIATE:
+                trajectory.trigger_mode = planning::Trajectory::TriggerMode::IMMEDIATE;
+                break;
+            case RobotIntent::TriggerMode::ON_BREAK_BEAM:
+                trajectory.trigger_mode = planning::Trajectory::TriggerMode::ON_BREAK_BEAM;
+                break;
+            default:
+                break;
         }
 
         switch (intent.shoot_mode) {

--- a/soccer/src/soccer/planning/planner_for_robot.cpp
+++ b/soccer/src/soccer/planning/planner_for_robot.cpp
@@ -87,7 +87,16 @@ void PlannerForRobot::execute_intent(const RobotIntent& intent) {
                     break;
             }
         }
-        
+
+        switch (intent.shoot_mode) {
+            case RobotIntent::ShootMode::CHIP:
+                trajectory.shoot_mode = planning::Trajectory::ShootMode::CHIP;
+                break;
+            case RobotIntent::ShootMode::KICK:
+                trajectory.shoot_mode = planning::Trajectory::ShootMode::KICK;
+                break;
+        }
+
         // send the kick/dribble commands to the radio
         manipulator_pub_->publish(rj_msgs::build<rj_msgs::msg::ManipulatorSetpoint>()
                                       .shoot_mode(trajectory.shoot_mode)

--- a/soccer/src/soccer/planning/planner_for_robot.cpp
+++ b/soccer/src/soccer/planning/planner_for_robot.cpp
@@ -69,7 +69,7 @@ void PlannerForRobot::execute_intent(const RobotIntent& intent) {
         auto trajectory = safe_plan_for_robot(plan_request);
         trajectory_topic_->publish(rj_convert::convert_to_ros(trajectory));
 
-        if (intent.dribbler_mode != RobotIntent::DribblerMode::NEUTRAL) {
+        if (intent.dribbler_mode != RobotIntent::DribblerMode::DEFAULT) {
             trajectory.dribbler_speed =
                 (intent.dribbler_mode == RobotIntent::DribblerMode::ON) ? 255.0 : 0.0;
         }

--- a/soccer/src/soccer/planning/planner_for_robot.cpp
+++ b/soccer/src/soccer/planning/planner_for_robot.cpp
@@ -70,10 +70,10 @@ void PlannerForRobot::execute_intent(const RobotIntent& intent) {
         trajectory_topic_->publish(rj_convert::convert_to_ros(trajectory));
 
         if (intent.dribbler_mode != RobotIntent::DribblerMode::NEUTRAL) {
-            trajectory.dribbler_speed = 
+            trajectory.dribbler_speed =
                 (intent.dribbler_mode == RobotIntent::DribblerMode::ON) ? 255.0 : 0.0;
         }
-        
+
         if (intent.trigger_mode != RobotIntent::TriggerMode::AT_END) {
             switch (intent.trigger_mode) {
                 case RobotIntent::TriggerMode::STAND_DOWN:

--- a/soccer/src/soccer/planning/trajectory.hpp
+++ b/soccer/src/soccer/planning/trajectory.hpp
@@ -432,12 +432,13 @@ public:
      * @return The robot instants forming the keypoints of this trajectory, sequenced by time.
      */
     [[nodiscard]] const RobotInstantSequence& instants() const { return instants_; }
-    
+
     enum ShootMode { KICK, CHIP };
     enum TriggerMode { STAND_DOWN, IMMEDIATE, ON_BREAK_BEAM };
     Trajectory::ShootMode shoot_mode = Trajectory::ShootMode::KICK;
     Trajectory::TriggerMode trigger_mode = Trajectory::TriggerMode::STAND_DOWN;
     float dribbler_speed = 0;
+
 private:
     // A sorted array of RobotInstants (by timestamp)
     RobotInstantSequence instants_;

--- a/soccer/src/soccer/planning/trajectory.hpp
+++ b/soccer/src/soccer/planning/trajectory.hpp
@@ -438,7 +438,6 @@ public:
     Trajectory::ShootMode shoot_mode = Trajectory::ShootMode::KICK;
     Trajectory::TriggerMode trigger_mode = Trajectory::TriggerMode::STAND_DOWN;
     float dribbler_speed = 0;
-    float kick_speed = 0;
 private:
     // A sorted array of RobotInstants (by timestamp)
     RobotInstantSequence instants_;

--- a/soccer/src/soccer/planning/trajectory.hpp
+++ b/soccer/src/soccer/planning/trajectory.hpp
@@ -432,7 +432,13 @@ public:
      * @return The robot instants forming the keypoints of this trajectory, sequenced by time.
      */
     [[nodiscard]] const RobotInstantSequence& instants() const { return instants_; }
-
+    
+    enum ShootMode { KICK, CHIP };
+    enum TriggerMode { STAND_DOWN, IMMEDIATE, ON_BREAK_BEAM };
+    Trajectory::ShootMode shoot_mode = Trajectory::ShootMode::KICK;
+    Trajectory::TriggerMode trigger_mode = Trajectory::TriggerMode::STAND_DOWN;
+    float dribbler_speed = 0;
+    float kick_speed = 0;
 private:
     // A sorted array of RobotInstants (by timestamp)
     RobotInstantSequence instants_;

--- a/soccer/src/soccer/radio/packet_convert.cpp
+++ b/soccer/src/soccer/radio/packet_convert.cpp
@@ -172,10 +172,10 @@ void to_rtp(const RobotIntent& intent, const MotionSetpoint& setpoint, int shell
         static_cast<int16_t>(setpoint.yvelocity * rtp::ControlMessage::VELOCITY_SCALE_FACTOR);
     rtp_message->body_w =
         static_cast<int16_t>(setpoint.avelocity * rtp::ControlMessage::VELOCITY_SCALE_FACTOR);
-    rtp_message->dribbler_speed =
-        std::clamp<uint16_t>(static_cast<uint16_t>((
-            intent.dribbler_mode == RobotIntent::DribblerMode::ON ? 1.0 : 0.0
-        )* kMaxDribble), 0, 255);
+    rtp_message->dribbler_speed = std::clamp<uint16_t>(
+        static_cast<uint16_t>((intent.dribbler_mode == RobotIntent::DribblerMode::ON ? 1.0 : 0.0) *
+                              kMaxDribble),
+        0, 255);
 
     if (intent.shoot_mode == RobotIntent::ShootMode::CHIP) {
         rtp_message->shoot_mode = 1;
@@ -265,8 +265,9 @@ void to_sim(const RobotIntent& intent, const MotionSetpoint& setpoint, int shell
     command->set_left(-static_cast<float>(setpoint.xvelocity));
     command->set_angular(static_cast<float>(setpoint.avelocity));
 
-    sim->set_dribbler_speed(static_cast<float>(PARAM_max_dribbler_speed * 
-        (intent.dribbler_mode == RobotIntent::DribblerMode::ON ? 255.0 : 0.0)));
+    sim->set_dribbler_speed(
+        static_cast<float>(PARAM_max_dribbler_speed *
+                           (intent.dribbler_mode == RobotIntent::DribblerMode::ON ? 255.0 : 0.0)));
 }
 void ros_to_rtp(const rj_msgs::msg::ManipulatorSetpoint& manipulator,
                 const rj_msgs::msg::MotionSetpoint& motion, int shell, rtp::ControlMessage* rtp,

--- a/soccer/src/soccer/radio/packet_convert.cpp
+++ b/soccer/src/soccer/radio/packet_convert.cpp
@@ -172,10 +172,10 @@ void to_rtp(const RobotIntent& intent, const MotionSetpoint& setpoint, int shell
         static_cast<int16_t>(setpoint.yvelocity * rtp::ControlMessage::VELOCITY_SCALE_FACTOR);
     rtp_message->body_w =
         static_cast<int16_t>(setpoint.avelocity * rtp::ControlMessage::VELOCITY_SCALE_FACTOR);
-    rtp_message->dribbler_speed = std::clamp<uint16_t>(
-        static_cast<uint16_t>((intent.dribbler_mode == RobotIntent::DribblerMode::ON ? 1.0 : 0.0) *
-                              kMaxDribble),
-        0, 255);
+    rtp_message->dribbler_speed =
+        std::clamp<uint16_t>(static_cast<uint16_t>((
+            intent.dribbler_mode == RobotIntent::DribblerMode::ON ? kMaxDribble : 0.0
+        )), 0, 255);
 
     if (intent.shoot_mode == RobotIntent::ShootMode::CHIP) {
         rtp_message->shoot_mode = 1;

--- a/soccer/src/soccer/radio/packet_convert.cpp
+++ b/soccer/src/soccer/radio/packet_convert.cpp
@@ -172,10 +172,10 @@ void to_rtp(const RobotIntent& intent, const MotionSetpoint& setpoint, int shell
         static_cast<int16_t>(setpoint.yvelocity * rtp::ControlMessage::VELOCITY_SCALE_FACTOR);
     rtp_message->body_w =
         static_cast<int16_t>(setpoint.avelocity * rtp::ControlMessage::VELOCITY_SCALE_FACTOR);
-    rtp_message->dribbler_speed =
-        std::clamp<uint16_t>(static_cast<uint16_t>((
-            intent.dribbler_mode == RobotIntent::DribblerMode::ON ? kMaxDribble : 0.0
-        )), 0, 255);
+    rtp_message->dribbler_speed = std::clamp<uint16_t>(
+        static_cast<uint16_t>(
+            (intent.dribbler_mode == RobotIntent::DribblerMode::ON ? kMaxDribble : 0.0)),
+        0, 255);
 
     if (intent.shoot_mode == RobotIntent::ShootMode::CHIP) {
         rtp_message->shoot_mode = 1;

--- a/soccer/src/soccer/radio/packet_convert.cpp
+++ b/soccer/src/soccer/radio/packet_convert.cpp
@@ -198,8 +198,8 @@ void to_rtp(const RobotIntent& intent, const MotionSetpoint& setpoint, int shell
     }
 }
 
-void to_proto(const planning::Trajectory& trajectory, const MotionSetpoint& setpoint, int shell,
-              Packet::Robot* proto) {
+void to_proto(const planning::Trajectory& trajectory, const RobotIntent& intent,
+              const MotionSetpoint& setpoint, int shell, Packet::Robot* proto) {
     if (proto == nullptr) {
         return;
     }
@@ -212,7 +212,7 @@ void to_proto(const planning::Trajectory& trajectory, const MotionSetpoint& setp
     control->set_yvelocity(static_cast<float>(setpoint.yvelocity));
     control->set_avelocity(static_cast<float>(setpoint.avelocity));
     control->set_dvelocity(trajectory.dribbler_speed);
-    control->set_kcstrength(kicker_speed_to_strength(trajectory.kick_speed));
+    control->set_kcstrength(kicker_speed_to_strength(intent.kick_speed));
 
     switch (trajectory.shoot_mode) {
         case RobotIntent::ShootMode::KICK:
@@ -266,7 +266,7 @@ void to_sim(const RobotIntent& intent, const MotionSetpoint& setpoint, int shell
     command->set_angular(static_cast<float>(setpoint.avelocity));
 
     sim->set_dribbler_speed(static_cast<float>(PARAM_max_dribbler_speed * 
-        (intent.dribbler_mode == RobotIntent::DribblerMode::ON ? 1.0 : 0.0)));
+        (intent.dribbler_mode == RobotIntent::DribblerMode::ON ? 255.0 : 0.0)));
 }
 void ros_to_rtp(const rj_msgs::msg::ManipulatorSetpoint& manipulator,
                 const rj_msgs::msg::MotionSetpoint& motion, int shell, rtp::ControlMessage* rtp,

--- a/soccer/src/soccer/radio/packet_convert.cpp
+++ b/soccer/src/soccer/radio/packet_convert.cpp
@@ -173,7 +173,9 @@ void to_rtp(const RobotIntent& intent, const MotionSetpoint& setpoint, int shell
     rtp_message->body_w =
         static_cast<int16_t>(setpoint.avelocity * rtp::ControlMessage::VELOCITY_SCALE_FACTOR);
     rtp_message->dribbler_speed =
-        std::clamp<uint16_t>(static_cast<uint16_t>(intent.dribbler_speed * kMaxDribble), 0, 255);
+        std::clamp<uint16_t>(static_cast<uint16_t>((
+            intent.dribbler_mode == RobotIntent::DribblerMode::ON ? 1.0 : 0.0
+        )* kMaxDribble), 0, 255);
 
     if (intent.shoot_mode == RobotIntent::ShootMode::CHIP) {
         rtp_message->shoot_mode = 1;
@@ -196,7 +198,7 @@ void to_rtp(const RobotIntent& intent, const MotionSetpoint& setpoint, int shell
     }
 }
 
-void to_proto(const RobotIntent& intent, const MotionSetpoint& setpoint, int shell,
+void to_proto(const planning::Trajectory& trajectory, const MotionSetpoint& setpoint, int shell,
               Packet::Robot* proto) {
     if (proto == nullptr) {
         return;
@@ -209,10 +211,10 @@ void to_proto(const RobotIntent& intent, const MotionSetpoint& setpoint, int she
     control->set_xvelocity(static_cast<float>(setpoint.xvelocity));
     control->set_yvelocity(static_cast<float>(setpoint.yvelocity));
     control->set_avelocity(static_cast<float>(setpoint.avelocity));
-    control->set_dvelocity(intent.dribbler_speed);
-    control->set_kcstrength(kicker_speed_to_strength(intent.kick_speed));
+    control->set_dvelocity(trajectory.dribbler_speed);
+    control->set_kcstrength(kicker_speed_to_strength(trajectory.kick_speed));
 
-    switch (intent.shoot_mode) {
+    switch (trajectory.shoot_mode) {
         case RobotIntent::ShootMode::KICK:
             control->set_shootmode(Packet::Control_ShootMode_KICK);
             break;
@@ -221,7 +223,7 @@ void to_proto(const RobotIntent& intent, const MotionSetpoint& setpoint, int she
             break;
     }
 
-    switch (intent.trigger_mode) {
+    switch (trajectory.trigger_mode) {
         case RobotIntent::TriggerMode::STAND_DOWN:
             control->set_triggermode(Packet::Control_TriggerMode_STAND_DOWN);
             break;
@@ -263,7 +265,8 @@ void to_sim(const RobotIntent& intent, const MotionSetpoint& setpoint, int shell
     command->set_left(-static_cast<float>(setpoint.xvelocity));
     command->set_angular(static_cast<float>(setpoint.avelocity));
 
-    sim->set_dribbler_speed(static_cast<float>(PARAM_max_dribbler_speed * intent.dribbler_speed));
+    sim->set_dribbler_speed(static_cast<float>(PARAM_max_dribbler_speed * 
+        (intent.dribbler_mode == RobotIntent::DribblerMode::ON ? 1.0 : 0.0)));
 }
 void ros_to_rtp(const rj_msgs::msg::ManipulatorSetpoint& manipulator,
                 const rj_msgs::msg::MotionSetpoint& motion, int shell, rtp::ControlMessage* rtp,

--- a/soccer/src/soccer/radio/packet_convert.hpp
+++ b/soccer/src/soccer/radio/packet_convert.hpp
@@ -15,6 +15,7 @@
 
 #include "robot_status.hpp"
 #include "strategy/agent/position/positions.hpp"
+#include "planning/trajectory.hpp"
 
 #include "rc-fshare/rtp.hpp"
 
@@ -56,7 +57,7 @@ void ros_to_rtp(const rj_msgs::msg::ManipulatorSetpoint& manipulator,
                 const rj_msgs::msg::MotionSetpoint& motion, int shell, rtp::ControlMessage* rtp,
                 strategy::Positions role, bool blue_team);
 
-void to_proto(const RobotIntent& intent, const MotionSetpoint& setpoint,
+void to_proto(const planning::Trajectory& trajectory, const MotionSetpoint& setpoint,
               int shell, Packet::Robot* proto);
 
 void to_sim(const RobotIntent& intent, const MotionSetpoint& setpoint,

--- a/soccer/src/soccer/radio/packet_convert.hpp
+++ b/soccer/src/soccer/radio/packet_convert.hpp
@@ -57,8 +57,8 @@ void ros_to_rtp(const rj_msgs::msg::ManipulatorSetpoint& manipulator,
                 const rj_msgs::msg::MotionSetpoint& motion, int shell, rtp::ControlMessage* rtp,
                 strategy::Positions role, bool blue_team);
 
-void to_proto(const planning::Trajectory& trajectory, const MotionSetpoint& setpoint,
-              int shell, Packet::Robot* proto);
+void to_proto(const planning::Trajectory& trajectory, const RobotIntent& intent,
+              const MotionSetpoint& setpoint, int shell, Packet::Robot* proto);
 
 void to_sim(const RobotIntent& intent, const MotionSetpoint& setpoint,
             int shell, RobotCommand* sim);

--- a/soccer/src/soccer/radio/packet_convert.hpp
+++ b/soccer/src/soccer/radio/packet_convert.hpp
@@ -13,9 +13,9 @@
 #include <rj_protos/ssl_simulation_robot_feedback.pb.h>
 #include <robot_intent.hpp>
 
+#include "planning/trajectory.hpp"
 #include "robot_status.hpp"
 #include "strategy/agent/position/positions.hpp"
-#include "planning/trajectory.hpp"
 
 #include "rc-fshare/rtp.hpp"
 

--- a/soccer/src/soccer/robot_intent.hpp
+++ b/soccer/src/soccer/robot_intent.hpp
@@ -13,7 +13,8 @@ struct RobotIntent {
 
     using Msg = rj_msgs::msg::RobotIntent;
     enum ShootMode { KICK, CHIP };
-    enum TriggerMode { STAND_DOWN, IMMEDIATE, ON_BREAK_BEAM };
+    enum TriggerMode { STAND_DOWN, IMMEDIATE, ON_BREAK_BEAM, AT_END };
+    enum DribblerMode { OFF, ON, NEUTRAL };
 
     planning::MotionCommand motion_command;
 
@@ -22,8 +23,8 @@ struct RobotIntent {
 
     ShootMode shoot_mode = ShootMode::KICK;
     TriggerMode trigger_mode = TriggerMode::STAND_DOWN;
+    DribblerMode dribbler_mode = DribblerMode::NEUTRAL;
     float kick_speed = 0;
-    float dribbler_speed = 0;
 
     bool is_active = false;
 
@@ -47,8 +48,8 @@ struct RosConverter<RobotIntent, rj_msgs::msg::RobotIntent> {
             .local_obstacles(convert_to_ros(from.local_obstacles))
             .shoot_mode(static_cast<uint8_t>(from.shoot_mode))
             .trigger_mode(static_cast<uint8_t>(from.trigger_mode))
+            .dribbler_mode(static_cast<uint8_t>(from.dribbler_mode))
             .kick_speed(convert_to_ros(from.kick_speed))
-            .dribbler_speed(convert_to_ros(from.dribbler_speed))
             .is_active(convert_to_ros(from.is_active))
             .priority(convert_to_ros(from.priority));
     }
@@ -60,8 +61,8 @@ struct RosConverter<RobotIntent, rj_msgs::msg::RobotIntent> {
         result.local_obstacles = convert_from_ros(from.local_obstacles);
         result.shoot_mode = static_cast<RobotIntent::ShootMode>(from.shoot_mode);
         result.trigger_mode = static_cast<RobotIntent::TriggerMode>(from.trigger_mode);
+        result.dribbler_mode = static_cast<RobotIntent::DribblerMode>(from.dribbler_mode);
         result.kick_speed = convert_from_ros(from.kick_speed);
-        result.dribbler_speed = convert_from_ros(from.dribbler_speed);
         result.is_active = convert_from_ros(from.is_active);
         result.priority = convert_from_ros(from.priority);
         return result;

--- a/soccer/src/soccer/robot_intent.hpp
+++ b/soccer/src/soccer/robot_intent.hpp
@@ -13,8 +13,8 @@ struct RobotIntent {
 
     using Msg = rj_msgs::msg::RobotIntent;
     enum ShootMode { KICK, CHIP };
-    enum TriggerMode { STAND_DOWN, IMMEDIATE, ON_BREAK_BEAM, AT_END };
-    enum DribblerMode { OFF, ON, NEUTRAL };
+    enum TriggerMode { STAND_DOWN = 0, IMMEDIATE, ON_BREAK_BEAM, AT_END };
+    enum DribblerMode { OFF = 0, ON, DEFAULT };
 
     planning::MotionCommand motion_command;
 
@@ -23,7 +23,7 @@ struct RobotIntent {
 
     ShootMode shoot_mode = ShootMode::KICK;
     TriggerMode trigger_mode = TriggerMode::STAND_DOWN;
-    DribblerMode dribbler_mode = DribblerMode::NEUTRAL;
+    DribblerMode dribbler_mode = DribblerMode::DEFAULT;
     float kick_speed = 0;
 
     bool is_active = false;

--- a/soccer/src/soccer/strategy/agent/position/goalie.cpp
+++ b/soccer/src/soccer/strategy/agent/position/goalie.cpp
@@ -95,7 +95,7 @@ std::optional<RobotIntent> Goalie::state_to_task(RobotIntent intent) {
         pivot_cmd.target = target_instant;
         pivot_cmd.pivot_point = ball_pt;
         intent.motion_command = pivot_cmd;
-        intent.dribbler_speed = 255.0;
+        intent.dribbler_mode = RobotIntent::DribblerMode::ON;
         return intent;
     } else if (latest_state_ == CLEARING) {
         planning::LinearMotionInstant target{clear_point_};
@@ -108,7 +108,7 @@ std::optional<RobotIntent> Goalie::state_to_task(RobotIntent intent) {
         intent.shoot_mode = RobotIntent::ShootMode::CHIP;
         intent.trigger_mode = RobotIntent::TriggerMode::ON_BREAK_BEAM;
         intent.kick_speed = 4.0;
-        intent.dribbler_speed = 255.0;
+        intent.dribbler_mode = RobotIntent::DribblerMode::ON;
         intent.is_active = true;
 
         return intent;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -267,7 +267,6 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
 
             auto collect_cmd = planning::MotionCommand{"collect"};
             intent.motion_command = collect_cmd;
-            intent.dribbler_speed = 255.0;
             // }
 
             return intent;
@@ -296,7 +295,6 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
             // } else {
             auto collect_cmd = planning::MotionCommand{"collect"};
             intent.motion_command = collect_cmd;
-            intent.dribbler_speed = 255.0;
             // }
 
             return intent;

--- a/soccer/src/soccer/strategy/agent/position/pivot_test.cpp
+++ b/soccer/src/soccer/strategy/agent/position/pivot_test.cpp
@@ -55,7 +55,7 @@ std::optional<RobotIntent> Pivot::state_to_task(RobotIntent intent) {
                                                      false, last_world_state_->ball.position};
             pivot_cmd.pivot_radius = 1;
             intent.motion_command = pivot_cmd;
-            intent.dribbler_speed = 255.0;
+            intent.dribbler_mode = RobotIntent::DribblerMode::ON;
             return intent;
         }
         case OPP_GOAL: {
@@ -65,7 +65,7 @@ std::optional<RobotIntent> Pivot::state_to_task(RobotIntent intent) {
             pivot_cmd.pivot_radius = 1;
 
             intent.motion_command = pivot_cmd;
-            intent.dribbler_speed = 255.0;
+            intent.dribbler_mode = RobotIntent::DribblerMode::ON;
             return intent;
         }
         case IDLE: {

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
@@ -60,7 +60,7 @@ SoloOffense::State SoloOffense::next_state() {
             if (check_is_done()) {
                 counter_ = 0;
                 kick_ = true;
-                return KICK;
+                return MARKER;
             }
             return ROTATE;
         }
@@ -109,6 +109,8 @@ std::optional<RobotIntent> SoloOffense::state_to_task(RobotIntent intent) {
                 planning::MotionCommand{"rotate", target, planning::FaceTarget{}, false};
             intent.motion_command = pivot_cmd;
             intent.dribbler_mode = RobotIntent::DribblerMode::ON;
+            intent.trigger_mode = RobotIntent::TriggerMode::AT_END;
+            intent.kick_speed = 4.0;
             return intent;
         }
         case KICK: {

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
@@ -101,7 +101,6 @@ std::optional<RobotIntent> SoloOffense::state_to_task(RobotIntent intent) {
                 last_world_state_->get_robot(true, robot_id_).pose.position() + robotToBall};
             auto pivot_cmd = planning::MotionCommand{"collect"};
             intent.motion_command = pivot_cmd;
-            intent.dribbler_speed = 255;
             return intent;
         }
         case ROTATE: {
@@ -109,7 +108,7 @@ std::optional<RobotIntent> SoloOffense::state_to_task(RobotIntent intent) {
             auto pivot_cmd =
                 planning::MotionCommand{"rotate", target, planning::FaceTarget{}, false};
             intent.motion_command = pivot_cmd;
-            intent.dribbler_speed = 255;
+            intent.dribbler_mode = RobotIntent::DribblerMode::ON;
             return intent;
         }
         case KICK: {


### PR DESCRIPTION
We can now do manipulator in planners.
New robot intent commands:
TriggerMode: AT_END = at the end of the planner, kick (currently only supported by rotate, but can be expanded to any planner)
DribblerMode: OFF = dribbler off the whole planner
DribblerMode: ON = dribbler on the whole planner
DribblerMode: NEUTRAL = planners decide dribbler behavior

currently, shoot mode is done by strategy but we can have it overwriten by planners
kick speed is set by strategy
dribbler speed set by planners
