### PR TITLE
move RobotFactoryPosition overriding position subscription to AgentActionClient

### DIFF
--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -53,6 +53,10 @@ AgentActionClient::AgentActionClient(int r_id)
         ::referee::topics::kGoalieTopic, rclcpp::QoS(1).transient_local(),
         [this](rj_msgs::msg::Goalie::SharedPtr msg) { goalie_id_callback(msg->goalie_id); });
 
+    override_play_sub_ = create_subscription<rj_msgs::msg::OverridePosition>(
+        "override_position/robot_" + std::to_string(r_id), 1,
+        [this](rj_msgs::msg::OverridePosition::SharedPtr msg) { test_play_callback(msg); });
+        
     robot_communication_srv_ = create_service<rj_msgs::srv::AgentCommunication>(
         fmt::format("agent_{}_incoming", r_id),
         [this](const std::shared_ptr<rj_msgs::srv::AgentCommunication::Request> request,
@@ -109,6 +113,13 @@ void AgentActionClient::field_dimensions_callback(
     FieldDimensions field_dimensions = rj_convert::convert_from_ros(*msg);
     field_dimensions_ = field_dimensions;
     current_position_->update_field_dimensions(field_dimensions);
+}
+
+void AgentActionClient::test_play_callback(
+    const rj_msgs::msg::OverridePosition::SharedPtr message) {
+    if (current_position_) {
+        current_position_->set_override_position(message);
+    }
 }
 
 void AgentActionClient::goalie_id_callback(int goalie_id) {

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -56,7 +56,7 @@ AgentActionClient::AgentActionClient(int r_id)
     override_play_sub_ = create_subscription<rj_msgs::msg::OverridePosition>(
         "override_position/robot_" + std::to_string(r_id), 1,
         [this](rj_msgs::msg::OverridePosition::SharedPtr msg) { test_play_callback(msg); });
-        
+
     robot_communication_srv_ = create_service<rj_msgs::srv::AgentCommunication>(
         fmt::format("agent_{}_incoming", r_id),
         [this](const std::shared_ptr<rj_msgs::srv::AgentCommunication::Request> request,
@@ -118,7 +118,8 @@ void AgentActionClient::field_dimensions_callback(
 void AgentActionClient::test_play_callback(
     const rj_msgs::msg::OverridePosition::SharedPtr message) {
     if (current_position_) {
-        current_position_->set_override_position(static_cast<strategy::OverridingPositions>(message->overriding_position));
+        current_position_->set_override_position(
+            static_cast<strategy::OverridingPositions>(message->overriding_position));
     }
 }
 

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -118,7 +118,7 @@ void AgentActionClient::field_dimensions_callback(
 void AgentActionClient::test_play_callback(
     const rj_msgs::msg::OverridePosition::SharedPtr message) {
     if (current_position_) {
-        current_position_->set_override_position(message);
+        current_position_->set_override_position(static_cast<strategy::OverridingPositions>(message->overriding_position));
     }
 }
 

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -55,7 +55,7 @@ AgentActionClient::AgentActionClient(int r_id)
 
     override_play_sub_ = create_subscription<rj_msgs::msg::OverridePosition>(
         "override_position/robot_" + std::to_string(r_id), 1,
-        [this](rj_msgs::msg::OverridePosition::SharedPtr msg) { test_play_callback(msg); });
+        [this](rj_msgs::msg::OverridePosition::SharedPtr msg) { test_play_callback(msg); }); // NOLINT
 
     robot_communication_srv_ = create_service<rj_msgs::srv::AgentCommunication>(
         fmt::format("agent_{}_incoming", r_id),
@@ -116,7 +116,7 @@ void AgentActionClient::field_dimensions_callback(
 }
 
 void AgentActionClient::test_play_callback(
-    const rj_msgs::msg::OverridePosition::SharedPtr message) {
+    const rj_msgs::msg::OverridePosition::SharedPtr& message) {
     if (current_position_) {
         current_position_->set_override_position(
             static_cast<strategy::OverridingPositions>(message->overriding_position));

--- a/soccer/src/soccer/strategy/agent/agent_action_client.cpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.cpp
@@ -55,7 +55,9 @@ AgentActionClient::AgentActionClient(int r_id)
 
     override_play_sub_ = create_subscription<rj_msgs::msg::OverridePosition>(
         "override_position/robot_" + std::to_string(r_id), 1,
-        [this](rj_msgs::msg::OverridePosition::SharedPtr msg) { test_play_callback(msg); }); // NOLINT
+        [this](rj_msgs::msg::OverridePosition::SharedPtr msg) {
+            test_play_callback(msg);
+        });  // NOLINT
 
     robot_communication_srv_ = create_service<rj_msgs::srv::AgentCommunication>(
         fmt::format("agent_{}_incoming", r_id),

--- a/soccer/src/soccer/strategy/agent/agent_action_client.hpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.hpp
@@ -68,12 +68,12 @@ private:
     void field_dimensions_callback(const rj_msgs::msg::FieldDimensions::SharedPtr& msg);
     void alive_robots_callback(const rj_msgs::msg::AliveRobots::SharedPtr& msg);
     void game_settings_callback(const rj_msgs::msg::GameSettings::SharedPtr& msg);
-    void test_play_callback(const rj_msgs::msg::OverridePosition::SharedPtr message);
+    void test_play_callback(const rj_msgs::msg::OverridePosition::SharedPtr& message);
     void goalie_id_callback(int goalie_id);
 
     rclcpp::Publisher<AgentStateMsg>::SharedPtr current_state_publisher_;
 
-    std::unique_ptr<Position> current_position_;
+    std::unique_ptr<RobotFactoryPosition> current_position_;
 
     // ROS ActionClient spec, for calls to planning ActionServer
     rclcpp_action::Client<RobotMove>::SharedPtr client_ptr_;

--- a/soccer/src/soccer/strategy/agent/agent_action_client.hpp
+++ b/soccer/src/soccer/strategy/agent/agent_action_client.hpp
@@ -58,6 +58,8 @@ private:
     rclcpp::Subscription<rj_msgs::msg::AliveRobots>::SharedPtr alive_robots_sub_;
     rclcpp::Subscription<rj_msgs::msg::GameSettings>::SharedPtr game_settings_sub_;
     rclcpp::Subscription<rj_msgs::msg::Goalie>::SharedPtr goalie_id_sub_;
+    // subscription for test mode - Allows position overriding
+    rclcpp::Subscription<rj_msgs::msg::OverridePosition>::SharedPtr override_play_sub_;
     // TODO(Kevin): communication module pub/sub here (e.g. passing)
 
     // callbacks for subs
@@ -66,6 +68,7 @@ private:
     void field_dimensions_callback(const rj_msgs::msg::FieldDimensions::SharedPtr& msg);
     void alive_robots_callback(const rj_msgs::msg::AliveRobots::SharedPtr& msg);
     void game_settings_callback(const rj_msgs::msg::GameSettings::SharedPtr& msg);
+    void test_play_callback(const rj_msgs::msg::OverridePosition::SharedPtr message);
     void goalie_id_callback(int goalie_id);
 
     rclcpp::Publisher<AgentStateMsg>::SharedPtr current_state_publisher_;

--- a/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
+++ b/soccer/src/soccer/strategy/agent/position/overriding_positions.hpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 
-namespace Strategy {
+namespace strategy {
 /*
     OverridingPositions refers to the positions that can be manually set in the UI.
     Normally, all robots are set to Auto. If you want to add a new position, add a new value
@@ -24,4 +24,4 @@ enum OverridingPositions {
     IDLE,
 };
 
-}  // namespace Strategy
+}  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -15,12 +15,12 @@
 #include <rj_msgs/msg/alive_robots.hpp>
 
 #include "game_state.hpp"
+#include "overriding_positions.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "rj_msgs/action/robot_move.hpp"
 #include "robot_intent.hpp"
 #include "world_state.hpp"
-#include "overriding_positions.hpp"
 
 // Communication
 #include "../communication/communication.hpp"
@@ -29,10 +29,10 @@
 #include <rj_msgs/msg/ball_in_transit_request.hpp>
 #include <rj_msgs/msg/incoming_ball_request.hpp>
 #include <rj_msgs/msg/kicker_request.hpp>
+#include <rj_msgs/msg/override_position.hpp>
 #include <rj_msgs/msg/pass_request.hpp>
 #include <rj_msgs/msg/position_request.hpp>
 #include <rj_msgs/msg/test_request.hpp>
-#include <rj_msgs/msg/override_position.hpp>
 
 // Responses
 #include <rj_msgs/msg/acknowledge.hpp>
@@ -231,7 +231,7 @@ public:
      */
     virtual void set_goalie_id(int goalie_id);
 
-    virtual void set_override_position(const strategy::OverridingPositions overriding_position) {};
+    virtual void set_override_position(const strategy::OverridingPositions overriding_position){};
 
 protected:
     Position(int r_id, std::string position_name);

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -31,6 +31,7 @@
 #include <rj_msgs/msg/pass_request.hpp>
 #include <rj_msgs/msg/position_request.hpp>
 #include <rj_msgs/msg/test_request.hpp>
+#include <rj_msgs/msg/override_position.hpp>
 
 // Responses
 #include <rj_msgs/msg/acknowledge.hpp>
@@ -228,6 +229,8 @@ public:
      * @brief setter for goalie id
      */
     virtual void set_goalie_id(int goalie_id);
+
+    virtual void set_override_position(const rj_msgs::msg::OverridePosition::SharedPtr message) {};
 
 protected:
     Position(int r_id, std::string position_name);

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -231,8 +231,6 @@ public:
      */
     virtual void set_goalie_id(int goalie_id);
 
-    virtual void set_override_position(const strategy::OverridingPositions overriding_position){};
-
 protected:
     Position(int r_id, std::string position_name);
 

--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -20,6 +20,7 @@
 #include "rj_msgs/action/robot_move.hpp"
 #include "robot_intent.hpp"
 #include "world_state.hpp"
+#include "overriding_positions.hpp"
 
 // Communication
 #include "../communication/communication.hpp"
@@ -230,7 +231,7 @@ public:
      */
     virtual void set_goalie_id(int goalie_id);
 
-    virtual void set_override_position(const rj_msgs::msg::OverridePosition::SharedPtr message) {};
+    virtual void set_override_position(const strategy::OverridingPositions overriding_position) {};
 
 protected:
     Position(int r_id, std::string position_name);

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -330,9 +330,8 @@ std::string RobotFactoryPosition::get_current_state() {
 }
 
 void RobotFactoryPosition::set_override_position(
-    const rj_msgs::msg::OverridePosition::SharedPtr message) {
-    override_play_position_ =
-        static_cast<Strategy::OverridingPositions>(message->overriding_position);
+    const strategy::OverridingPositions overriding_position) {
+    override_play_position_ = overriding_position;
 }
 
 /**
@@ -341,39 +340,39 @@ void RobotFactoryPosition::set_override_position(
  */
 bool RobotFactoryPosition::set_position_override_if_requested() {
     switch (override_play_position_) {
-        case Strategy::OverridingPositions::OFFENSE: {
+        case strategy::OverridingPositions::OFFENSE: {
             set_current_position<Offense>();
             return true;
         }
-        case Strategy::OverridingPositions::DEFENSE: {
+        case strategy::OverridingPositions::DEFENSE: {
             set_current_position<Defense>();
             return true;
         }
-        case Strategy::OverridingPositions::FREE_KICKER: {
+        case strategy::OverridingPositions::FREE_KICKER: {
             set_current_position<FreeKicker>();
             return true;
         }
-        case Strategy::OverridingPositions::PENALTY_PLAYER: {
+        case strategy::OverridingPositions::PENALTY_PLAYER: {
             set_current_position<PenaltyPlayer>();
             return true;
         }
-        case Strategy::OverridingPositions::PENALTY_NON_KICKER: {
+        case strategy::OverridingPositions::PENALTY_NON_KICKER: {
             set_current_position<PenaltyNonKicker>();
             return true;
         }
-        case Strategy::OverridingPositions::SMART_IDLE: {
+        case strategy::OverridingPositions::SMART_IDLE: {
             set_current_position<SmartIdle>();
             return true;
         }
-        case Strategy::OverridingPositions::SOLO_OFFENSE: {
+        case strategy::OverridingPositions::SOLO_OFFENSE: {
             set_current_position<SoloOffense>();
             return true;
         }
-        case Strategy::OverridingPositions::ZONER: {
+        case strategy::OverridingPositions::ZONER: {
             set_current_position<Zoner>();
             return true;
         }
-        case Strategy::OverridingPositions::IDLE: {
+        case strategy::OverridingPositions::IDLE: {
             set_current_position<Idle>();
             return true;
         }

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -15,14 +15,6 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id) : Position(r_id, "RobotFact
     } else {
         current_position_ = std::make_unique<Defense>(robot_id_);
     }
-
-    std::string node_name{"robot_factory_position_"};
-    _node = std::make_shared<rclcpp::Node>(node_name.append(std::to_string(robot_id_)));
-    override_play_sub_ = _node->create_subscription<rj_msgs::msg::OverridePosition>(
-        "override_position/robot_" + std::to_string(robot_id_), 1,
-        [this](const rj_msgs::msg::OverridePosition::SharedPtr msg) { test_play_callback(msg); });
-    _executor.add_node(_node);
-    _executor_thread = std::thread([this]() { _executor.spin(); });
 }
 
 std::optional<RobotIntent> RobotFactoryPosition::derived_get_task([
@@ -337,7 +329,7 @@ std::string RobotFactoryPosition::get_current_state() {
     return current_position_->get_current_state();
 }
 
-void RobotFactoryPosition::test_play_callback(
+void RobotFactoryPosition::set_override_position(
     const rj_msgs::msg::OverridePosition::SharedPtr message) {
     override_play_position_ =
         static_cast<Strategy::OverridingPositions>(message->overriding_position);

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -330,7 +330,7 @@ std::string RobotFactoryPosition::get_current_state() {
 }
 
 void RobotFactoryPosition::set_override_position(
-    const strategy::OverridingPositions overriding_position) {
+    const strategy::OverridingPositions& overriding_position) {
     override_play_position_ = overriding_position;
 }
 

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
@@ -110,12 +110,12 @@ public:
         current_position_->send_pass_confirmation(target_robot);
     }
 
-    void set_override_position(const strategy::OverridingPositions overriding_position) override;
+    void set_override_position(const OverridingPositions& overriding_position);
 
 private:
     std::unique_ptr<Position> current_position_;
 
-    strategy::OverridingPositions override_play_position_{strategy::OverridingPositions::AUTO};
+    OverridingPositions override_play_position_{OverridingPositions::AUTO};
 
     std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
 

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
@@ -110,16 +110,12 @@ public:
         current_position_->send_pass_confirmation(target_robot);
     }
 
+    void set_override_position(const rj_msgs::msg::OverridePosition::SharedPtr message) override;
+
 private:
     std::unique_ptr<Position> current_position_;
 
-    // subscription for test mode - Allows position overriding
-    rclcpp::Subscription<rj_msgs::msg::OverridePosition>::SharedPtr override_play_sub_;
-    rclcpp::executors::SingleThreadedExecutor _executor;
-    std::thread _executor_thread;
-    void test_play_callback(const rj_msgs::msg::OverridePosition::SharedPtr message);
     Strategy::OverridingPositions override_play_position_{Strategy::OverridingPositions::AUTO};
-    rclcpp::Node::SharedPtr _node;
 
     std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
 

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.hpp
@@ -110,12 +110,12 @@ public:
         current_position_->send_pass_confirmation(target_robot);
     }
 
-    void set_override_position(const rj_msgs::msg::OverridePosition::SharedPtr message) override;
+    void set_override_position(const strategy::OverridingPositions overriding_position) override;
 
 private:
     std::unique_ptr<Position> current_position_;
 
-    Strategy::OverridingPositions override_play_position_{Strategy::OverridingPositions::AUTO};
+    strategy::OverridingPositions override_play_position_{strategy::OverridingPositions::AUTO};
 
     std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
 


### PR DESCRIPTION
## Description
RobotFactoryPosition currently spins up a subscription to listen for overriding positions. This is inconsistent with our current design--AgentActionClient should be interacting with ROS instead.

## Testing
Overriding position works as it did before