### PR TITLE
Kickoff formation

### DIFF
--- a/launch/soccer.launch.py
+++ b/launch/soccer.launch.py
@@ -191,7 +191,6 @@ def generate_launch_description():
                 executable="agent_action_client_node",
                 output="screen",
                 parameters=[param_config_filepath],
-                prefix=['xterm -e gdb -ex run --args'],
                 on_exit=Shutdown(),
             ),
             Node(

--- a/launch/soccer.launch.py
+++ b/launch/soccer.launch.py
@@ -191,6 +191,7 @@ def generate_launch_description():
                 executable="agent_action_client_node",
                 output="screen",
                 parameters=[param_config_filepath],
+                prefix=['xterm -e gdb -ex run --args'],
                 on_exit=Shutdown(),
             ),
             Node(

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -627,7 +627,10 @@ void Offense::broadcast_seeker_request(rj_geometry::Point seeking_point, bool ad
     communication_requests_.push_back(communication_request);
 }
 
-// NOTE: If the kickoff formation implementation changes this method will also need to
+// NOTE: This method will change when coordinators are added
+/**
+ * Joins a kickoff formation given a point as a vector of doubles.
+ */
 void Offense::join_kickoff_formation(std::vector<double> point) {
     if (point.size() != 2) {
         SPDLOG_INFO("Invalid point for kickoff formation.");
@@ -635,6 +638,6 @@ void Offense::join_kickoff_formation(std::vector<double> point) {
 
     formation_point_ = point;
 
-    current_state_ = Offense::State::KICKOFF_FORMATION_START;
+    current_state_ = Offense::State::KICKOFF_FORMATION;
 }
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -125,9 +125,8 @@ Offense::State Offense::next_state() {
                 // (because is_done for settle/collect are not great)
                 if (distance_to_ball() < kOwnBallRadius) {
                     return POSSESSION_START;
-                } 
+                }
                 return DEFAULT;
-                
             }
 
             return STEALING;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -178,21 +178,12 @@ Offense::State Offense::next_state() {
             return SHOOTING;
         }
 
-        case KICKOFF_FORMATION_START: {
-            if (current_play_state_.is_kickoff() && !check_is_done()) {
-                return KICKOFF_FORMATION_START;
-            } else if (current_play_state_.is_kickoff()) {
+        case KICKOFF_FORMATION: {
+            if (current_play_state_.is_kickoff()) {
                 return KICKOFF_FORMATION;
             } else {
                 return DEFAULT;
             }
-        }
-
-        case KICKOFF_FORMATION: {
-            if (!current_play_state_.is_kickoff()) {
-                return DEFAULT;
-            }
-            return KICKOFF_FORMATION;
         }
     }
 }
@@ -290,7 +281,6 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
             return intent;
         }
 
-        case KICKOFF_FORMATION:
         case RECEIVING_START: {
             // Turn to face the ball
 
@@ -357,16 +347,15 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
             return intent;
         }
 
-        case KICKOFF_FORMATION_START: {
-            rj_geometry::Point formation_pos = 
+        case KICKOFF_FORMATION: {
+            rj_geometry::Point formation_pos =
                 rj_geometry::Point(formation_point_.at(0), formation_point_.at(1));
-            planning::LinearMotionInstant target {formation_pos};
+            planning::LinearMotionInstant target{formation_pos};
             auto go_to_cmd = planning::MotionCommand{"path_target", target, planning::FaceBall{}};
 
             intent.motion_command = go_to_cmd;
             return intent;
         }
-
     }
 }
 
@@ -647,6 +636,5 @@ void Offense::join_kickoff_formation(std::vector<double> point) {
     formation_point_ = point;
 
     current_state_ = Offense::State::KICKOFF_FORMATION_START;
-
 }
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -125,9 +125,9 @@ Offense::State Offense::next_state() {
                 // (because is_done for settle/collect are not great)
                 if (distance_to_ball() < kOwnBallRadius) {
                     return POSSESSION_START;
-                } else {
-                    return DEFAULT;
-                }
+                } 
+                return DEFAULT;
+                
             }
 
             return STEALING;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -348,9 +348,7 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
         }
 
         case KICKOFF_FORMATION: {
-            rj_geometry::Point formation_pos =
-                rj_geometry::Point(formation_point_.at(0), formation_point_.at(1));
-            planning::LinearMotionInstant target{formation_pos};
+            planning::LinearMotionInstant target{formation_point_};
             auto go_to_cmd = planning::MotionCommand{"path_target", target, planning::FaceBall{}};
 
             intent.motion_command = go_to_cmd;
@@ -631,11 +629,7 @@ void Offense::broadcast_seeker_request(rj_geometry::Point seeking_point, bool ad
 /**
  * Joins a kickoff formation given a point as a vector of doubles.
  */
-void Offense::join_kickoff_formation(std::vector<double> point) {
-    if (point.size() != 2) {
-        SPDLOG_INFO("Invalid point for kickoff formation.");
-    }
-
+void Offense::join_kickoff_formation(rj_geometry::Point point) {
     formation_point_ = point;
 
     current_state_ = Offense::State::KICKOFF_FORMATION;

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -177,6 +177,23 @@ Offense::State Offense::next_state() {
 
             return SHOOTING;
         }
+
+        case KICKOFF_FORMATION_START: {
+            if (current_play_state_.is_kickoff() && !check_is_done()) {
+                return KICKOFF_FORMATION_START;
+            } else if (current_play_state_.is_kickoff()) {
+                return KICKOFF_FORMATION;
+            } else {
+                return DEFAULT;
+            }
+        }
+
+        case KICKOFF_FORMATION: {
+            if (!current_play_state_.is_kickoff()) {
+                return DEFAULT;
+            }
+            return KICKOFF_FORMATION;
+        }
     }
 }
 
@@ -336,6 +353,16 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
             intent.trigger_mode = RobotIntent::TriggerMode::ON_BREAK_BEAM;
             intent.kick_speed = 4.0;
 
+            return intent;
+        }
+
+        case KICKOFF_FORMATION_START: {
+            rj_geometry::Point formation_pos = 
+                rj_geometry::Point(formation_point_.at(0), formation_point_.at(1));
+            planning::LinearMotionInstant target {formation_pos};
+            auto go_to_cmd = planning::MotionCommand{"path_target", target, planning::FaceBall{}};
+
+            intent.motion_command = go_to_cmd;
             return intent;
         }
     }
@@ -607,5 +634,17 @@ void Offense::broadcast_seeker_request(rj_geometry::Point seeking_point, bool ad
     communication_request.urgent = false;
     communication_request.broadcast = true;
     communication_requests_.push_back(communication_request);
+}
+
+// NOTE: If the kickoff formation implementation changes this method will also need to
+void Offense::join_kickoff_formation(std::vector<double> point) {
+    if (point.size() != 2) {
+        SPDLOG_INFO("Invalid point for kickoff formation.");
+    }
+
+    formation_point_ = point;
+
+    current_state_ = Offense::State::KICKOFF_FORMATION_START;
+
 }
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.cpp
@@ -290,6 +290,7 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
             return intent;
         }
 
+        case KICKOFF_FORMATION:
         case RECEIVING_START: {
             // Turn to face the ball
 
@@ -365,6 +366,7 @@ std::optional<RobotIntent> Offense::state_to_task(RobotIntent intent) {
             intent.motion_command = go_to_cmd;
             return intent;
         }
+
     }
 }
 

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -41,7 +41,7 @@ public:
 
     std::string get_current_state() override;
 
-    void join_kickoff_formation(std::vector<double> point);
+    void join_kickoff_formation(rj_geometry::Point point);
 
 private:
     /**
@@ -246,7 +246,7 @@ private:
     std::unordered_map<int, rj_geometry::Point> seeker_points_;
 
     // Spot that a robot in a formation must assume.
-    std::vector<double> formation_point_{{0, 0}};
+    rj_geometry::Point formation_point_{0, 0};
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -50,20 +50,19 @@ private:
     std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
 
     enum State {
-        DEFAULT,                   // Decide what to do
-        SEEKING_START,             // Calculate seeking point
-        SEEKING,                   // Get open
-        POSSESSION_START,          // Try to shoot and send pass request
-        POSSESSION,                // Holding the ball
-        PASSING_START,             // Prepare to pass
-        PASSING,                   // Getting rid of it
-        STEALING,                  // Getting the ball
-        RECEIVING_START,           // Facing the ball
-        RECEIVING,                 // Getting the ball from a pass
-        SHOOTING_START,            // Calculate shot
-        SHOOTING,                  // Winning the game
-        KICKOFF_FORMATION_START,   // Joining formation, i.e. going to a point
-        KICKOFF_FORMATION,         // Holding the point and facing the ball while in current game state
+        DEFAULT,            // Decide what to do
+        SEEKING_START,      // Calculate seeking point
+        SEEKING,            // Get open
+        POSSESSION_START,   // Try to shoot and send pass request
+        POSSESSION,         // Holding the ball
+        PASSING_START,      // Prepare to pass
+        PASSING,            // Getting rid of it
+        STEALING,           // Getting the ball
+        RECEIVING_START,    // Facing the ball
+        RECEIVING,          // Getting the ball from a pass
+        SHOOTING_START,     // Calculate shot
+        SHOOTING,           // Winning the game
+        KICKOFF_FORMATION,  // Going to pre-determined location for kickoff
     };
 
     /**
@@ -247,7 +246,7 @@ private:
     std::unordered_map<int, rj_geometry::Point> seeker_points_;
 
     // Spot that a robot in a formation must assume.
-    std::vector<double> formation_point_ {{0, 0}};
+    std::vector<double> formation_point_{{0, 0}};
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -117,6 +117,8 @@ private:
                 return RJ::Seconds{3};
             case SHOOTING:
                 return RJ::Seconds{-1};
+            case KICKOFF_FORMATION:
+                return RJ::Seconds{-1};
         }
     }
 
@@ -147,6 +149,8 @@ private:
                 return "SHOOTING_START";
             case SHOOTING:
                 return "SHOOTING";
+            case KICKOFF_FORMATION:
+                return "KICKOFF_FORMATION";
         }
     }
 

--- a/soccer/src/soccer/strategy/agent/position/offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/offense.hpp
@@ -41,6 +41,8 @@ public:
 
     std::string get_current_state() override;
 
+    void join_kickoff_formation(std::vector<double> point);
+
 private:
     /**
      * @brief Overriden from Position. Calls next_state and then state_to_task on each tick.
@@ -48,18 +50,20 @@ private:
     std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
 
     enum State {
-        DEFAULT,           // Decide what to do
-        SEEKING_START,     // Calculate seeking point
-        SEEKING,           // Get open
-        POSSESSION_START,  // Try to shoot and send pass request
-        POSSESSION,        // Holding the ball
-        PASSING_START,     // Prepare to pass
-        PASSING,           // Getting rid of it
-        STEALING,          // Getting the ball
-        RECEIVING_START,   // Facing the ball
-        RECEIVING,         // Getting the ball from a pass
-        SHOOTING_START,    // Calculate shot
-        SHOOTING,          // Winning the game
+        DEFAULT,                   // Decide what to do
+        SEEKING_START,             // Calculate seeking point
+        SEEKING,                   // Get open
+        POSSESSION_START,          // Try to shoot and send pass request
+        POSSESSION,                // Holding the ball
+        PASSING_START,             // Prepare to pass
+        PASSING,                   // Getting rid of it
+        STEALING,                  // Getting the ball
+        RECEIVING_START,           // Facing the ball
+        RECEIVING,                 // Getting the ball from a pass
+        SHOOTING_START,            // Calculate shot
+        SHOOTING,                  // Winning the game
+        KICKOFF_FORMATION_START,   // Joining formation, i.e. going to a point
+        KICKOFF_FORMATION,         // Holding the point and facing the ball while in current game state
     };
 
     /**
@@ -241,6 +245,9 @@ private:
     void broadcast_seeker_request(rj_geometry::Point seeking_point, bool adding);
 
     std::unordered_map<int, rj_geometry::Point> seeker_points_;
+
+    // Spot that a robot in a formation must assume.
+    std::vector<double> formation_point_ {{0, 0}};
 };
 
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -153,7 +153,7 @@ void RobotFactoryPosition::update_position() {
                             set_current_position<PenaltyPlayer>();
                         }
                     } else {
-                        if (current_play_state_.is_kickoff()) {
+                        if (current_play_state_.is_kickoff()) { // TODO: Change to update position such that a formation is created
                             set_current_position<Defense>();
                         } else if (current_play_state_.is_penalty()) {
                             // set_current_position<SmartIdle>();
@@ -173,7 +173,7 @@ void RobotFactoryPosition::update_position() {
                 }
 
             } else {  // Their restart
-                if (current_play_state_.is_kickoff()) {
+                if (current_play_state_.is_kickoff()) { // TODO: Possibly change to create a formation. May not be necessary; ball is not ours
                     set_current_position<Defense>();
                 } else if (current_play_state_.is_penalty()) {
                     // set_current_position<SmartIdle>();

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -154,7 +154,23 @@ void RobotFactoryPosition::update_position() {
                         }
                     } else {
                         if (current_play_state_.is_kickoff()) { // TODO: Change to update position such that a formation is created
-                            set_current_position<Defense>();
+                            if (robot_id_ == 5) {
+                                set_current_position<Offense>();
+                                Position* base_pos = current_position_.get();
+                                if (dynamic_cast<Offense*>(base_pos) != nullptr) {
+                                    Offense* offense_pos = dynamic_cast<Offense*>(base_pos);
+                                    offense_pos->join_kickoff_formation({1.8, 3.5});
+                                }
+                            } else if (robot_id_ == 4) {
+                                set_current_position<Offense>();
+                                Position* base_pos = current_position_.get();
+                                if (dynamic_cast<Offense*>(base_pos) != nullptr) {
+                                    Offense* offense_pos = dynamic_cast<Offense*>(base_pos);
+                                    offense_pos->join_kickoff_formation({-1.8, 3.5});
+                                }
+                            } else {
+                                set_current_position<Defense>();
+                            }
                         } else if (current_play_state_.is_penalty()) {
                             // set_current_position<SmartIdle>();
                             set_current_position<PenaltyNonKicker>();
@@ -173,7 +189,7 @@ void RobotFactoryPosition::update_position() {
                 }
 
             } else {  // Their restart
-                if (current_play_state_.is_kickoff()) { // TODO: Possibly change to create a formation. May not be necessary; ball is not ours
+                if (current_play_state_.is_kickoff()) {
                     set_current_position<Defense>();
                 } else if (current_play_state_.is_penalty()) {
                     // set_current_position<SmartIdle>();

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -153,8 +153,9 @@ void RobotFactoryPosition::update_position() {
                             set_current_position<PenaltyPlayer>();
                         }
                     } else {
-                        if (current_play_state_.is_kickoff()) { // TODO: Change to update position such that a formation is created
-                            if (robot_id_ == 5) {
+                        if (current_play_state_.is_kickoff()) {  // Sets up a kickoff formation
+                            if (robot_id_ ==
+                                5) {  // NOTE: Will be replaced when Coordinators are added
                                 set_current_position<Offense>();
                                 Position* base_pos = current_position_.get();
                                 if (dynamic_cast<Offense*>(base_pos) != nullptr) {


### PR DESCRIPTION
## Description
Describe your pull request.
Added formation that robots will enter for a kickoff. Two robots, currently 5 and 4, are sent to pre-determined locations on the map when a kickoff is initially called. They stay there until the game proceeds.

NOTE: This hard-coded formation and hard-coded robots will change when we add Coordinators, so the addition of a Formation type or a coordinator to set up formations should be added to the backlog.
## Associated / Resolved Issue
Resolves # or [ClickUp card](link-to-clickup-card)

## Design Documents
[Link](link-to-design-doc)

## Steps to Test
### Test Case 1
1. Step 1. Start up the stack.
2. Step 2. Click the kickoff button for yellow.
3. Step 3. Wait for all robots to be in position, then click the yellow or green check marks.

**Expected result:**
Robots 5 and 4 should be sent to positions on either side of the kicking robot, then move from those positions when the game properly starts.

## Key Files to Review
Group 1
 * File 1. offense.cpp and hpp
 * File 2 robot_factory_position.cpp and hpp


## Review Checklist

- [ ] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [ ] **Remove extra print statements**: Any print statements used for debugging should be removed
- [ ] **Tag reviewers**: Tag some people for review and ping them on Slack

## (Optional) Sub-issues (for drafts)
_Note: if you find yourself breaking this PR into many smaller features, it may make sense to break up the PR into logical units based on these features._
- [ ] Step 1
- [ ] Step 2
