### PR TITLE
added SoloOffense collect+pivot-kick behavior

### DIFF
--- a/soccer/src/soccer/strategy/agent/position/position.hpp
+++ b/soccer/src/soccer/strategy/agent/position/position.hpp
@@ -302,7 +302,7 @@ protected:
     // true if this robot is alive
     bool alive = false;
 
-    // protected to allow WorldState to be accessed directly by deriveed
+    // protected to allow WorldState to be accessed directly by derivees
     WorldState* last_world_state_;
 
     // Current goalie

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -16,6 +16,15 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id) : Position(r_id, "RobotFact
         current_position_ = std::make_unique<Defense>(robot_id_);
     }
 
+    // Override for testing SoloOffense on branch solo-pivot-kick
+    if (robot_id_ == 0) {
+        current_position_ = std::make_unique<Goalie>(robot_id_);
+    } else if (robot_id_ == 1) {
+        current_position_ = std::make_unique<SoloOffense>(robot_id_);
+    } else {
+        current_position_ = std::make_unique<Defense>(robot_id_);
+    }
+
     std::string node_name{"robot_factory_position_"};
     _node = std::make_shared<rclcpp::Node>(node_name.append(std::to_string(robot_id_)));
     override_play_sub_ = _node->create_subscription<rj_msgs::msg::OverridePosition>(
@@ -242,6 +251,9 @@ void RobotFactoryPosition::set_default_position() {
             robots_copy.emplace_back(i, last_world_state_->our_robots[i].pose.position().y());
         }
     }
+
+    // Override for testing SoloOffense on branch solo-pivot-kick
+    return;
 
     std::sort(robots_copy.begin(), robots_copy.end(),
               [](RobotPos const& a, RobotPos const& b) { return a.second < b.second; });

--- a/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
+++ b/soccer/src/soccer/strategy/agent/position/robot_factory_position.cpp
@@ -16,15 +16,6 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id) : Position(r_id, "RobotFact
         current_position_ = std::make_unique<Defense>(robot_id_);
     }
 
-    // Override for testing SoloOffense on branch solo-pivot-kick
-    if (robot_id_ == 0) {
-        current_position_ = std::make_unique<Goalie>(robot_id_);
-    } else if (robot_id_ == 1) {
-        current_position_ = std::make_unique<SoloOffense>(robot_id_);
-    } else {
-        current_position_ = std::make_unique<Defense>(robot_id_);
-    }
-
     std::string node_name{"robot_factory_position_"};
     _node = std::make_shared<rclcpp::Node>(node_name.append(std::to_string(robot_id_)));
     override_play_sub_ = _node->create_subscription<rj_msgs::msg::OverridePosition>(
@@ -251,9 +242,6 @@ void RobotFactoryPosition::set_default_position() {
             robots_copy.emplace_back(i, last_world_state_->our_robots[i].pose.position().y());
         }
     }
-
-    // Override for testing SoloOffense on branch solo-pivot-kick
-    return;
 
     std::sort(robots_copy.begin(), robots_copy.end(),
               [](RobotPos const& a, RobotPos const& b) { return a.second < b.second; });

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
@@ -113,16 +113,6 @@ std::optional<RobotIntent> SoloOffense::state_to_task(RobotIntent intent) {
             return intent;
         }
         case SHOOTING_START: {
-            // TODO: coconut.vtf (deleting this section causes the simulator to crash)
-            rj_geometry::Point robotToBall =
-                (last_world_state_->ball.position -
-                 last_world_state_->get_robot(true, robot_id_).pose.position());
-            double slowDown = 1.0;
-            double length = robotToBall.mag() - kRobotRadius * slowDown;
-            robotToBall = robotToBall.normalized(length);
-            planning::LinearMotionInstant target{last_world_state_->get_robot(true, robot_id_).pose.position() + robotToBall};
-            // END TODO
-
             auto cmd = planning::MotionCommand{"collect"};
 
             intent.motion_command = cmd;

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
@@ -11,13 +11,14 @@ SoloOffense::SoloOffense(int r_id) : Position{r_id, "SoloOffense"} {}
 std::optional<RobotIntent> SoloOffense::derived_get_task(RobotIntent intent) {
     // Get next state.
     State new_state = DEFAULT;
-    if (!timed_out()) { // on timeout, move to DEFAULT
+    if (!timed_out()) {  // on timeout, move to DEFAULT
         new_state = next_state();
     }
 
     // Check if a transition occurred.
     if (new_state != current_state_) {
-        SPDLOG_INFO("Robot {}: Transitioned from {} -> {}", robot_id_,  state_to_name(current_state_),  state_to_name(new_state));
+        SPDLOG_INFO("Robot {}: Transitioned from {} -> {}", robot_id_,
+                    state_to_name(current_state_), state_to_name(new_state));
         reset_timeout();
     }
     current_state_ = new_state;
@@ -30,7 +31,8 @@ std::optional<RobotIntent> SoloOffense::derived_get_task(RobotIntent intent) {
  * @brief A richer to_string.
  */
 std::string SoloOffense::get_current_state() {
-    return std::string("SoloOffense-") + std::string(state_to_name(current_state_)); // SoloOffense-MARKER, e.g.
+    return std::string("SoloOffense-") +
+           std::string(state_to_name(current_state_));  // SoloOffense-MARKER, e.g.
 }
 
 /**
@@ -41,13 +43,12 @@ SoloOffense::State SoloOffense::next_state() {
     rj_geometry::Point our_pose = last_world_state_->get_robot(true, robot_id_).pose.position();
     double our_dist = our_pose.dist_to(ball_pose);
 
-
     // Scan opponent positions to determine transition.
     double closest_dist = std::numeric_limits<double>::infinity();
-    for (int i = 0; i < 6; i++) { // TODO: replace 6 with number of opponent robots (to be proper)
+    for (int i = 0; i < 6; i++) {  // TODO: replace 6 with number of opponent robots (to be proper)
         RobotState opp = last_world_state_->get_robot(false, i);
         rj_geometry::Point opp_pose = opp.pose.position();
-        double opp_dist = opp_pose.dist_to(ball_pose); // distance from opp to ball
+        double opp_dist = opp_pose.dist_to(ball_pose);  // distance from opp to ball
         if (opp_dist < closest_dist) {
             marking_id_ = i;
             closest_dist = opp_dist;
@@ -57,10 +58,11 @@ SoloOffense::State SoloOffense::next_state() {
     // closest_dist contains the distance from the robot to the ball
 
     // UNCONDITIONAL TRANSITIONS
-    if (!field_dimensions_.field_coordinates().contains_point(ball_pose)) { // Ball OOB.
+    if (!field_dimensions_.field_coordinates().contains_point(ball_pose)) {  // Ball OOB.
         return DEFAULT;
     }
-    if ((our_dist > closest_dist) && (closest_dist < kPosessionRadius)) { // Opponent vaguely has possession.
+    if ((our_dist > closest_dist) &&
+        (closest_dist < kPosessionRadius)) {  // Opponent vaguely has possession.
         return MARKER;
     }
     // CONDITIONAL TRANSITIONS
@@ -71,15 +73,21 @@ SoloOffense::State SoloOffense::next_state() {
             return SHOOTING_START;
         }
         case SHOOTING_START: {
-            if (check_is_done()) { return SHOOTING_PIVOT; } // ball is collected
+            if (check_is_done()) {
+                return SHOOTING_PIVOT;
+            }  // ball is collected
             return SHOOTING_START;
         }
         case SHOOTING_PIVOT: {
-            if (check_is_done()) { return SHOOTING_KICK; } // is facing target
+            if (check_is_done()) {
+                return SHOOTING_KICK;
+            }  // is facing target
             return SHOOTING_PIVOT;
         }
         case SHOOTING_KICK: {
-            if (our_pose.dist_to(ball_pose) > kPosessionRadius) { return DEFAULT; } // ball is kicked (or we've been robbed)
+            if (our_pose.dist_to(ball_pose) > kPosessionRadius) {
+                return DEFAULT;
+            }  // ball is kicked (or we've been robbed)
             return SHOOTING_KICK;
         }
     }
@@ -99,15 +107,14 @@ std::optional<RobotIntent> SoloOffense::state_to_task(RobotIntent intent) {
         }
         case MARKER: {
             auto mark_pose = last_world_state_->get_robot(false, marking_id_).pose.position();
-            auto mark_defend_pose = mark_pose + (field_dimensions_.our_goal_loc() - mark_pose).normalized(kMarkDistance);
+            auto mark_defend_pose =
+                mark_pose +
+                (field_dimensions_.our_goal_loc() - mark_pose).normalized(kMarkDistance);
             // Move in between the mark and the goal.
 
-            auto cmd = planning::MotionCommand{
-                "path_target",
-                planning::LinearMotionInstant{mark_defend_pose},
-                planning::FaceBall{},
-                true
-            };
+            auto cmd = planning::MotionCommand{"path_target",
+                                               planning::LinearMotionInstant{mark_defend_pose},
+                                               planning::FaceBall{}, true};
 
             intent.motion_command = cmd;
             return intent;
@@ -122,12 +129,9 @@ std::optional<RobotIntent> SoloOffense::state_to_task(RobotIntent intent) {
         case SHOOTING_PIVOT: {
             shot_target_ = calculate_best_shot();
 
-            auto cmd = planning::MotionCommand{
-                "rotate",
-                planning::LinearMotionInstant{shot_target_},
-                planning::FaceTarget{}, 
-                false
-            };
+            auto cmd =
+                planning::MotionCommand{"rotate", planning::LinearMotionInstant{shot_target_},
+                                        planning::FaceTarget{}, false};
 
             intent.motion_command = cmd;
             intent.dribbler_speed = 255;
@@ -137,16 +141,14 @@ std::optional<RobotIntent> SoloOffense::state_to_task(RobotIntent intent) {
         case SHOOTING_KICK: {
             auto cmd = planning::MotionCommand{
                 "path_target",
-                planning::LinearMotionInstant{shot_target_}, // target obtained from pivot
-                planning::FaceTarget{},
-                true
-            };
+                planning::LinearMotionInstant{shot_target_},  // target obtained from pivot
+                planning::FaceTarget{}, true};
 
             intent.motion_command = cmd;
             intent.dribbler_speed = 255;
             intent.shoot_mode = RobotIntent::ShootMode::KICK;
             intent.trigger_mode = RobotIntent::TriggerMode::IMMEDIATE;
-            intent.kick_speed = 4.0; // TODO: what's the best value for this?
+            intent.kick_speed = 4.0;  // TODO: what's the best value for this?
 
             return intent;
         }
@@ -178,7 +180,8 @@ rj_geometry::Point SoloOffense::calculate_best_shot() const {
     return best_shot;
 }
 
-double SoloOffense::distance_from_their_robots(rj_geometry::Point tail, rj_geometry::Point head) const {
+double SoloOffense::distance_from_their_robots(rj_geometry::Point tail,
+                                               rj_geometry::Point head) const {
     rj_geometry::Point vec = head - tail;
     auto& their_robots = this->last_world_state_->their_robots;
 

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.cpp
@@ -9,128 +9,153 @@ SoloOffense::SoloOffense(const Position& other) : Position{other} {
 SoloOffense::SoloOffense(int r_id) : Position{r_id, "SoloOffense"} {}
 
 std::optional<RobotIntent> SoloOffense::derived_get_task(RobotIntent intent) {
-    // Get next state, and if different, reset clock
-    State new_state = next_state();
-    // if (new_state != current_state_) {
-    // }
-    // SPDLOG_INFO("New State: {}", std::to_string(static_cast<int>(new_state)));
+    // Get next state.
+    State new_state = DEFAULT;
+    if (!timed_out()) { // on timeout, move to DEFAULT
+        new_state = next_state();
+    }
+
+    // Check if a transition occurred.
+    if (new_state != current_state_) {
+        SPDLOG_INFO("Robot {}: Transitioned from {} -> {}", robot_id_,  state_to_name(current_state_),  state_to_name(new_state));
+        reset_timeout();
+    }
     current_state_ = new_state;
 
     // Calculate task based on state
     return state_to_task(intent);
 }
 
+/**
+ * @brief A richer to_string.
+ */
 std::string SoloOffense::get_current_state() {
-    return std::string{"Solo Offense"} + std::to_string(static_cast<int>(current_state_));
+    return std::string("SoloOffense-") + std::string(state_to_name(current_state_)); // SoloOffense-MARKER, e.g.
 }
 
+/**
+ * @brief State transitions.
+ */
 SoloOffense::State SoloOffense::next_state() {
-    // handle transitions between current state
-    double closest_dist = std::numeric_limits<double>::infinity();
-    auto current_point = last_world_state_->ball.position;
+    rj_geometry::Point ball_pose = last_world_state_->ball.position;
+    rj_geometry::Point our_pose = last_world_state_->get_robot(true, robot_id_).pose.position();
+    double our_dist = our_pose.dist_to(ball_pose);
 
-    for (int i = 0; i < 6; i++) {
-        RobotState robot = last_world_state_->get_robot(false, i);
-        rj_geometry::Point opp_pos = robot.pose.position();
-        auto robot_dist = opp_pos.dist_to(current_point);
-        if (robot_dist < closest_dist) {
+
+    // Scan opponent positions to determine transition.
+    double closest_dist = std::numeric_limits<double>::infinity();
+    for (int i = 0; i < 6; i++) { // TODO: replace 6 with number of opponent robots (to be proper)
+        RobotState opp = last_world_state_->get_robot(false, i);
+        rj_geometry::Point opp_pose = opp.pose.position();
+        double opp_dist = opp_pose.dist_to(ball_pose); // distance from opp to ball
+        if (opp_dist < closest_dist) {
             marking_id_ = i;
-            closest_dist = robot_dist;
+            closest_dist = opp_dist;
         }
     }
+    // marking_id_ contains the shell id of the opponent robot closest to the ball
+    // closest_dist contains the distance from the robot to the ball
 
-    // SPDLOG_INFO("Closest dist: {}, i-{}", closest_dist,  marking_id_);
-
-    if (closest_dist < (0.5) || field_dimensions_.their_goal_area().contains_point(current_point) ||
-        field_dimensions_.their_defense_area().contains_point(current_point) ||
-        !field_dimensions_.field_coordinates().contains_point(current_point)) {
+    // UNCONDITIONAL TRANSITIONS
+    if (!field_dimensions_.field_coordinates().contains_point(ball_pose)) { // Ball OOB.
+        return DEFAULT;
+    }
+    if ((our_dist > closest_dist) && (closest_dist < kPosessionRadius)) { // Opponent vaguely has possession.
         return MARKER;
     }
+    // CONDITIONAL TRANSITIONS
     switch (current_state_) {
+        case DEFAULT:
+            return SHOOTING_START;
         case MARKER: {
-            return TO_BALL;
+            return SHOOTING_START;
         }
-        case TO_BALL: {
-            if (check_is_done()) {
-                return ROTATE;
-            }
-            return TO_BALL;
+        case SHOOTING_START: {
+            if (check_is_done()) { return SHOOTING_PIVOT; } // ball is collected
+            return SHOOTING_START;
         }
-        case ROTATE: {
-            if (check_is_done()) {
-                counter_ = 0;
-                kick_ = true;
-                return KICK;
-            }
-            return ROTATE;
+        case SHOOTING_PIVOT: {
+            if (check_is_done()) { return SHOOTING_KICK; } // is facing target
+            return SHOOTING_PIVOT;
         }
-        case KICK: {
-            if (!kick_ ||
-                (last_world_state_->get_robot(true, robot_id_).pose.position() - current_point)
-                        .mag() > kRobotRadius * 5) {
-                return TO_BALL;
-            }
-            return KICK;
+        case SHOOTING_KICK: {
+            if (our_pose.dist_to(ball_pose) > kPosessionRadius) { return DEFAULT; } // ball is kicked (or we've been robbed)
+            return SHOOTING_KICK;
         }
     }
     return current_state_;
 }
 
+/**
+ * @brief State behaviors.
+ */
 std::optional<RobotIntent> SoloOffense::state_to_task(RobotIntent intent) {
     switch (current_state_) {
-        case MARKER: {
-            auto marker_target_pos =
-                last_world_state_->get_robot(false, marking_id_).pose.position();
-            auto target =
-                marker_target_pos +
-                (field_dimensions_.our_goal_loc() - marker_target_pos).normalized(kRobotRadius * 5);
-            auto mark_cmd = planning::MotionCommand{
-                "path_target", planning::LinearMotionInstant{target}, planning::FaceBall{}, true};
-            intent.motion_command = mark_cmd;
+        case DEFAULT: {
+            auto cmd = planning::MotionCommand{"halt"};
 
+            intent.motion_command = cmd;
             return intent;
         }
-        case TO_BALL: {
+        case MARKER: {
+            auto mark_pose = last_world_state_->get_robot(false, marking_id_).pose.position();
+            auto mark_defend_pose = mark_pose + (field_dimensions_.our_goal_loc() - mark_pose).normalized(kMarkDistance);
+            // Move in between the mark and the goal.
+
+            auto cmd = planning::MotionCommand{
+                "path_target",
+                planning::LinearMotionInstant{mark_defend_pose},
+                planning::FaceBall{},
+                true
+            };
+
+            intent.motion_command = cmd;
+            return intent;
+        }
+        case SHOOTING_START: {
+            // TODO: coconut.vtf (deleting this section causes the simulator to crash)
             rj_geometry::Point robotToBall =
                 (last_world_state_->ball.position -
                  last_world_state_->get_robot(true, robot_id_).pose.position());
             double slowDown = 1.0;
             double length = robotToBall.mag() - kRobotRadius * slowDown;
             robotToBall = robotToBall.normalized(length);
-            planning::LinearMotionInstant target{
-                last_world_state_->get_robot(true, robot_id_).pose.position() + robotToBall};
-            auto pivot_cmd = planning::MotionCommand{"collect"};
-            intent.motion_command = pivot_cmd;
+            planning::LinearMotionInstant target{last_world_state_->get_robot(true, robot_id_).pose.position() + robotToBall};
+            // END TODO
+
+            auto cmd = planning::MotionCommand{"collect"};
+
+            intent.motion_command = cmd;
             intent.dribbler_speed = 255;
             return intent;
         }
-        case ROTATE: {
-            planning::LinearMotionInstant target{calculate_best_shot()};
-            auto pivot_cmd =
-                planning::MotionCommand{"rotate", target, planning::FaceTarget{}, false};
-            intent.motion_command = pivot_cmd;
+        case SHOOTING_PIVOT: {
+            shot_target_ = calculate_best_shot();
+
+            auto cmd = planning::MotionCommand{
+                "rotate",
+                planning::LinearMotionInstant{shot_target_},
+                planning::FaceTarget{}, 
+                false
+            };
+
+            intent.motion_command = cmd;
             intent.dribbler_speed = 255;
             return intent;
         }
-        case KICK: {
-            // double scaleFactor = 0.1;
-            // rj_geometry::Point point = (last_world_state_->ball.position -
-            // last_world_state_->get_robot(true,
-            // robot_id_).pose.position()).normalized(scaleFactor); point +=
-            // last_world_state_->get_robot(true, robot_id_).pose.position();
-            // planning::LinearMotionInstant target{point};
-            planning::LinearMotionInstant target{calculate_best_shot()};
-            // planning::LinearMotionInstant target{last_world_state_->ball.position};
-            auto kick_cmd =
-                planning::MotionCommand{"line_kick", target, planning::FaceTarget{}, true};
-            intent.motion_command = kick_cmd;
+        case SHOOTING_KICK: {
+            auto cmd = planning::MotionCommand{
+                "path_target",
+                planning::LinearMotionInstant{shot_target_}, // target obtained from pivot
+                planning::FaceTarget{},
+                true
+            };
+
+            intent.motion_command = cmd;
+            intent.dribbler_speed = 255;
             intent.shoot_mode = RobotIntent::ShootMode::KICK;
-            intent.trigger_mode = RobotIntent::TriggerMode::ON_BREAK_BEAM;
-            intent.kick_speed = 4.0;
-            counter_++;
-            if (counter_ > 15) {
-                kick_ = false;
-            }
+            intent.trigger_mode = RobotIntent::TriggerMode::IMMEDIATE;
+            intent.kick_speed = 4.0; // TODO: what's the best value for this?
 
             return intent;
         }
@@ -162,8 +187,7 @@ rj_geometry::Point SoloOffense::calculate_best_shot() const {
     return best_shot;
 }
 
-double SoloOffense::distance_from_their_robots(rj_geometry::Point tail,
-                                               rj_geometry::Point head) const {
+double SoloOffense::distance_from_their_robots(rj_geometry::Point tail, rj_geometry::Point head) const {
     rj_geometry::Point vec = head - tail;
     auto& their_robots = this->last_world_state_->their_robots;
 
@@ -186,4 +210,5 @@ double SoloOffense::distance_from_their_robots(rj_geometry::Point tail,
     }
     return min_angle;
 }
+
 }  // namespace strategy

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.hpp
@@ -20,6 +20,10 @@
 
 namespace strategy {
 
+/**
+ * The SoloOffense position is a simple offensive template which
+ * gets posession and shoots.
+ */
 class SoloOffense : public Position {
 public:
     SoloOffense(const Position& other);
@@ -36,16 +40,77 @@ private:
      */
     std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
 
-    enum State { TO_BALL, KICK, MARKER, ROTATE };
+    // States for position.
+    enum State {
+        DEFAULT,
+        MARKER,
+        SHOOTING_START, // collect
+        SHOOTING_PIVOT, // face goal
+        SHOOTING_KICK, // score
+    };
 
-    State current_state_ = TO_BALL;
+    State current_state_ = State::DEFAULT;
 
-    rj_geometry::Point target_;
+    /**
+     * @brief A more custom to-string for debugging better.
+     */
+    static constexpr std::string_view state_to_name(State s) {
+        switch (s) {
+            case DEFAULT:
+                return "DEFAULT";
+            case MARKER:
+                return "MARKER";
+            case SHOOTING_START:
+                return "SHOOTING_START";
+            case SHOOTING_PIVOT:
+                return "SHOOTING_PIVOT";
+            case SHOOTING_KICK:
+                return "SHOOTING_KICK";
+        }
+    }
 
-    int marking_id_;
+    /**
+     * @brief This FSM has timeouts for certain states.
+     * Ideally, these would not be necessary; as planners get more sophisticated
+     * they should not get "stuck".
+     * 
+     * The timeouts are a safety mechanism, and should not be the primary reason for a
+     * state transition. They are set relatively high for this reason. Here, they're
+     * currently used for debugging.
+     *
+     * @return the maximum duration to stay in a given state, or -1 if there is no maximum.
+     */
+    static constexpr RJ::Seconds timeout(State s) {
+        switch (s) {
+            case DEFAULT:
+                return RJ::Seconds{-1};
+            case MARKER:
+                return RJ::Seconds{-1};
+            case SHOOTING_START:
+                return RJ::Seconds{10};
+            case SHOOTING_PIVOT:
+                return RJ::Seconds{10};
+            case SHOOTING_KICK:
+                return RJ::Seconds{10};
+        }
+    }
 
-    bool kick_ = false;
-    int counter_ = 0;
+    // The time at which the last state started.
+    RJ::Time last_time_;
+
+    /**
+     * @brief Reset the timeout for the current state
+     */
+    void reset_timeout() { last_time_ = RJ::now(); }
+
+    /**
+     * @return if the current state has timed out
+     */
+    bool timed_out() const {
+        using namespace std::chrono_literals;
+        const auto max_time = timeout(current_state_);
+        return (max_time > 0s) && (last_time_ + max_time < RJ::now());
+    };
 
     /**
      * @return what the state should be right now. called on each get_task tick
@@ -57,7 +122,25 @@ private:
      */
     std::optional<RobotIntent> state_to_task(RobotIntent intent);
 
+    // The shell id of the opponent robot that is closest to the ball (to "mark" them).
+    int marking_id_;
+
+    // Distances
+    static constexpr double kTightPosessionRadius{kRobotRadius + 0.1};
+    static constexpr double kPosessionRadius{kRobotRadius + 0.5};
+    static constexpr double kMarkDistance{kRobotRadius * 6};
+
+    // The best shot available.
+    rj_geometry::Point shot_target_;
+
+    /**
+     * @return the best shot available, always tries something
+     */
     rj_geometry::Point calculate_best_shot() const;
+
+    /**
+     * @return the distance from opponent robots, used as a heuristic
+     */
     double distance_from_their_robots(rj_geometry::Point tail, rj_geometry::Point head) const;
 };
 

--- a/soccer/src/soccer/strategy/agent/position/solo_offense.hpp
+++ b/soccer/src/soccer/strategy/agent/position/solo_offense.hpp
@@ -44,9 +44,9 @@ private:
     enum State {
         DEFAULT,
         MARKER,
-        SHOOTING_START, // collect
-        SHOOTING_PIVOT, // face goal
-        SHOOTING_KICK, // score
+        SHOOTING_START,  // collect
+        SHOOTING_PIVOT,  // face goal
+        SHOOTING_KICK,   // score
     };
 
     State current_state_ = State::DEFAULT;
@@ -73,7 +73,7 @@ private:
      * @brief This FSM has timeouts for certain states.
      * Ideally, these would not be necessary; as planners get more sophisticated
      * they should not get "stuck".
-     * 
+     *
      * The timeouts are a safety mechanism, and should not be the primary reason for a
      * state transition. They are set relatively high for this reason. Here, they're
      * currently used for debugging.


### PR DESCRIPTION
## Description
During my first semester, I was assigned a [task](https://app.clickup.com/t/86b2ca5vg) to update kicks to pivot kicks from the previous, free kick-like kicking style. However, that code was terrible (branch [edit-pivot](https://github.com/RoboJackets/robocup-software/tree/edit-pivot)). Turns out, Rishi was working on new code for collecting the ball, which is highly relevant. This code applies that framework to SoloOffense.

## Steps to Test
1. Add a SoloOffense to the position factory and set everything else to defense/goalie
2. Run the sim
3. Place the ball in bounds

**Expected result:** robot should path the ball (collect), turn to target with the dribbler active (pivot), and kick (kick)
