### PR TITLE
Adding dynamic thresholding to pivot when kicking

### DIFF
--- a/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
@@ -19,6 +19,11 @@ namespace planning {
 using namespace rj_geometry;
 
 Trajectory RotatePathPlanner::plan(const PlanRequest& request) {
+    if (!cached_angle_change_ && request.trigger_mode == RobotIntent::TriggerMode::AT_END) {
+        double target_distance = 
+            (request.motion_command.target.position - request.start.pose.position()).mag();
+        kIsDoneAngleChangeThresh = max(pow(2, -target_distance), 0.01);
+    }
     update_state();
     switch (current_state_) {
         case PIVOT:

--- a/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
@@ -20,7 +20,7 @@ using namespace rj_geometry;
 
 Trajectory RotatePathPlanner::plan(const PlanRequest& request) {
     if (!cached_angle_change_ && request.trigger_mode == RobotIntent::TriggerMode::AT_END) {
-        double target_distance = 
+        double target_distance =
             (request.motion_command.target.position - request.start.pose.position()).mag();
         kIsDoneAngleChangeThresh = max(pow(2, -target_distance), 0.01);
     }

--- a/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
+++ b/soccer/src/soccer/planning/planner/rotate_path_planner.cpp
@@ -22,7 +22,7 @@ Trajectory RotatePathPlanner::plan(const PlanRequest& request) {
     if (!cached_angle_change_ && request.trigger_mode == RobotIntent::TriggerMode::AT_END) {
         double target_distance =
             (request.motion_command.target.position - request.start.pose.position()).mag();
-        kIsDoneAngleChangeThresh = max(pow(2, -target_distance), 0.01);
+        isDoneAngleChangeThresh = max(pow(2, -target_distance), 0.01);
     }
     update_state();
     switch (current_state_) {
@@ -40,7 +40,7 @@ void RotatePathPlanner::update_state() {
         return;
     }
     current_state_ = abs(cached_angle_change_.value()) <
-                             degrees_to_radians(static_cast<float>(kIsDoneAngleChangeThresh))
+                             degrees_to_radians(static_cast<float>(isDoneAngleChangeThresh))
                          ? END
                          : PIVOT;
 }
@@ -75,7 +75,7 @@ Trajectory RotatePathPlanner::pivot(const PlanRequest& request) {
     Trajectory path{};
 
     if (cached_target_angle_.has_value() &&
-        (*cached_target_angle_ - target_angle) < degrees_to_radians(kIsDoneAngleChangeThresh)) {
+        (*cached_target_angle_ - target_angle) < degrees_to_radians(isDoneAngleChangeThresh)) {
         if (cached_path_) {
             path = cached_path_.value();
         } else {

--- a/soccer/src/soccer/planning/planner/rotate_path_planner.hpp
+++ b/soccer/src/soccer/planning/planner/rotate_path_planner.hpp
@@ -47,6 +47,6 @@ private:
     enum State { PIVOT, END };
     RotatePathPlanner::State current_state_ = RotatePathPlanner::State::PIVOT;
 
-    static constexpr double kIsDoneAngleChangeThresh{1.0};
+    double kIsDoneAngleChangeThresh{1.0};
 };
 }  // namespace planning

--- a/soccer/src/soccer/planning/planner/rotate_path_planner.hpp
+++ b/soccer/src/soccer/planning/planner/rotate_path_planner.hpp
@@ -47,6 +47,6 @@ private:
     enum State { PIVOT, END };
     RotatePathPlanner::State current_state_ = RotatePathPlanner::State::PIVOT;
 
-    double kIsDoneAngleChangeThresh{1.0};
+    double isDoneAngleChangeThresh{1.0};
 };
 }  // namespace planning


### PR DESCRIPTION
## Description
Making angle rotation more precise when robot is shooting at further target

## Associated / Resolved Issue
Related to [ClickUp card](https://app.clickup.com/t/86b41jn72)

## Steps to Test
1. Make every robot but one solo offense
2. Try taking shots from different distances

**Expected result:** Should not miss (as much)
