### PR TITLE
Updating our constants for C++17

### DIFF
--- a/rj_constants/include/rj_constants/constants.hpp
+++ b/rj_constants/include/rj_constants/constants.hpp
@@ -7,34 +7,34 @@
 /// all weights in kilograms
 
 // Number of identifiable robots on one team
-constexpr size_t kNumShells = 16;
+inline constexpr size_t kNumShells = 16;
 
 // Number of playing robots on one team
-constexpr size_t kRobotsPerTeam = 6;
+inline constexpr size_t kRobotsPerTeam = 6;
 
-constexpr size_t kMaxDribble = 128;
-constexpr size_t kMaxKick = 255;
+inline constexpr size_t kMaxDribble = 128;
+inline constexpr size_t kMaxKick = 255;
 
-constexpr float kBallDiameter = 0.043f;
-constexpr float kBallRadius = kBallDiameter / 2.0f;
-constexpr float kBallMass = 0.048f;
+inline constexpr float kBallDiameter = 0.043f;
+inline constexpr float kBallRadius = kBallDiameter / 2.0f;
+inline constexpr float kBallMass = 0.048f;
 
-constexpr float kRobotDiameter = 0.180f;
-constexpr float kRobotRadius = kRobotDiameter / 2.0f;
-constexpr float kRobotHeight = 0.150f;
-constexpr float kRobotMouthWidth = 0.0635f;
-constexpr float kRobotMouthRadius = 0.078f;
+inline constexpr float kRobotDiameter = 0.180f;
+inline constexpr float kRobotRadius = kRobotDiameter / 2.0f;
+inline constexpr float kRobotHeight = 0.150f;
+inline constexpr float kRobotMouthWidth = 0.0635f;
+inline constexpr float kRobotMouthRadius = 0.078f;
 
 // Constant for ball deceleration on field
-constexpr float kBallDecel{-0.4f};
+inline constexpr float kBallDecel{-0.4f};
 
 /** constants for dot patterns */
-constexpr float kDotsSmallOffset = 0.035;
-constexpr float kDotsLargeOffset = 0.054772;
-constexpr float kDotsRadius = 0.02;
+inline constexpr float kDotsSmallOffset = 0.035;
+inline constexpr float kDotsLargeOffset = 0.054772;
+inline constexpr float kDotsRadius = 0.02;
 
 /** constants for planning */
-constexpr double kAvoidBallDistance = 0.01;
+inline constexpr double kAvoidBallDistance = 0.01;
 
-const std::string kTeamNameLower = "robojackets";
-const std::string kTeamName = "RoboJackets";
+inline const std::string kTeamNameLower = "robojackets";
+inline const std::string kTeamName = "RoboJackets";

--- a/rj_constants/include/rj_constants/topic_names.hpp
+++ b/rj_constants/include/rj_constants/topic_names.hpp
@@ -7,44 +7,44 @@
  */
 
 namespace config_server::topics {
-constexpr auto kGameSettingsTopic{"config/game_settings"};
-constexpr auto kFieldDimensionsTopic{"config/field_dimensions"};
+inline constexpr auto kGameSettingsTopic{"config/game_settings"};
+inline constexpr auto kFieldDimensionsTopic{"config/field_dimensions"};
 
-constexpr auto kGameSettingsSrv{"config/set_game_settings"};
-constexpr auto kFieldDimensionsSrv{"config/set_field_dimensions"};
+inline constexpr auto kGameSettingsSrv{"config/set_game_settings"};
+inline constexpr auto kFieldDimensionsSrv{"config/set_field_dimensions"};
 }  // namespace config_server::topics
 
 namespace sim::topics {
 
-constexpr auto kSimPlacementSrv{"sim/placement"};
+inline constexpr auto kSimPlacementSrv{"sim/placement"};
 
 }  // namespace sim::topics
 
 namespace viz::topics {
 
-constexpr auto kDebugDrawTopic{"viz/debug_draw"};
+inline constexpr auto kDebugDrawTopic{"viz/debug_draw"};
 
 }  // namespace viz::topics
 
 namespace referee::topics {
-constexpr auto kPlayStateTopic{"referee/play_state"};
-constexpr auto kMatchStateTopic{"referee/match_state"};
-constexpr auto kOurInfoTopic{"referee/our_info"};
-constexpr auto kTheirInfoTopic{"referee/their_info"};
-constexpr auto kRefereeRawTopic{"referee/raw_protobuf"};
-constexpr auto kGoalieTopic{"referee/our_goalie"};
-constexpr auto kTeamColorTopic{"referee/team_color"};
+inline constexpr auto kPlayStateTopic{"referee/play_state"};
+inline constexpr auto kMatchStateTopic{"referee/match_state"};
+inline constexpr auto kOurInfoTopic{"referee/our_info"};
+inline constexpr auto kTheirInfoTopic{"referee/their_info"};
+inline constexpr auto kRefereeRawTopic{"referee/raw_protobuf"};
+inline constexpr auto kGoalieTopic{"referee/our_goalie"};
+inline constexpr auto kTeamColorTopic{"referee/team_color"};
 
-constexpr auto kQuickCommandsSrv{"referee/quick_commands"};
+inline constexpr auto kQuickCommandsSrv{"referee/quick_commands"};
 }  // namespace referee::topics
 
 namespace vision_receiver::topics {
-constexpr auto kRawProtobufTopic{"vision_receiver/raw_protobuf"};
-constexpr auto kDetectionFrameTopic{"vision_receiver/detection_frame"};
+inline constexpr auto kRawProtobufTopic{"vision_receiver/raw_protobuf"};
+inline constexpr auto kDetectionFrameTopic{"vision_receiver/detection_frame"};
 }  // namespace vision_receiver::topics
 
 namespace vision_filter::topics {
-constexpr auto kWorldStateTopic{"vision_filter/world_state"};
+inline constexpr auto kWorldStateTopic{"vision_filter/world_state"};
 }  // namespace vision_filter::topics
 
 namespace gameplay::topics {
@@ -53,14 +53,14 @@ static inline std::string robot_intent_topic(int robot_id) {
     return "gameplay/robot_intent/robot_" + std::to_string(robot_id);
 }
 
-constexpr auto kDebugTextTopic{"gameplay/debug_text"};
+inline constexpr auto kDebugTextTopic{"gameplay/debug_text"};
 
 }  // namespace gameplay::topics
 
 namespace planning::topics {
 
-constexpr auto kGlobalObstaclesTopic{"planning/global_obstacles"};
-constexpr auto kDefAreaObstaclesTopic{"planning/def_area_obstacles"};
+inline constexpr auto kGlobalObstaclesTopic{"planning/global_obstacles"};
+inline constexpr auto kDefAreaObstaclesTopic{"planning/def_area_obstacles"};
 
 static inline std::string trajectory_topic(int robot_id) {
     return "planning/trajectory/robot_" + std::to_string(robot_id);
@@ -92,14 +92,14 @@ static inline std::string robot_controlled_topic(int robot_id) {
 
 namespace params {
 
-constexpr auto kMotionControlParamModule = "motion_control";
+inline constexpr auto kMotionControlParamModule = "motion_control";
 }  // namespace params
 
 }  // namespace control
 
 namespace radio::topics {
 
-constexpr auto kAliveRobotsTopic{"radio/alive_robots"};
+inline constexpr auto kAliveRobotsTopic{"radio/alive_robots"};
 
 static inline std::string robot_status_topic(int robot_id) {
     return "radio/robot_status/robot_" + std::to_string(robot_id);


### PR DESCRIPTION
## Description
Using modern practice for C++17 by inlining constants. Inlining them ensures that they are only defined once and shared among all the files, meaning reduced binary size.
