### PR TITLE
Updated Docker Containers

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,6 +5,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV USER=root
 ENV DISPLAY=:1
+ENV MAKEFLAGS="-j 1"
 
 # Define the architecture-specific variable
 ARG TARGETARCH

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,42 @@
+# Use the ros2 desktop image
+FROM osrf/ros:humble-desktop-full
+
+WORKDIR /ws
+
+ENV MAKEFLAGS="-j 1"
+
+# Set timeszone to avoid interactive prompt
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Run ubuntu-setup
+COPY ./util/ubuntu-setup /ubuntu-setup
+COPY ./util/ubuntu-packages.txt /util/ubuntu-packages.txt
+COPY ./util/requirements3.txt /util/requirements3.txt
+RUN /ubuntu-setup -y
+
+# Clone and build ER-Force’s simulator
+RUN git clone https://github.com/robotics-erlangen/framework.git /root/framework && \
+    cd /root/framework && \
+    mkdir build && cd build && \
+    cmake .. && \
+    make simulator-cli
+
+# Clone, build ER-Force's autoref
+RUN git clone https://github.com/robotics-erlangen/autoref.git /root/autoref && \
+    cd /root/autoref && \
+    git submodule update --init && \
+    mkdir build && cd build && \
+    cmake .. && \
+    make
+
+# Install external ref (conditionally download the correct binary based on architecture)
+RUN cd /root && \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+        curl https://github.com/RoboCup-SSL/ssl-game-controller/releases/download/v3.18.0/ssl-game-controller_v3.18.0_linux_amd64 -L -O && echo "TEST" >> /test.txt; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        curl https://github.com/RoboCup-SSL/ssl-game-controller/releases/download/v3.18.0/ssl-game-controller_v3.18.0_linux_arm64 -L -O && echo "TEST2" >> /test2.txt; \
+    else \
+        curl https://github.com/RoboCup-SSL/ssl-game-controller/releases/download/v3.18.0/ssl-game-controller_v3.18.0_linux_arm -L -O; \
+    fi && \
+    chmod +x /root/ssl-game-controll*

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,14 +16,14 @@ For linux, you don't need to install any dependencies and you should be able to 
 
 ### MacOs
 
-For MacOs, you will need to install an X server (for example [XQuartz]()) and then you can start up the docker development container by running:
+For MacOs, you will need to install an X server (for example [XQuartz](https://www.xquartz.org/)) and then you can start up the docker development container by running:
 
 ```bash
 ./docker/docker-build.sh && ./docker/docker-run-mac.sh
 ```
 
 ### Windows
-For Windows, you will also need to install an X server (for example [VcXsrv]()).  You should also be using WSL with Docker Desktop.  Then you can start up the docker development container by running:
+For Windows, you will also need to install an X server.  You should also be using WSL with Docker Desktop.  Then you can start up the docker development container by running:
 
 ```bash
 .\docker\docker-build.sh && .\docker\docker-run-windows.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,34 @@
+# Robocup Dev Containers
+
+## Description
+
+To make developing with the RoboJackets robocup software eaiser, a development image has been created to encapsulate and standardize the development of software.  This docker image mounts the local robocup-software code to /ws and comes complete with most of the league software we use.
+
+## Running
+
+### Linux
+
+For linux, you don't need to install any dependencies and you should be able to start up the docker development container by running:
+
+```bash
+./docker/docker-build.sh && ./docker/docker-run-linux.sh
+```
+
+### MacOs
+
+For MacOs, you will need to install an X server (for example [XQuartz]()) and then you can start up the docker development container by running:
+
+```bash
+./docker/docker-build.sh && ./docker/docker-run-mac.sh
+```
+
+### Windows
+For Windows, you will also need to install an X server (for example [VcXsrv]()).  You should also be using WSL with Docker Desktop.  Then you can start up the docker development container by running:
+
+```bash
+.\docker\docker-build.sh && .\docker\docker-run-windows.sh
+```
+
+## Developing
+
+Once the development container is crunning, you can connect to the container via vscode (or your preferred ide) and begin developing as normal.

--- a/docker/docker-build.ps1
+++ b/docker/docker-build.ps1
@@ -1,0 +1,1 @@
+docker build -t robocup-dev --f $PSScriptRoot $PSScriptRoot\..\

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+docker build -t robocup-dev -f ${SCRIPT_DIR}/Dockerfile.dev ${SCRIPT_DIR}/../

--- a/docker/docker-run-linux.sh
+++ b/docker/docker-run-linux.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+xhost +
+docker run -d -it \
+    --name robocup-dev \
+    -v ${SCRIPT_DIR}/..:/ws \
+    -v /dev/shm:/dev/shm \
+    -v /tmp:/tmp \
+    --net=host \
+    -e "DISPLAY=$DISPLAY" \
+    robocup-dev \
+    /bin/bash

--- a/docker/docker-run-mac.sh
+++ b/docker/docker-run-mac.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+xhost +
+docker run -d -it \
+    --name robocup-dev \
+    -v ${SCRIPT_DIR}/..:/ws \
+    -v /dev/shm:/dev/shm \
+    -v /tmp:/tmp \
+    --net=host \
+    -e "DISPLAY=host.docker.internal:0" \
+    robocup-dev \
+    /bin/bash

--- a/util/ubuntu-setup
+++ b/util/ubuntu-setup
@@ -166,3 +166,7 @@ apt-get install $ARGS $PACKAGES
 # install python3 requirements
 python3 -m pip install pip==22.1
 pip3 install -r $BASE/util/requirements3.txt
+
+echo 'export MAKEFLAGS="-j 1"' >> ~/.bashrc
+echo 'source /opt/ros/humble/setup.bash' >> ~/.bashrc
+


### PR DESCRIPTION
## Description
This PR creates updated docker containers to make development a bit easier.  It also introduces the usage of `export MAKEFLAGS="-j 41"` to the ubuntu-setup script so colcon is forced to only use a singular core.

## Steps to Test
### Linux
1. Run ./docker/docker-build.sh
2. Run ./docker/docker-run-linux.sh
3. Enjoy the stack dockerized

### Mac
1. Download an X server (basically a unix server that allows windows to be shared across programs) such as [XQuartz](https://www.xquartz.org/).
4. Run ./docker/docker-build.sh
5. Run ./docker/docker-run.mac.sh
6. Enjoy the stack dockerized

### Windows
1. For windows, just use wsl
2. If you really want to use the docker container get an X server like on mac
3. Run ./docker/docker-build.sh
4. Run ./docker/docker-run-windows.sh
5. Enjoy the stack dockerized.

**Expected result:**You should be able to develop seamlessly within the docker container.

## Review Checklist

- [X] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [X] **Remove extra print statements**: Any print statements used for debugging should be removed
- [X] **Tag reviewers**: Tag some people for review and ping them on Slack
