### PR TITLE
Fixing static obstacles 

### DIFF
--- a/src/rj_planning/src/plan_request.cpp
+++ b/src/rj_planning/src/plan_request.cpp
@@ -6,7 +6,7 @@ rj_geometry::Circle make_inflated_static_obs(rj_geometry::Point position,
                                              rj_geometry::Point velocity, double radius) {
     // params for obstacle shift
     constexpr double obs_center_shift{0.5};
-    constexpr double obs_radius_inflation{1};
+    constexpr double obs_radius_inflation{1.0};
     constexpr double max_safety_margin{5};
 
     rj_geometry::Point obs_center{position + (velocity * radius * obs_center_shift)};

--- a/src/rj_planning/src/plan_request.cpp
+++ b/src/rj_planning/src/plan_request.cpp
@@ -6,11 +6,14 @@ rj_geometry::Circle make_inflated_static_obs(rj_geometry::Point position,
                                              rj_geometry::Point velocity, double radius) {
     // params for obstacle shift
     constexpr double obs_center_shift{0.5};
-    constexpr double obs_radius_inflation{1.0};
+    constexpr double obs_radius_inflation{1};
+    constexpr double max_safety_margin{5};
 
     rj_geometry::Point obs_center{position + (velocity * radius * obs_center_shift)};
 
     double safety_margin{velocity.mag() * obs_radius_inflation};
+    safety_margin = std::min(safety_margin, max_safety_margin);
+
     double obs_radius{radius + (safety_margin * radius)};
 
     return rj_geometry::Circle{obs_center, static_cast<float>(obs_radius)};


### PR DESCRIPTION
## Description
There was an issue at comp where the robots kept clustering together during stops. The suspected reason is that the static obstacles were covering too large of an area. This PR limits the dynamic scaling of obstacles to prevent this from happening.

## Associated / Resolved Issue
[ClickUp card](https://app.clickup.com/t/86b6e8ne2)

## Steps to Test
On field testing?
