### PR TITLE
Refactor Shape class to be pure virtual

### DIFF
--- a/src/rj_geometry/include/rj_geometry/shape.hpp
+++ b/src/rj_geometry/include/rj_geometry/shape.hpp
@@ -9,15 +9,6 @@ class Segment;
 
 /**
  * The shape class provides the interface to all shapes that are subclasses.
- *
- * TODO(Kevin): do we use boost python anymore? more likely this docstring
- * was never updated (4/29/22 at time of reading)
- *
- * We expose this class and its subclasses to python through boost python, which
- * unfortunately handles abstract base classes very strangely.  The only way I
- * could get inheritance to work properly with boost was to provide
- * implementations for the methods in this class even though we'd prefer them to
- * be pure virtual (not implemented in this class).
  */
 class Shape {
 public:
@@ -28,29 +19,18 @@ public:
     Shape& operator=(const Shape& other) = default;
     Shape& operator=(Shape&& other) = default;
 
-    [[nodiscard]] virtual Shape* clone() const {
-        throw std::runtime_error("Unimplemented method");
-    }
+    [[nodiscard]] virtual Shape* clone() const = 0;
 
-    [[nodiscard]] virtual bool contains_point(Point /*pt*/) const {
-        throw std::runtime_error("Unimplemented method");
-    }
+    [[nodiscard]] virtual bool contains_point(Point) const = 0;
 
     // TODO(1517): Refactor hit so that it doesn't force implementations to
     // have a dependency on RobotRadius in rj_constants
-    /// Returns true if the given point is within one robot radius of the shape
-    [[nodiscard]] virtual bool hit(Point /*pt*/) const {
-        throw std::runtime_error("Unimplemented method");
-    }
+    // Returns true if the given point is within one robot radius of the shape
+    [[nodiscard]] virtual bool hit(Point) const = 0;
 
-    [[nodiscard]] virtual bool hit(const Segment& /*seg*/) const {
-        throw std::runtime_error("Unimplemented method");
-    }
+    [[nodiscard]] virtual bool hit(const Segment&) const = 0;
 
-    [[nodiscard]] virtual bool near_point(Point /*other*/,
-                                         float /*threshold*/) const {
-        throw std::runtime_error("Unimplemented method");
-    }
+    [[nodiscard]] virtual bool near_point(Point, float) const = 0;
 
     virtual std::string to_string() { return "Shape"; }
 


### PR DESCRIPTION
## Description
Refactoring the `Shape` class to be pure virtual. It was previously not possible due to some dependencies on Python bindings. Those bindings are gone, so we can make it pure virtual.

## Testing
Nothing broken
