### PR TITLE
Improve build in Docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -27,6 +27,7 @@ RUN apt-get update && \
     wget \
     cmake \
     build-essential \
+    ccache \
     lsb-release \
     software-properties-common \
     gnupg \
@@ -51,6 +52,14 @@ RUN mkdir -p /root/.vnc && \
 ENV TZ=America/New_York
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+# Configure ccache for faster rebuilds
+ENV CCACHE_DIR=/root/.ccache
+ENV CCACHE_COMPRESS=1
+ENV CCACHE_COMPRESSLEVEL=1
+ENV CCACHE_MAXSIZE=5G
+ENV CCACHE_SLOPPINESS=pch_defines,time_macros,include_file_mtime,include_file_ctime
+RUN ccache -M 5G || true
+
 # Clone RoboJackets RoboCup software
 RUN git clone https://github.com/RoboJackets/robocup-software.git /root/robocup-software
 
@@ -68,7 +77,7 @@ RUN git clone https://github.com/robotics-erlangen/framework.git /root/framework
 # Build our stack
 RUN bash -c "source /opt/ros/humble/setup.bash && \
     cd /root/robocup-software && \
-    colcon build --parallel-workers 1 --executor sequential && \
+    make perf_docker && \
     source install/setup.bash"
 
 # Clone, build ER-Force's autoref

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -114,14 +114,14 @@ that ``colcon`` takes up, by running:
 
 .. code-block:: bash
    
-   colcon build --parallel-workers 1 --executor sequential
+   make perf_docker
 
 After building, we need to source our custom ROS setup. Run the following in
 the ``robocup-software`` directory:
 
 .. code-block:: bash
 
-    source install/setup.bash
+   source install/setup.bash
 
 (Again, if you're on zsh, source the ``.zsh`` version instead.)
 

--- a/makefile
+++ b/makefile
@@ -58,6 +58,13 @@ release: all-release
 again:
 	colcon build --parallel-workers 4
 
+perf_docker:
+	MAKEFLAGS='-j3' colcon build --parallel-workers 1 --executor sequential --cmake-args \
+	-DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+	-DCMAKE_BUILD_TYPE=Debug \ 
+	-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
+	-DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" 
+
 # run soccer with default flags
 # TODO: lots of the default flags are for sim, except run_sim
 # fix this so defaults launch sim, with special cases for real

--- a/makefile
+++ b/makefile
@@ -59,11 +59,10 @@ again:
 	colcon build --parallel-workers 4
 
 perf_docker:
-	MAKEFLAGS='-j3' colcon build --parallel-workers 1 --executor sequential --cmake-args \
+	MAKEFLAGS='-j5' colcon build --parallel-workers 1 --executor sequential --cmake-args \
 	-DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-	-DCMAKE_BUILD_TYPE=Debug \ 
-	-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
-	-DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" 
+	-DCMAKE_BUILD_TYPE=Debug \
+	-DCMAKE_CXX_FLAGS_DEBUG="-g1" 
 
 # run soccer with default flags
 # TODO: lots of the default flags are for sim, except run_sim


### PR DESCRIPTION
## Description
We have run into issues of slow builds and high memory/CPU usage in Docker. We noticed builds >1hr and maxed out CPU/memory usage even with 10 cores + 16GB memory.

This PR applies some optimizations to reduce builds down to ~30 minutes and prevent excessive CPU/memory usage (peaks around 800% CPU and 9GB memory).

## Steps to Test
In Docker container:
1. `rm -rf build/`
2. `make perf_docker`