### PR TITLE
double wall spacing

### DIFF
--- a/src/rj_strategy/src/agent/position/waller.cpp
+++ b/src/rj_strategy/src/agent/position/waller.cpp
@@ -37,6 +37,8 @@ std::optional<RobotIntent> Waller::get_task(RobotIntent intent, const WorldState
 
     auto wall_spacing = kRobotDiameterMultiplier * kRobotDiameter + kBallRadius;
 
+    wall_spacing *= 2;
+
     rj_geometry::Point target_point{};
     auto angle = (mid_point - goal_pos).angle();
     auto delta_angle = (wall_spacing * (waller_pos_ - num_wallers / 2. - 0.5)) / min_wall_rad;


### PR DESCRIPTION
<img width="457" height="635" alt="RoboCup SW Double Wall Spacing" src="https://github.com/user-attachments/assets/da82ecfb-374e-4c60-a91f-e9a453e7e488" />

I pulled from the wrong branch, on my other pull request (mb)