### PR TITLE
Coordinator Client Handles

### DIFF
--- a/src/rj_strategy/include/rj_strategy/agent/position.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position.hpp
@@ -40,10 +40,18 @@
 #include <rj_msgs/msg/position_request.hpp>
 #include <rj_msgs/msg/test_response.hpp>
 
+// Coordinators
+#include "rj_strategy/coordinator/kicker_picker_client.hpp"
+
 // tell compiler this class exists, but no need to import the whole header
 class AgentActionClient;
 
 namespace strategy {
+
+// Client Handles for coordinators
+struct ClientHandles {
+    std::unique_ptr<KickerPickerClient> kicker_picker;
+};
 
 /*
  * Position is an abstract superclass. Its subclasses handle strategy logic.
@@ -60,7 +68,7 @@ class Position {
 public:
     Position(int r_id);
     virtual ~Position() = default;
-    Position(const Position& other) = default;
+    Position(Position&& other) = default;
 
     /**
      * @brief return a RobotIntent to be sent to PlannerNode by AC; nullopt
@@ -229,6 +237,11 @@ public:
      */
     virtual void set_goalie_id(int goalie_id);
 
+    /**
+     * @brief allows RobotFactoryPosition to synchronize with its client handles
+     */
+    void set_client_handles(std::shared_ptr<ClientHandles> client_handles);
+
 protected:
     Position(int r_id, std::string position_name);
 
@@ -307,6 +320,9 @@ protected:
 
     // Current goalie
     int goalie_id_;
+
+    // Client Handles
+    std::shared_ptr<ClientHandles> client_handles_;
 
 private:
     /**

--- a/src/rj_strategy/include/rj_strategy/agent/position/defense.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/defense.hpp
@@ -29,7 +29,7 @@ class Defense : public Position {
 public:
     Defense(int r_id);
     ~Defense() override = default;
-    Defense(const Position& other);
+    Defense(Position&& other);
 
     void receive_communication_response(communication::AgentPosResponseWrapper response) override;
     communication::PosAgentResponseWrapper receive_communication_request(

--- a/src/rj_strategy/include/rj_strategy/agent/position/free_kicker.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/free_kicker.hpp
@@ -18,7 +18,7 @@ namespace strategy {
 class FreeKicker : public Position {
 public:
     FreeKicker(int r_id);
-    FreeKicker(Position &&);
+    FreeKicker(Position&&);
     ~FreeKicker() = default;
 
     /**

--- a/src/rj_strategy/include/rj_strategy/agent/position/free_kicker.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/free_kicker.hpp
@@ -18,7 +18,7 @@ namespace strategy {
 class FreeKicker : public Position {
 public:
     FreeKicker(int r_id);
-    FreeKicker(const Position&);
+    FreeKicker(Position &&);
     ~FreeKicker() = default;
 
     /**

--- a/src/rj_strategy/include/rj_strategy/agent/position/goalie.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/goalie.hpp
@@ -24,7 +24,7 @@ class Goalie : public Position {
 public:
     Goalie(int r_id);
     ~Goalie() override = default;
-    Goalie(const Position& other);
+    Goalie(Position&& other);
 
     void derived_acknowledge_pass() override;
     void derived_pass_ball() override;

--- a/src/rj_strategy/include/rj_strategy/agent/position/idle.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/idle.hpp
@@ -9,7 +9,7 @@ class Idle : public Position {
 public:
     Idle(int r_id);
     ~Idle() = default;
-    Idle(const Position& other);
+    Idle(Position&& other);
 
     /**
      * @brief Does nothing; this position is a special case

--- a/src/rj_strategy/include/rj_strategy/agent/position/line.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/line.hpp
@@ -8,7 +8,7 @@
 namespace strategy {
 class Line : public Position {
 public:
-    Line(const Position& other);
+    Line(Position&& other);
     Line(int r_id);
     Line(int r_id, bool forward);
     ~Line() override = default;

--- a/src/rj_strategy/include/rj_strategy/agent/position/offense.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/offense.hpp
@@ -29,7 +29,7 @@ class Offense : public Position {
 public:
     Offense(int r_id);
     ~Offense() override = default;
-    Offense(const Position& other);
+    Offense(Position&& other);
     communication::PosAgentResponseWrapper receive_communication_request(
         communication::AgentPosRequestWrapper request) override;
 

--- a/src/rj_strategy/include/rj_strategy/agent/position/penalty_non_kicker.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/penalty_non_kicker.hpp
@@ -19,7 +19,7 @@ class PenaltyNonKicker : public Position {
 public:
     PenaltyNonKicker(int r_id);
     ~PenaltyNonKicker() = default;
-    PenaltyNonKicker(const Position& other);
+    PenaltyNonKicker(Position&& other);
 
     /**
      * @brief Does nothing; this position is a special case

--- a/src/rj_strategy/include/rj_strategy/agent/position/penalty_player.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/penalty_player.hpp
@@ -22,7 +22,7 @@ class PenaltyPlayer : public Position {
 public:
     PenaltyPlayer(int r_id);
     ~PenaltyPlayer() = default;
-    PenaltyPlayer(const Position& other);
+    PenaltyPlayer(Position&& other);
 
     /**
      * @brief Does nothing; this position is a special case

--- a/src/rj_strategy/include/rj_strategy/agent/position/robot_factory_position.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/robot_factory_position.hpp
@@ -32,7 +32,6 @@
 #include "rj_strategy/agent/position/smartidling.hpp"
 #include "rj_strategy/agent/position/solo_offense.hpp"
 #include "rj_strategy/agent/position/zoner.hpp"
-#include "rj_strategy/coordinator/kicker_picker_client.hpp"
 
 namespace strategy {
 
@@ -116,7 +115,6 @@ public:
 private:
     std::unique_ptr<Position> current_position_;
 
-    KickerPickerClient kicker_picker_;
     OverridingPositions override_play_position_{OverridingPositions::AUTO};
 
     std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;
@@ -148,7 +146,7 @@ private:
             // This line requires Pos to implement the constructor Pos(const
             // Position&)
             current_position_->die();
-            current_position_ = std::make_unique<Pos>(*current_position_);
+            current_position_ = std::make_unique<Pos>(std::move(*current_position_));
             SPDLOG_INFO("Robot {}: change {}", robot_id_, current_position_->get_name());
         }
     }

--- a/src/rj_strategy/include/rj_strategy/agent/position/robot_factory_position.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/robot_factory_position.hpp
@@ -143,8 +143,7 @@ private:
     template <class Pos>
     void set_current_position() {
         if (dynamic_cast<Pos*>(current_position_.get()) == nullptr) {
-            // This line requires Pos to implement the constructor Pos(const
-            // Position&)
+            // This line requires Pos to implement the constructor Pos(Position&&)
             current_position_->die();
             current_position_ = std::make_unique<Pos>(std::move(*current_position_));
             SPDLOG_INFO("Robot {}: change {}", robot_id_, current_position_->get_name());

--- a/src/rj_strategy/include/rj_strategy/agent/position/smartidling.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/smartidling.hpp
@@ -9,7 +9,7 @@ class SmartIdle : public Position {
 public:
     SmartIdle(int r_id);
     ~SmartIdle() = default;
-    SmartIdle(const Position& other);
+    SmartIdle(Position&& other);
 
     /**
      * @brief Does nothing; this position is a special case

--- a/src/rj_strategy/include/rj_strategy/agent/position/solo_offense.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/solo_offense.hpp
@@ -22,7 +22,7 @@ namespace strategy {
 
 class SoloOffense : public Position {
 public:
-    SoloOffense(const Position& other);
+    SoloOffense(Position&& other);
     SoloOffense(int r_id);
     ~SoloOffense() override = default;
     SoloOffense(const SoloOffense& other) = default;

--- a/src/rj_strategy/include/rj_strategy/agent/position/zoner.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/zoner.hpp
@@ -28,7 +28,7 @@ class Zoner : public Position {
 public:
     Zoner(int r_id);
     ~Zoner() override = default;
-    Zoner(const Position& other);
+    Zoner(Position&& other);
     Zoner(Zoner&& other) = default;
     Zoner& operator=(const Zoner& other) = default;
     Zoner& operator=(Zoner&& other) = default;

--- a/src/rj_strategy/src/agent/position.cpp
+++ b/src/rj_strategy/src/agent/position.cpp
@@ -8,8 +8,8 @@ Position::Position(int r_id) : robot_id_(r_id) {
 
 Position::Position(int r_id, std::string position_name)
     : position_name_{std::move(position_name)}, robot_id_{r_id} {
-        client_handles_ = std::make_shared<ClientHandles>();
-    };
+    client_handles_ = std::make_shared<ClientHandles>();
+};
 
 std::optional<RobotIntent> Position::get_task(WorldState& world_state,
                                               FieldDimensions& field_dimensions,

--- a/src/rj_strategy/src/agent/position.cpp
+++ b/src/rj_strategy/src/agent/position.cpp
@@ -2,10 +2,14 @@
 
 namespace strategy {
 
-Position::Position(int r_id) : robot_id_(r_id) {}
+Position::Position(int r_id) : robot_id_(r_id) {
+    client_handles_ = std::make_shared<ClientHandles>();
+}
 
 Position::Position(int r_id, std::string position_name)
-    : position_name_{std::move(position_name)}, robot_id_{r_id} {};
+    : position_name_{std::move(position_name)}, robot_id_{r_id} {
+        client_handles_ = std::make_shared<ClientHandles>();
+    };
 
 std::optional<RobotIntent> Position::get_task(WorldState& world_state,
                                               FieldDimensions& field_dimensions,
@@ -76,6 +80,10 @@ bool Position::assert_world_state_valid() {
         return false;
     }
     return true;
+}
+
+void Position::set_client_handles(std::shared_ptr<ClientHandles> client_handles) {
+    client_handles_ = client_handles;
 }
 
 std::deque<communication::PosAgentRequestWrapper> Position::send_communication_request() {

--- a/src/rj_strategy/src/agent/position/defense.cpp
+++ b/src/rj_strategy/src/agent/position/defense.cpp
@@ -4,7 +4,7 @@ namespace strategy {
 
 Defense::Defense(int r_id) : Position(r_id, "Defense"), marker_{field_dimensions_} {}
 
-Defense::Defense(const Position& other) : Position{other}, marker_{field_dimensions_} {
+Defense::Defense(Position&& other) : Position{std::move(other)}, marker_{field_dimensions_} {
     position_name_ = "Defense";
     walling_robots_ = {};
 }

--- a/src/rj_strategy/src/agent/position/free_kicker.cpp
+++ b/src/rj_strategy/src/agent/position/free_kicker.cpp
@@ -4,7 +4,9 @@ namespace strategy {
 
 FreeKicker::FreeKicker(int r_id) : Position(r_id, "FreeKicker") {}
 
-FreeKicker::FreeKicker(Position&& other) : Position{std::move(other)} { position_name_ = "FreeKicker"; }
+FreeKicker::FreeKicker(Position&& other) : Position{std::move(other)} {
+    position_name_ = "FreeKicker";
+}
 
 std::optional<RobotIntent> FreeKicker::derived_get_task(RobotIntent intent) {
     // Penalty Kicker kicks the ball into the goal

--- a/src/rj_strategy/src/agent/position/free_kicker.cpp
+++ b/src/rj_strategy/src/agent/position/free_kicker.cpp
@@ -4,7 +4,7 @@ namespace strategy {
 
 FreeKicker::FreeKicker(int r_id) : Position(r_id, "FreeKicker") {}
 
-FreeKicker::FreeKicker(const Position& other) : Position{other} { position_name_ = "FreeKicker"; }
+FreeKicker::FreeKicker(Position&& other) : Position{std::move(other)} { position_name_ = "FreeKicker"; }
 
 std::optional<RobotIntent> FreeKicker::derived_get_task(RobotIntent intent) {
     // Penalty Kicker kicks the ball into the goal

--- a/src/rj_strategy/src/agent/position/goalie.cpp
+++ b/src/rj_strategy/src/agent/position/goalie.cpp
@@ -4,7 +4,7 @@ namespace strategy {
 
 Goalie::Goalie(int r_id) : Position(r_id, "Goalie") {}
 
-Goalie::Goalie(const Position& other) : Position{other} {}
+Goalie::Goalie(Position&& other) : Position{std::move(other)} {}
 
 std::optional<RobotIntent> Goalie::derived_get_task(RobotIntent intent) {
     latest_state_ = update_state();

--- a/src/rj_strategy/src/agent/position/idle.cpp
+++ b/src/rj_strategy/src/agent/position/idle.cpp
@@ -4,7 +4,7 @@ namespace strategy {
 
 Idle::Idle(int r_id) : Position{r_id, "Idle"} {}
 
-Idle::Idle(const Position& other) : Position{other} {}
+Idle::Idle(Position&& other) : Position{std::move(other)} {}
 
 std::string Idle::get_current_state() { return "Idle"; }
 

--- a/src/rj_strategy/src/agent/position/line.cpp
+++ b/src/rj_strategy/src/agent/position/line.cpp
@@ -2,7 +2,7 @@
 
 namespace strategy {
 
-Line::Line(const Position& other) : Position{other} { position_name_ = "Line"; }
+Line::Line(Position&& other) : Position{std::move(other)} { position_name_ = "Line"; }
 
 Line::Line(int r_id) : Position{r_id, "Line"} {}
 

--- a/src/rj_strategy/src/agent/position/offense.cpp
+++ b/src/rj_strategy/src/agent/position/offense.cpp
@@ -4,7 +4,7 @@ namespace strategy {
 
 Offense::Offense(int r_id) : Position{r_id, "Offense"}, seeker_{r_id} {}
 
-Offense::Offense(const Position& other) : Position{other}, seeker_{robot_id_} {
+Offense::Offense(Position&& other) : Position{std::move(other)}, seeker_{robot_id_} {
     position_name_ = "Offense";
 }
 

--- a/src/rj_strategy/src/agent/position/penalty_non_kicker.cpp
+++ b/src/rj_strategy/src/agent/position/penalty_non_kicker.cpp
@@ -4,7 +4,7 @@ namespace strategy {
 
 PenaltyNonKicker::PenaltyNonKicker(int r_id) : Position{r_id, "PenaltyNonKicker"} {}
 
-PenaltyNonKicker::PenaltyNonKicker(const Position& other) : Position{other} {}
+PenaltyNonKicker::PenaltyNonKicker(Position&& other) : Position{std::move(other)} {}
 
 std::string PenaltyNonKicker::get_current_state() { return "PenaltyNonKicker"; }
 

--- a/src/rj_strategy/src/agent/position/penalty_player.cpp
+++ b/src/rj_strategy/src/agent/position/penalty_player.cpp
@@ -5,7 +5,7 @@ namespace strategy {
 // ALSO USED AS KickoffKicker
 PenaltyPlayer::PenaltyPlayer(int r_id) : Position(r_id, "PenaltyPlayer") {}
 
-PenaltyPlayer::PenaltyPlayer(const Position& other) : Position{other} {}
+PenaltyPlayer::PenaltyPlayer(Position&& other) : Position{std::move(other)} {}
 
 std::optional<RobotIntent> PenaltyPlayer::derived_get_task(RobotIntent intent) {
     latest_state_ = update_state();

--- a/src/rj_strategy/src/agent/position/robot_factory_position.cpp
+++ b/src/rj_strategy/src/agent/position/robot_factory_position.cpp
@@ -3,7 +3,8 @@
 namespace strategy {
 
 RobotFactoryPosition::RobotFactoryPosition(int r_id, rclcpp::Node::SharedPtr node)
-    : Position(r_id, "RobotFactoryPosition"), kicker_picker_(std::move(node), r_id) {
+    : Position(r_id, "RobotFactoryPosition") {
+    client_handles_->kicker_picker = std::make_unique<KickerPickerClient>(std::move(node), r_id);
     if (robot_id_ == 0) {
         current_position_ = std::make_unique<Goalie>(robot_id_);
     } else if (robot_id_ == 1 || robot_id_ == 2) {
@@ -11,6 +12,8 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id, rclcpp::Node::SharedPtr nod
     } else {
         current_position_ = std::make_unique<Defense>(robot_id_);
     }
+
+    current_position_->set_client_handles(client_handles_);
 }
 
 std::optional<RobotIntent> RobotFactoryPosition::derived_get_task([
@@ -39,7 +42,7 @@ void RobotFactoryPosition::process_play_state() {
             case PlayState::State::Playing: {
                 // We just became regular playing.
                 // set_default_position();
-                kicker_picker_.leave_group();
+                client_handles_->kicker_picker->leave_group();
                 break;
             }
 
@@ -69,7 +72,7 @@ void RobotFactoryPosition::process_play_state() {
             case PlayState::State::Halt: {
                 // The game has been stopped or halted. In this case, we typically want to keep
                 // our current position. The rules for movement should be handled at a lower level.
-                kicker_picker_.leave_group();
+                client_handles_->kicker_picker->leave_group();
                 handle_stop();
                 break;
             }
@@ -81,7 +84,7 @@ void RobotFactoryPosition::process_play_state() {
 void RobotFactoryPosition::handle_stop() { set_default_position(); }
 
 void RobotFactoryPosition::handle_penalty_playing() {
-    if (!(kicker_picker_.am_i_member() && kicker_picker_.is_selected())) {
+    if (!(client_handles_->kicker_picker->am_i_member() && client_handles_->kicker_picker->is_selected())) {
         set_current_position<SmartIdle>();
     }
 }
@@ -92,8 +95,8 @@ void RobotFactoryPosition::handle_setup() {
         // Set up our restart
 
         if ((current_play_state_.is_kickoff() || current_play_state_.is_penalty()) &&
-            !kicker_picker_.am_i_member()) {
-            kicker_picker_.join_group([this](KickerPickerClient::Result result) {
+            !client_handles_->kicker_picker->am_i_member()) {
+            client_handles_->kicker_picker->join_group([this](KickerPickerClient::Result result) {
                 if (result.am_i_member && result.kicker_id == robot_id_ &&
                     current_play_state_.is_kickoff()) {
                     set_current_position<FreeKicker>();
@@ -117,9 +120,9 @@ void RobotFactoryPosition::handle_ready() {
     // Time to kick
 
     if (current_play_state_.is_our_restart() && current_play_state_.is_free_kick() &&
-        !kicker_picker_.am_i_member()) {
+        !client_handles_->kicker_picker->am_i_member()) {
         // There is no "Setup" stage for free kicks, so this is when we choose kicker
-        kicker_picker_.join_group([this](KickerPickerClient::Result result) {
+        client_handles_->kicker_picker->join_group([this](KickerPickerClient::Result result) {
             if (result.am_i_member && result.kicker_id == robot_id_) {
                 set_current_position<FreeKicker>();
             } else {

--- a/src/rj_strategy/src/agent/position/robot_factory_position.cpp
+++ b/src/rj_strategy/src/agent/position/robot_factory_position.cpp
@@ -84,7 +84,8 @@ void RobotFactoryPosition::process_play_state() {
 void RobotFactoryPosition::handle_stop() { set_default_position(); }
 
 void RobotFactoryPosition::handle_penalty_playing() {
-    if (!(client_handles_->kicker_picker->am_i_member() && client_handles_->kicker_picker->is_selected())) {
+    if (!(client_handles_->kicker_picker->am_i_member() &&
+          client_handles_->kicker_picker->is_selected())) {
         set_current_position<SmartIdle>();
     }
 }

--- a/src/rj_strategy/src/agent/position/smartidling.cpp
+++ b/src/rj_strategy/src/agent/position/smartidling.cpp
@@ -4,7 +4,7 @@ namespace strategy {
 
 SmartIdle::SmartIdle(int r_id) : Position{r_id, "SmartIdle"} {}
 
-SmartIdle::SmartIdle(const Position& other) : Position{other} {}
+SmartIdle::SmartIdle(Position&& other) : Position{std::move(other)} {}
 
 std::string SmartIdle::get_current_state() { return "SmartIdle"; }
 

--- a/src/rj_strategy/src/agent/position/solo_offense.cpp
+++ b/src/rj_strategy/src/agent/position/solo_offense.cpp
@@ -2,7 +2,7 @@
 
 namespace strategy {
 
-SoloOffense::SoloOffense(const Position& other) : Position{other} {
+SoloOffense::SoloOffense(Position&& other) : Position{std::move(other)} {
     position_name_ = "SoloOffense";
 }
 

--- a/src/rj_strategy/src/agent/position/zoner.cpp
+++ b/src/rj_strategy/src/agent/position/zoner.cpp
@@ -4,7 +4,7 @@ namespace strategy {
 
 Zoner::Zoner(int r_id) : Position(r_id, "Zoner") {}
 
-Zoner::Zoner(const Position& other) : Position{other} { position_name_ = "Zoner"; }
+Zoner::Zoner(Position&& other) : Position{std::move(other)} { position_name_ = "Zoner"; }
 
 std::optional<RobotIntent> Zoner::derived_get_task(RobotIntent intent) {
     current_state_ = next_state();


### PR DESCRIPTION
Creates client handles to manage coordinator clients, also converts Position's copy constructor into a move constructor.
RFP also has a copy of client handles that it syncs with its `current_position_` version of it