### PR TITLE
Adding Feature for Global Latency Benchmarking (Independent of a Robot)

### DIFF
--- a/src/rj_benchmarking/include/rj_benchmarking/registry.hpp
+++ b/src/rj_benchmarking/include/rj_benchmarking/registry.hpp
@@ -30,7 +30,7 @@ private:
     std::string get_curr_datetime();
 
     // registry[robot_id][label] -> latency sampling
-    std::array<std::unordered_map<std::string, std::vector<uint64_t>>, kNumShells> registry_{};
+    std::array<std::unordered_map<std::string, std::vector<uint64_t>>, kNumShells + 1> registry_{};
     rclcpp::Subscription<rj_msgs::msg::Latency>::SharedPtr subscription_{};
     size_t max_rows_{};
 };

--- a/src/rj_benchmarking/include/rj_benchmarking/registry.hpp
+++ b/src/rj_benchmarking/include/rj_benchmarking/registry.hpp
@@ -28,7 +28,7 @@ private:
     void topic_callback(const rj_msgs::msg::Latency& msg);
 
     std::string get_curr_datetime();
-    void Registry::print_data(std::ofstream& file, int registry_index);
+    void print_data(std::ofstream& file, int registry_index);
 
     // registry[robot_id][label] -> latency sampling
     std::array<std::unordered_map<std::string, std::vector<uint64_t>>, kNumShells + 1> registry_{};

--- a/src/rj_benchmarking/include/rj_benchmarking/registry.hpp
+++ b/src/rj_benchmarking/include/rj_benchmarking/registry.hpp
@@ -19,6 +19,7 @@
 #include <rj_constants/constants.hpp>
 #include <rj_msgs/msg/latency.hpp>
 
+// Set RobotId to -1 for Global Profiling
 class Registry : public rclcpp::Node {
 public:
     Registry();
@@ -30,7 +31,6 @@ private:
     std::string get_curr_datetime();
     void print_data(std::ofstream& file, int registry_index);
 
-    // registry[robot_id][label] -> latency sampling
     std::array<std::unordered_map<std::string, std::vector<uint64_t>>, kNumShells + 1> registry_{};
     rclcpp::Subscription<rj_msgs::msg::Latency>::SharedPtr subscription_{};
     size_t max_rows_{};

--- a/src/rj_benchmarking/include/rj_benchmarking/registry.hpp
+++ b/src/rj_benchmarking/include/rj_benchmarking/registry.hpp
@@ -28,6 +28,7 @@ private:
     void topic_callback(const rj_msgs::msg::Latency& msg);
 
     std::string get_curr_datetime();
+    void Registry::print_data(std::ofstream& file, int registry_index);
 
     // registry[robot_id][label] -> latency sampling
     std::array<std::unordered_map<std::string, std::vector<uint64_t>>, kNumShells + 1> registry_{};

--- a/src/rj_benchmarking/src/registry.cpp
+++ b/src/rj_benchmarking/src/registry.cpp
@@ -29,14 +29,13 @@ Registry::~Registry() {
             ss += "/robot_";
             ss += std::to_string(i);
             ss += ".csv";
-            std::ofstream robot_csv {base_path + ss};
+            std::ofstream robot_csv{base_path + ss};
             print_data(robot_csv, i);
         }
 
-        if (!registry_[kNumShells].empty())
-        {
-            std::string file_name {"/global.csv"};
-            std::ofstream global_csv {base_path + file_name};
+        if (!registry_[kNumShells].empty()) {
+            std::string file_name{"/global.csv"};
+            std::ofstream global_csv{base_path + file_name};
             print_data(global_csv, kNumShells);
         }
     }
@@ -46,12 +45,12 @@ void Registry::topic_callback(const rj_msgs::msg::Latency& msg) {
     if (msg.robot_id == -1)  // robot independent; will go at end
     {
         registry_[kNumShells][msg.label].push_back(msg.duration_ns);
-        max_rows_ = std::max(max_rows_, static_cast<size_t>(
-            registry_[kNumShells][msg.label].size()));
+        max_rows_ =
+            std::max(max_rows_, static_cast<size_t>(registry_[kNumShells][msg.label].size()));
     } else {
         registry_[msg.robot_id][msg.label].push_back(msg.duration_ns);
-        max_rows_ = std::max(max_rows_, static_cast<size_t>(
-            registry_[msg.robot_id][msg.label].size()));
+        max_rows_ =
+            std::max(max_rows_, static_cast<size_t>(registry_[msg.robot_id][msg.label].size()));
     }
 }
 

--- a/src/rj_benchmarking/src/registry.cpp
+++ b/src/rj_benchmarking/src/registry.cpp
@@ -29,34 +29,30 @@ Registry::~Registry() {
             ss += "/robot_";
             ss += std::to_string(i);
             ss += ".csv";
-            std::ofstream robot_csv{base_path + ss};
+            std::ofstream robot_csv {base_path + ss};
+            print_data(robot_csv, i);
+        }
 
-            // Print out labels
-            for (const auto& [label, timestamps] : registry_[i]) {
-                robot_csv << label << ',';
-            }
-            robot_csv << '\n';
-
-            // Print out data row by row
-            for (size_t row = 0; row < max_rows_; ++row) {
-                for (const auto& [label, timestamps] : registry_[i]) {
-                    if (row >= timestamps.size()) {
-                        // sentinel value
-                        robot_csv << -1 << ',';
-                    } else {
-                        robot_csv << timestamps[row] << ',';
-                    }
-                }
-
-                robot_csv << '\n';
-            }
+        if (!registry_[kNumShells].empty())
+        {
+            std::string file_name {"/global.csv"};
+            std::ofstream global_csv {base_path + file_name};
+            print_data(global_csv, kNumShells);
         }
     }
 }
 
 void Registry::topic_callback(const rj_msgs::msg::Latency& msg) {
-    registry_[msg.robot_id][msg.label].push_back(msg.duration_ns);
-    max_rows_ = std::max(max_rows_, static_cast<size_t>(registry_[msg.robot_id][msg.label].size()));
+    if (msg.robot_id == -1)  // robot independent; will go at end
+    {
+        registry_[kNumShells][msg.label].push_back(msg.duration_ns);
+        max_rows_ = std::max(max_rows_, static_cast<size_t>(
+            registry_[kNumShells][msg.label].size()));
+    } else {
+        registry_[msg.robot_id][msg.label].push_back(msg.duration_ns);
+        max_rows_ = std::max(max_rows_, static_cast<size_t>(
+            registry_[msg.robot_id][msg.label].size()));
+    }
 }
 
 std::string Registry::get_curr_datetime() {
@@ -69,4 +65,25 @@ std::string Registry::get_curr_datetime() {
     std::ostringstream ss;
     ss << std::put_time(&tm_buf, "%Y-%m-%d_%H:%M:%S");
     return ss.str();
+}
+
+void Registry::print_data(std::ofstream& file, int registry_index) {
+    // Print out labels
+    for (const auto& [label, timestamps] : registry_[registry_index]) {
+        file << label << ',';
+    }
+    file << '\n';
+
+    // Print out data row by row
+    for (size_t row = 0; row < max_rows_; ++row) {
+        for (const auto& [label, timestamps] : registry_[registry_index]) {
+            if (row >= timestamps.size()) {
+                // sentinel value
+                file << -1 << ',';
+            } else {
+                file << timestamps[row] << ',';
+            }
+        }
+        file << '\n';
+    }
 }


### PR DESCRIPTION
In a comment right before break, @rishiso  mentioned that we should be able to profile events independent of the robots (#2461). I have implemented that as a feature of the benchmarking module. You would set robot_id to -1 to do this.