### PR TITLE
Removing 0.2 Offset to Prevent Path Behind Goal

### DIFF
--- a/src/rj_planning/src/primitives/create_path.cpp
+++ b/src/rj_planning/src/primitives/create_path.cpp
@@ -107,10 +107,8 @@ Trajectory intermediate(const LinearMotionInstant& start, const LinearMotionInst
             auto offset = intermediate - field_dimensions->center_point();
 
             // Ignore out-of-bounds intermediate points
-            // The offset 0.2m is chosen because the sim prevents you from moving
-            // more than 0.2m away from the border lines
-            if (abs(offset.x()) > field_dimensions->width() / 2 + 0.2 ||
-                abs(offset.y()) > field_dimensions->length() / 2 + 0.2) {
+            if (abs(offset.x()) > field_dimensions->width() / 2 ||
+                abs(offset.y()) > field_dimensions->length() / 2) {
                 continue;
             }
             Trajectory trajectory =


### PR DESCRIPTION
Main issue:
- When offensive robots were seeking or defensive robots walling, there were paths being generated behind the goal.
- This caused numerous issues with path creation, motion planning, and other logistics
- Led to an overall constant replan until it generated another path that was not behind the goal
- Based on the code, this was because of a 0.2m offset that was purposefully made with an unknown reason

Main solution:
- Removal of the 0.2m offset within create_path.cpp and its comments regarding it

If this 0.2m offset was made with some purpose/reason, please let me know and we can make an alternative solution (extending the goal obstacle or wrapping the out-of-bounds zone along that area).