### PR TITLE
Unique PID Parameters for each Robot

### DIFF
--- a/src/rj_control/include/rj_control/motion_control.hpp
+++ b/src/rj_control/include/rj_control/motion_control.hpp
@@ -34,43 +34,6 @@ namespace control {
 // DECLARE_FLOAT64(params::kMotionControlParamModule, translation_kd);
 // DECLARE_INT64(params::kMotionControlParamModule, translation_windup);
 
-MotionControl::MotionControl(int shell_id, rclcpp::Node* node) : shell_id_(shell_id) {
-    std::string param_prefix = fmt::format("robot_{}", std::to_string(shell_id_));
-
-    // declare params
-    // robot specific
-    node->declare_parameter(param_prefix + ".translation_kp", 0.6);
-    node->declare_parameter(param_prefix + ".translation_ki", 0.0);
-    node->declare_parameter(param_prefix + ".translation_kd", 0.3);
-    node->declare_parameter(param_prefix + ".rotation_kp", 10.0);
-    node->declare_parameter(param_prefix + ".rotation_ki", 0.0);
-    node->declare_parameter(param_prefix + ".rotation_kd", 0.9);
-
-    // shared between robots
-    node->declare_parameter("translation_windup", 0);
-    node->declare_parameter("rotation_windup", 50);
-    node->declare_parameter("max_velocity", 2.4);
-    node->declare_parameter("max_acceleration", 3.0);
-    node->declare_paramter("max_angular_velocity", 5.0);
-
-    // populate params
-    // robot specific
-    node->get_parameter(param_prefix + ".translation_kp", translation_kp_);
-    node->get_parameter(param_prefix + ".translation_ki", translation_ki_);
-    node->get_parameter(param_prefix + ".translation_kd", translation_kd_);
-    node->get_parameter(param_prefix + ".rotation_kp", rotation_kp_);
-    node->get_parameter(param_prefix + ".rotation_ki", rotation_ki_);
-    node->get_parameter(param_prefix + ".rotation_kd", rotation_kd_);
-    
-    // shared between robots
-    node->get_parameter("translation_windup", translation_windup_);
-    node->get_parameter("rotation_windup", rotation_windup_);
-    node->get_parameter("max_velocity", max_velocity_);
-    node->get_parameter("max_acceleration", max_acceleration_);
-    node->get_parameter("max_angular_velocity", max_angular_velocity_);
-
-}
-
 namespace testing {
 
 class MotionControlTest;
@@ -116,7 +79,7 @@ private:
      */
     void update_params();
 
-    static void set_velocity(MotionSetpoint* setpoint, rj_geometry::Twist target_vel);
+    void set_velocity(MotionSetpoint* setpoint, rj_geometry::Twist target_vel);
 
     int shell_id_;
 

--- a/src/rj_control/include/rj_control/motion_control.hpp
+++ b/src/rj_control/include/rj_control/motion_control.hpp
@@ -23,16 +23,53 @@
 
 namespace control {
 
-DECLARE_FLOAT64(params::kMotionControlParamModule, max_acceleration);
-DECLARE_FLOAT64(params::kMotionControlParamModule, max_velocity);
-DECLARE_FLOAT64(params::kMotionControlParamModule, rotation_kp);
-DECLARE_FLOAT64(params::kMotionControlParamModule, rotation_ki);
-DECLARE_FLOAT64(params::kMotionControlParamModule, rotation_kd);
-DECLARE_INT64(params::kMotionControlParamModule, rotation_windup);
-DECLARE_FLOAT64(params::kMotionControlParamModule, translation_kp);
-DECLARE_FLOAT64(params::kMotionControlParamModule, translation_ki);
-DECLARE_FLOAT64(params::kMotionControlParamModule, translation_kd);
-DECLARE_INT64(params::kMotionControlParamModule, translation_windup);
+// DECLARE_FLOAT64(params::kMotionControlParamModule, max_acceleration);
+// DECLARE_FLOAT64(params::kMotionControlParamModule, max_velocity);
+// DECLARE_FLOAT64(params::kMotionControlParamModule, rotation_kp);
+// DECLARE_FLOAT64(params::kMotionControlParamModule, rotation_ki);
+// DECLARE_FLOAT64(params::kMotionControlParamModule, rotation_kd);
+// DECLARE_INT64(params::kMotionControlParamModule, rotation_windup);
+// DECLARE_FLOAT64(params::kMotionControlParamModule, translation_kp);
+// DECLARE_FLOAT64(params::kMotionControlParamModule, translation_ki);
+// DECLARE_FLOAT64(params::kMotionControlParamModule, translation_kd);
+// DECLARE_INT64(params::kMotionControlParamModule, translation_windup);
+
+MotionControl::MotionControl(int shell_id, rclcpp::Node* node) : shell_id_(shell_id) {
+    std::string param_prefix = fmt::format("robot_{}", std::to_string(shell_id_));
+
+    // declare params
+    // robot specific
+    node->declare_parameter(param_prefix + ".translation_kp", 0.6);
+    node->declare_parameter(param_prefix + ".translation_ki", 0.0);
+    node->declare_parameter(param_prefix + ".translation_kd", 0.3);
+    node->declare_parameter(param_prefix + ".rotation_kp", 10.0);
+    node->declare_parameter(param_prefix + ".rotation_ki", 0.0);
+    node->declare_parameter(param_prefix + ".rotation_kd", 0.9);
+
+    // shared between robots
+    node->declare_parameter("translation_windup", 0);
+    node->declare_parameter("rotation_windup", 50);
+    node->declare_parameter("max_velocity", 2.4);
+    node->declare_parameter("max_acceleration", 3.0);
+    node->declare_paramter("max_angular_velocity", 5.0);
+
+    // populate params
+    // robot specific
+    node->get_parameter(param_prefix + ".translation_kp", translation_kp_);
+    node->get_parameter(param_prefix + ".translation_ki", translation_ki_);
+    node->get_parameter(param_prefix + ".translation_kd", translation_kd_);
+    node->get_parameter(param_prefix + ".rotation_kp", rotation_kp_);
+    node->get_parameter(param_prefix + ".rotation_ki", rotation_ki_);
+    node->get_parameter(param_prefix + ".rotation_kd", rotation_kd_);
+    
+    // shared between robots
+    node->get_parameter("translation_windup", translation_windup_);
+    node->get_parameter("rotation_windup", rotation_windup_);
+    node->get_parameter("max_velocity", max_velocity_);
+    node->get_parameter("max_acceleration", max_acceleration_);
+    node->get_parameter("max_angular_velocity", max_angular_velocity_);
+
+}
 
 namespace testing {
 
@@ -107,6 +144,23 @@ private:
     rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr error_x_pub_;
     rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr error_y_pub_;
     rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr error_heading_pub_;
+
+    // Robot-specific PID gains
+    double translation_kp_;
+    double translation_ki_;
+    double translation_kd_;
+
+    double rotation_kp_;
+    double rotation_ki_;
+    double rotation_kd_;
+
+    // Shared limits
+    double max_velocity_;
+    double max_acceleration_;
+    double max_angular_velocity_;
+
+    int translation_windup_;
+    int rotation_windup_;
 };
 
 }  // namespace control

--- a/src/rj_control/include/rj_control/motion_control.hpp
+++ b/src/rj_control/include/rj_control/motion_control.hpp
@@ -107,6 +107,7 @@ private:
     rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr error_x_pub_;
     rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr error_y_pub_;
     rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr error_heading_pub_;
+    rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 
     // Robot-specific PID gains
     double translation_kp_;

--- a/src/rj_control/include/rj_control/motion_control.hpp
+++ b/src/rj_control/include/rj_control/motion_control.hpp
@@ -23,17 +23,6 @@
 
 namespace control {
 
-// DECLARE_FLOAT64(params::kMotionControlParamModule, max_acceleration);
-// DECLARE_FLOAT64(params::kMotionControlParamModule, max_velocity);
-// DECLARE_FLOAT64(params::kMotionControlParamModule, rotation_kp);
-// DECLARE_FLOAT64(params::kMotionControlParamModule, rotation_ki);
-// DECLARE_FLOAT64(params::kMotionControlParamModule, rotation_kd);
-// DECLARE_INT64(params::kMotionControlParamModule, rotation_windup);
-// DECLARE_FLOAT64(params::kMotionControlParamModule, translation_kp);
-// DECLARE_FLOAT64(params::kMotionControlParamModule, translation_ki);
-// DECLARE_FLOAT64(params::kMotionControlParamModule, translation_kd);
-// DECLARE_INT64(params::kMotionControlParamModule, translation_windup);
-
 namespace testing {
 
 class MotionControlTest;

--- a/src/rj_control/src/motion_control.cpp
+++ b/src/rj_control/src/motion_control.cpp
@@ -38,22 +38,6 @@ MotionControl::MotionControl(int shell_id, rclcpp::Node* node)
 
             std::string param_prefix = fmt::format("robot_{}", std::to_string(shell_id_));
 
-    // declare params
-    // robot specific
-    // node->declare_parameter(param_prefix + ".translation_kp", 0.6);
-    // node->declare_parameter(param_prefix + ".translation_ki", 0.0);
-    // node->declare_parameter(param_prefix + ".translation_kd", 0.3);
-    // node->declare_parameter(param_prefix + ".rotation_kp", 10.0);
-    // node->declare_parameter(param_prefix + ".rotation_ki", 0.0);
-    // node->declare_parameter(param_prefix + ".rotation_kd", 0.9);
-
-    // // shared between robots
-    // node->declare_parameter("translation_windup", 0);
-    // node->declare_parameter("rotation_windup", 50);
-    // node->declare_parameter("max_velocity", 2.4);
-    // node->declare_parameter("max_acceleration", 3.0);
-    // node->declare_parameter("max_angular_velocity", 5.0);
-
     // populate params
     // robot specific
     node->get_parameter(param_prefix + ".translation_kp", translation_kp_);
@@ -69,6 +53,30 @@ MotionControl::MotionControl(int shell_id, rclcpp::Node* node)
     node->get_parameter("max_velocity", max_velocity_);
     node->get_parameter("max_acceleration", max_acceleration_);
     node->get_parameter("max_angular_velocity", max_angular_velocity_);
+
+    param_callback_handle_ = node->add_on_set_parameters_callback(
+        [this, param_prefix](const std::vector<rclcpp::Parameter>& params) {
+        rcl_interfaces::msg::SetParametersResult result;
+        result.successful = true;
+
+        for (const auto& param : params) {
+            const auto& name = param.get_name();
+
+            if (name == param_prefix + ".translation_kp")       translation_kp_ = param.as_double();
+            else if (name == param_prefix + ".translation_ki")  translation_ki_ = param.as_double();
+            else if (name == param_prefix + ".translation_kd")  translation_kd_ = param.as_double();
+            else if (name == param_prefix + ".rotation_kp")     rotation_kp_ = param.as_double();
+            else if (name == param_prefix + ".rotation_ki")     rotation_ki_ = param.as_double();
+            else if (name == param_prefix + ".rotation_kd")     rotation_kd_ = param.as_double();
+            else if (name == "translation_windup")              translation_windup_ = param.as_int();
+            else if (name == "rotation_windup")                 rotation_windup_ = param.as_int();
+            else if (name == "max_velocity")                    max_velocity_ = param.as_double();
+            else if (name == "max_acceleration")                max_acceleration_ = param.as_double();
+            else if (name == "max_angular_velocity")            max_angular_velocity_ = param.as_double();
+        }
+
+        return result;
+    });
         
     motion_setpoint_pub_ = node->create_publisher<MotionSetpoint::Msg>(
         topics::motion_setpoint_topic(shell_id_), rclcpp::QoS(1));

--- a/src/rj_control/src/motion_control.cpp
+++ b/src/rj_control/src/motion_control.cpp
@@ -35,8 +35,7 @@ MotionControl::MotionControl(int shell_id, rclcpp::Node* node)
       drawer_(
           node->create_publisher<rj_drawing_msgs::msg::DebugDraw>(viz::topics::kDebugDrawTopic, 10),
           fmt::format("motion_control/{}", std::to_string(shell_id))) {
-
-            std::string param_prefix = fmt::format("robot_{}", std::to_string(shell_id_));
+    std::string param_prefix = fmt::format("robot_{}", std::to_string(shell_id_));
 
     // populate params
     // robot specific
@@ -46,7 +45,7 @@ MotionControl::MotionControl(int shell_id, rclcpp::Node* node)
     node->get_parameter(param_prefix + ".rotation_kp", rotation_kp_);
     node->get_parameter(param_prefix + ".rotation_ki", rotation_ki_);
     node->get_parameter(param_prefix + ".rotation_kd", rotation_kd_);
-    
+
     // shared between robots
     node->get_parameter("translation_windup", translation_windup_);
     node->get_parameter("rotation_windup", rotation_windup_);
@@ -56,28 +55,39 @@ MotionControl::MotionControl(int shell_id, rclcpp::Node* node)
 
     param_callback_handle_ = node->add_on_set_parameters_callback(
         [this, param_prefix](const std::vector<rclcpp::Parameter>& params) {
-        rcl_interfaces::msg::SetParametersResult result;
-        result.successful = true;
+            rcl_interfaces::msg::SetParametersResult result;
+            result.successful = true;
 
-        for (const auto& param : params) {
-            const auto& name = param.get_name();
+            for (const auto& param : params) {
+                const auto& name = param.get_name();
 
-            if (name == param_prefix + ".translation_kp")       translation_kp_ = param.as_double();
-            else if (name == param_prefix + ".translation_ki")  translation_ki_ = param.as_double();
-            else if (name == param_prefix + ".translation_kd")  translation_kd_ = param.as_double();
-            else if (name == param_prefix + ".rotation_kp")     rotation_kp_ = param.as_double();
-            else if (name == param_prefix + ".rotation_ki")     rotation_ki_ = param.as_double();
-            else if (name == param_prefix + ".rotation_kd")     rotation_kd_ = param.as_double();
-            else if (name == "translation_windup")              translation_windup_ = param.as_int();
-            else if (name == "rotation_windup")                 rotation_windup_ = param.as_int();
-            else if (name == "max_velocity")                    max_velocity_ = param.as_double();
-            else if (name == "max_acceleration")                max_acceleration_ = param.as_double();
-            else if (name == "max_angular_velocity")            max_angular_velocity_ = param.as_double();
-        }
+                if (name == param_prefix + ".translation_kp")
+                    translation_kp_ = param.as_double();
+                else if (name == param_prefix + ".translation_ki")
+                    translation_ki_ = param.as_double();
+                else if (name == param_prefix + ".translation_kd")
+                    translation_kd_ = param.as_double();
+                else if (name == param_prefix + ".rotation_kp")
+                    rotation_kp_ = param.as_double();
+                else if (name == param_prefix + ".rotation_ki")
+                    rotation_ki_ = param.as_double();
+                else if (name == param_prefix + ".rotation_kd")
+                    rotation_kd_ = param.as_double();
+                else if (name == "translation_windup")
+                    translation_windup_ = param.as_int();
+                else if (name == "rotation_windup")
+                    rotation_windup_ = param.as_int();
+                else if (name == "max_velocity")
+                    max_velocity_ = param.as_double();
+                else if (name == "max_acceleration")
+                    max_acceleration_ = param.as_double();
+                else if (name == "max_angular_velocity")
+                    max_angular_velocity_ = param.as_double();
+            }
 
-        return result;
-    });
-        
+            return result;
+        });
+
     motion_setpoint_pub_ = node->create_publisher<MotionSetpoint::Msg>(
         topics::motion_setpoint_topic(shell_id_), rclcpp::QoS(1));
     target_state_pub_ = node->create_publisher<RobotState::Msg>(

--- a/src/rj_control/src/motion_control.cpp
+++ b/src/rj_control/src/motion_control.cpp
@@ -35,6 +35,41 @@ MotionControl::MotionControl(int shell_id, rclcpp::Node* node)
       drawer_(
           node->create_publisher<rj_drawing_msgs::msg::DebugDraw>(viz::topics::kDebugDrawTopic, 10),
           fmt::format("motion_control/{}", std::to_string(shell_id))) {
+
+            std::string param_prefix = fmt::format("robot_{}", std::to_string(shell_id_));
+
+    // declare params
+    // robot specific
+    // node->declare_parameter(param_prefix + ".translation_kp", 0.6);
+    // node->declare_parameter(param_prefix + ".translation_ki", 0.0);
+    // node->declare_parameter(param_prefix + ".translation_kd", 0.3);
+    // node->declare_parameter(param_prefix + ".rotation_kp", 10.0);
+    // node->declare_parameter(param_prefix + ".rotation_ki", 0.0);
+    // node->declare_parameter(param_prefix + ".rotation_kd", 0.9);
+
+    // // shared between robots
+    // node->declare_parameter("translation_windup", 0);
+    // node->declare_parameter("rotation_windup", 50);
+    // node->declare_parameter("max_velocity", 2.4);
+    // node->declare_parameter("max_acceleration", 3.0);
+    // node->declare_parameter("max_angular_velocity", 5.0);
+
+    // populate params
+    // robot specific
+    node->get_parameter(param_prefix + ".translation_kp", translation_kp_);
+    node->get_parameter(param_prefix + ".translation_ki", translation_ki_);
+    node->get_parameter(param_prefix + ".translation_kd", translation_kd_);
+    node->get_parameter(param_prefix + ".rotation_kp", rotation_kp_);
+    node->get_parameter(param_prefix + ".rotation_ki", rotation_ki_);
+    node->get_parameter(param_prefix + ".rotation_kd", rotation_kd_);
+    
+    // shared between robots
+    node->get_parameter("translation_windup", translation_windup_);
+    node->get_parameter("rotation_windup", rotation_windup_);
+    node->get_parameter("max_velocity", max_velocity_);
+    node->get_parameter("max_acceleration", max_acceleration_);
+    node->get_parameter("max_angular_velocity", max_angular_velocity_);
+        
     motion_setpoint_pub_ = node->create_publisher<MotionSetpoint::Msg>(
         topics::motion_setpoint_topic(shell_id_), rclcpp::QoS(1));
     target_state_pub_ = node->create_publisher<RobotState::Msg>(

--- a/src/rj_control/src/motion_control.cpp
+++ b/src/rj_control/src/motion_control.cpp
@@ -6,28 +6,6 @@ using planning::RobotInstant;
 using rj_geometry::Pose;
 using rj_geometry::Twist;
 
-// DEFINE_FLOAT64(params::kMotionControlParamModule, max_acceleration, 3.0,
-//                "Maximum acceleration limit (motion control) (m/s^2)");
-// DEFINE_FLOAT64(params::kMotionControlParamModule, max_velocity, 2.4,
-//                "Maximum velocity limit (motion control) (m/s)");
-// DEFINE_FLOAT64(params::kMotionControlParamModule, max_angular_velocity, 5.0,
-//                "Maximum angular velocity limit (motion control) (rad/s)");
-// DEFINE_FLOAT64(params::kMotionControlParamModule, rotation_kp, 10.0,
-//                "Kp for rotation ((rad/s)/rad)");
-// DEFINE_FLOAT64(params::kMotionControlParamModule, rotation_ki, 0.0,
-//                "Ki for rotation ((rad/s)/(rad*s))");
-// DEFINE_FLOAT64(params::kMotionControlParamModule, rotation_kd, 0.9,
-//                "Kd for rotation ((rad/s)/(rad/s))");
-// DEFINE_INT64(params::kMotionControlParamModule, rotation_windup, 0,
-//              "Windup limit for rotation (unknown units)");
-// DEFINE_FLOAT64(params::kMotionControlParamModule, translation_kp, 0.6,
-//                "Kp for translation ((m/s)/m)");
-// DEFINE_FLOAT64(params::kMotionControlParamModule, translation_ki, 0.0,
-//                "Ki for translation ((m/s)/(m*s))");
-// DEFINE_FLOAT64(params::kMotionControlParamModule, translation_kd, 0.3,
-//                "Kd for translation ((m/s)/(m/s))");
-// DEFINE_INT64(params::kMotionControlParamModule, translation_windup, 0,
-//              "Windup limit for translation (unknown units)");
 
 MotionControl::MotionControl(int shell_id, rclcpp::Node* node)
     : shell_id_(shell_id),

--- a/src/rj_control/src/motion_control.cpp
+++ b/src/rj_control/src/motion_control.cpp
@@ -6,28 +6,28 @@ using planning::RobotInstant;
 using rj_geometry::Pose;
 using rj_geometry::Twist;
 
-DEFINE_FLOAT64(params::kMotionControlParamModule, max_acceleration, 3.0,
-               "Maximum acceleration limit (motion control) (m/s^2)");
-DEFINE_FLOAT64(params::kMotionControlParamModule, max_velocity, 2.4,
-               "Maximum velocity limit (motion control) (m/s)");
-DEFINE_FLOAT64(params::kMotionControlParamModule, max_angular_velocity, 5.0,
-               "Maximum angular velocity limit (motion control) (rad/s)");
-DEFINE_FLOAT64(params::kMotionControlParamModule, rotation_kp, 10.0,
-               "Kp for rotation ((rad/s)/rad)");
-DEFINE_FLOAT64(params::kMotionControlParamModule, rotation_ki, 0.0,
-               "Ki for rotation ((rad/s)/(rad*s))");
-DEFINE_FLOAT64(params::kMotionControlParamModule, rotation_kd, 0.9,
-               "Kd for rotation ((rad/s)/(rad/s))");
-DEFINE_INT64(params::kMotionControlParamModule, rotation_windup, 0,
-             "Windup limit for rotation (unknown units)");
-DEFINE_FLOAT64(params::kMotionControlParamModule, translation_kp, 0.6,
-               "Kp for translation ((m/s)/m)");
-DEFINE_FLOAT64(params::kMotionControlParamModule, translation_ki, 0.0,
-               "Ki for translation ((m/s)/(m*s))");
-DEFINE_FLOAT64(params::kMotionControlParamModule, translation_kd, 0.3,
-               "Kd for translation ((m/s)/(m/s))");
-DEFINE_INT64(params::kMotionControlParamModule, translation_windup, 0,
-             "Windup limit for translation (unknown units)");
+// DEFINE_FLOAT64(params::kMotionControlParamModule, max_acceleration, 3.0,
+//                "Maximum acceleration limit (motion control) (m/s^2)");
+// DEFINE_FLOAT64(params::kMotionControlParamModule, max_velocity, 2.4,
+//                "Maximum velocity limit (motion control) (m/s)");
+// DEFINE_FLOAT64(params::kMotionControlParamModule, max_angular_velocity, 5.0,
+//                "Maximum angular velocity limit (motion control) (rad/s)");
+// DEFINE_FLOAT64(params::kMotionControlParamModule, rotation_kp, 10.0,
+//                "Kp for rotation ((rad/s)/rad)");
+// DEFINE_FLOAT64(params::kMotionControlParamModule, rotation_ki, 0.0,
+//                "Ki for rotation ((rad/s)/(rad*s))");
+// DEFINE_FLOAT64(params::kMotionControlParamModule, rotation_kd, 0.9,
+//                "Kd for rotation ((rad/s)/(rad/s))");
+// DEFINE_INT64(params::kMotionControlParamModule, rotation_windup, 0,
+//              "Windup limit for rotation (unknown units)");
+// DEFINE_FLOAT64(params::kMotionControlParamModule, translation_kp, 0.6,
+//                "Kp for translation ((m/s)/m)");
+// DEFINE_FLOAT64(params::kMotionControlParamModule, translation_ki, 0.0,
+//                "Ki for translation ((m/s)/(m*s))");
+// DEFINE_FLOAT64(params::kMotionControlParamModule, translation_kd, 0.3,
+//                "Kd for translation ((m/s)/(m/s))");
+// DEFINE_INT64(params::kMotionControlParamModule, translation_windup, 0,
+//              "Windup limit for translation (unknown units)");
 
 MotionControl::MotionControl(int shell_id, rclcpp::Node* node)
     : shell_id_(shell_id),
@@ -188,9 +188,9 @@ void MotionControl::run(const RobotState& state, const planning::Trajectory& tra
 
 void MotionControl::set_velocity(MotionSetpoint* setpoint, Twist target_vel) {
     // Limit Velocity
-    target_vel.linear().clamp(PARAM_max_velocity);
+    target_vel.linear().clamp(max_velocity_);
     target_vel.angular() =
-        std::clamp(target_vel.angular(), -PARAM_max_angular_velocity, PARAM_max_angular_velocity);
+        std::clamp(target_vel.angular(), -max_angular_velocity_, max_angular_velocity_);
 
     // make sure we don't send any bad values
     if (Eigen::Vector3d(target_vel).hasNaN()) {
@@ -211,20 +211,20 @@ void MotionControl::set_velocity(MotionSetpoint* setpoint, Twist target_vel) {
 
 void MotionControl::update_params() {
     // Update PID parameters
-    position_x_controller_.kp = static_cast<float>(PARAM_translation_kp);
-    position_x_controller_.ki = static_cast<float>(PARAM_translation_ki);
-    position_x_controller_.kd = static_cast<float>(PARAM_translation_kd);
-    position_x_controller_.setWindup(PARAM_translation_windup);
+    position_x_controller_.kp = static_cast<float>(translation_kp_);
+    position_x_controller_.ki = static_cast<float>(translation_ki_);
+    position_x_controller_.kd = static_cast<float>(translation_kd_);
+    position_x_controller_.setWindup(translation_windup_);
 
-    position_y_controller_.kp = static_cast<float>(PARAM_translation_kp);
-    position_y_controller_.ki = static_cast<float>(PARAM_translation_ki);
-    position_y_controller_.kd = static_cast<float>(PARAM_translation_kd);
-    position_y_controller_.setWindup(PARAM_translation_windup);
+    position_y_controller_.kp = static_cast<float>(translation_kp_);
+    position_y_controller_.ki = static_cast<float>(translation_ki_);
+    position_y_controller_.kd = static_cast<float>(translation_kd_);
+    position_y_controller_.setWindup(translation_windup_);
 
-    angle_controller_.kp = static_cast<float>(PARAM_rotation_kp);
-    angle_controller_.ki = static_cast<float>(PARAM_rotation_ki);
-    angle_controller_.kd = static_cast<float>(PARAM_rotation_kd);
-    angle_controller_.setWindup(PARAM_rotation_windup);
+    angle_controller_.kp = static_cast<float>(rotation_kp_);
+    angle_controller_.ki = static_cast<float>(rotation_ki_);
+    angle_controller_.kd = static_cast<float>(rotation_kd_);
+    angle_controller_.setWindup(rotation_windup_);
 }
 
 void MotionControl::reset() {

--- a/src/rj_param_utils/config/real_params.yaml
+++ b/src/rj_param_utils/config/real_params.yaml
@@ -4,15 +4,52 @@
 
 /control:
   ros__parameters:
+    robot_0:
+      rotation_kd: 0.9
+      rotation_ki: 0.0
+      rotation_kp: 10.0
+      translation_kd: 0.45
+      translation_ki: 0.0
+      translation_kp: 3.0
+    robot_1:
+      rotation_kd: 0.9
+      rotation_ki: 0.0
+      rotation_kp: 10.0
+      translation_kd: 0.45
+      translation_ki: 0.0
+      translation_kp: 3.0
+    robot_2:
+      rotation_kd: 0.9
+      rotation_ki: 0.0
+      rotation_kp: 10.0
+      translation_kd: 0.45
+      translation_ki: 0.0
+      translation_kp: 3.0
+    robot_3:
+      rotation_kd: 0.9
+      rotation_ki: 0.0
+      rotation_kp: 10.0
+      translation_kd: 0.45
+      translation_ki: 0.0
+      translation_kp: 3.0
+    robot_4:
+      rotation_kd: 0.9
+      rotation_ki: 0.0
+      rotation_kp: 10.0
+      translation_kd: 0.45
+      translation_ki: 0.0
+      translation_kp: 3.0
+    robot_5:
+      rotation_kd: 0.9
+      rotation_ki: 0.0
+      rotation_kp: 10.0
+      translation_kd: 0.45
+      translation_ki: 0.0
+      translation_kp: 3.0
     max_acceleration: 2.0
+    max_angular_velocity: 1.0
     max_velocity: 0.5
-    rotation_kd: 0.9
-    rotation_ki: 0.0
-    rotation_kp: 10.0
     rotation_windup: 0
-    translation_kd: 0.45
-    translation_ki: 0.0
-    translation_kp: 3.0
     translation_windup: 0
     use_sim_time: false
 

--- a/src/rj_param_utils/config/sim_params.yaml
+++ b/src/rj_param_utils/config/sim_params.yaml
@@ -4,15 +4,52 @@
 
 /control:
   ros__parameters:
+    robot_0:
+      rotation_kd: 0.0
+      rotation_ki: 0.0
+      rotation_kp: 8.0
+      translation_kd: 0.0
+      translation_ki: 0.0
+      translation_kp: 4.0
+    robot_1:
+      rotation_kd: 0.0
+      rotation_ki: 0.0
+      rotation_kp: 8.0
+      translation_kd: 0.0
+      translation_ki: 0.0
+      translation_kp: 4.0
+    robot_2:
+      rotation_kd: 0.0
+      rotation_ki: 0.0
+      rotation_kp: 8.0
+      translation_kd: 0.0
+      translation_ki: 0.0
+      translation_kp: 4.0
+    robot_3:
+      rotation_kd: 0.0
+      rotation_ki: 0.0
+      rotation_kp: 8.0
+      translation_kd: 0.0
+      translation_ki: 0.0
+      translation_kp: 4.0
+    robot_4:
+      rotation_kd: 0.0
+      rotation_ki: 0.0
+      rotation_kp: 8.0
+      translation_kd: 0.0
+      translation_ki: 0.0
+      translation_kp: 4.0
+    robot_5:
+      rotation_kd: 0.0
+      rotation_ki: 0.0
+      rotation_kp: 8.0
+      translation_kd: 0.0
+      translation_ki: 0.0
+      translation_kp: 4.0
     max_acceleration: 1.5
+    max_angular_velocity: 1.0
     max_velocity: 2.0
-    rotation_kd: 0.0
-    rotation_ki: 0.0
-    rotation_kp: 8.0
     rotation_windup: 0
-    translation_kd: 0.0
-    translation_ki: 0.0
-    translation_kp: 4.0
     translation_windup: 0
     use_sim_time: false
 


### PR DESCRIPTION
## Description
Changed the sim and real params .yamls to use per robot PID values for rotation and translation, kp, kd, ki for robots 0-5. Modified the motion_control cpp and hpp files for this change, removed the constant DEFINES.

## Associated / Resolved Issue
https://app.clickup.com/t/86b6w4xcu


## Steps to Test
1. Source, make, and make run-sim
2. In another terminal window, open up RQT using the rqt command after sourcing
3. Run the simulator and note which robots are moving
4. Change the kp value for one of the moving robots to 100000

**Expected result:**
Should see the robot that had it's value change start moving weirdly, while the other robots remain fine.

## Key Files to Review
 * sim_params.yaml
 * real_params.yaml
 * motion_control.cpp
 * motion_control.hpp