### PR TITLE
debug_drawer expansion into strategy/position files

### DIFF
--- a/src/rj_strategy/CMakeLists.txt
+++ b/src/rj_strategy/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(rj_msgs REQUIRED)
 find_package(rj_constants REQUIRED)
 find_package(rj_convert REQUIRED)
 find_package(rj_common REQUIRED)
+find_package(rj_drawing_msgs REQUIRED)
 find_package(rj_geometry REQUIRED)
 find_package(rj_param_utils REQUIRED)
 find_package(rj_utils REQUIRED)
@@ -33,6 +34,7 @@ set(RJ_STRATEGY_DEPS
   rj_constants
   rj_convert
   rj_common
+  rj_drawing_msgs
   rj_geometry
   rj_param_utils
   rj_utils

--- a/src/rj_strategy/include/rj_strategy/agent/position.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position.hpp
@@ -320,6 +320,11 @@ protected:
     // farthest distance the robot is willing to go before it declares it has lost the ball
     static constexpr double ball_lost_distance_ = 0.5;
 
+    // constant for label offset in debug drawing
+    static constexpr double kLabelRadius = 0.15;
+
+    static constexpr double label_angle_constant = 2.0 * M_PI;
+
     // vector of alive robots from the agent action client
     std::array<bool, kNumShells> alive_robots_ = {};
 

--- a/src/rj_strategy/include/rj_strategy/agent/position.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position.hpp
@@ -14,8 +14,10 @@
 #include <rj_common/field_dimensions.hpp>
 #include <rj_common/game_state.hpp>
 #include <rj_common/robot_intent.hpp>
+#include <rj_common/ros_debug_drawer.hpp>
 #include <rj_common/time.hpp>
 #include <rj_common/world_state.hpp>
+#include <rj_constants/topic_names.hpp>
 #include <rj_geometry/geometry_conversions.hpp>
 #include <rj_geometry/point.hpp>
 #include <rj_msgs/action/robot_move.hpp>
@@ -245,6 +247,12 @@ public:
      */
     void set_client_handles(std::shared_ptr<ClientHandles> client_handles);
 
+    /**
+     * @brief Sets the debug drawer for this position. When debug_draw_enabled_
+     * is true, draw calls will be published to the sim/UI each tick.
+     */
+    void set_debug_drawer(std::shared_ptr<rj_drawing::RosDebugDrawer> drawer);
+
 protected:
     Position(int r_id, std::string position_name);
 
@@ -326,6 +334,10 @@ protected:
 
     // Current goalie
     int goalie_id_;
+
+    // Debug drawing support: shared across position swaps via move semantics
+    std::shared_ptr<rj_drawing::RosDebugDrawer> debug_drawer_;
+    bool debug_draw_enabled_ = false;
 
 private:
     /**

--- a/src/rj_strategy/include/rj_strategy/agent/position/defense.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/defense.hpp
@@ -73,6 +73,29 @@ private:
     State current_state_ = JOINING_WALL;
     std::optional<RobotIntent> state_to_task(RobotIntent intent);
 
+     static constexpr std::string_view state_to_name(State s) {
+        switch (s) {
+            case IDLING:
+                return "IDLING";
+            case JOINING_WALL:
+                return "JOINING_WALL";
+            case WALLING:
+                return "WALLING";
+            case SEARCHING:
+                return "SEARCHING";
+            case RECEIVING:
+                return "RECEIVING";
+            case PASSING:
+                return "PASSING";
+            case FACING:
+                return "FACING";
+            case MARKING:
+                return "ENTERING_MARKING";
+            case ENTERING_MARKING:
+                return "ENTERING_MARKING";
+        }
+    }
+
     bool sent_join_marking_group_request_ = false;
     RJ::Time request_time_;
 

--- a/src/rj_strategy/include/rj_strategy/agent/position/defense.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/defense.hpp
@@ -73,7 +73,7 @@ private:
     State current_state_ = JOINING_WALL;
     std::optional<RobotIntent> state_to_task(RobotIntent intent);
 
-     static constexpr std::string_view state_to_name(State s) {
+    static constexpr std::string_view state_to_name(State s) {
         switch (s) {
             case IDLING:
                 return "IDLING";

--- a/src/rj_strategy/include/rj_strategy/agent/position/goalie.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/goalie.hpp
@@ -86,6 +86,29 @@ private:
     // current state of Goalie (state machine)
     State latest_state_ = IDLING;
 
+    static constexpr std::string_view state_to_name(State s) {
+        switch (s) {
+            case IDLING:
+                return "IDLING";
+            case BLOCKING:
+                return "BLOCKING";
+            case CLEARING:
+                return "CLEARING";
+            case PREPARING_SHOT:
+                return "PREPARING_SHOT";
+            case BALL_NOT_FOUND:
+                return "BALL_NOT_FOUND";
+            case RECEIVING:
+                return "RECEIVING";
+            case PASSING:
+                return "PASSING";
+            case FACING:
+                return "FACING";
+            case PENALTY:
+                return "PENALTY";
+        }
+    }
+
     rj_geometry::Point penalty_location();
 };
 

--- a/src/rj_strategy/include/rj_strategy/agent/position/robot_factory_position.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/robot_factory_position.hpp
@@ -115,6 +115,9 @@ public:
 private:
     std::unique_ptr<Position> current_position_;
 
+    // Persistent handle to the debug drawer so it survives position swaps
+    std::shared_ptr<rj_drawing::RosDebugDrawer> strategy_debug_drawer_;
+
     OverridingPositions override_play_position_{OverridingPositions::AUTO};
 
     std::optional<RobotIntent> derived_get_task(RobotIntent intent) override;

--- a/src/rj_strategy/src/agent/position.cpp
+++ b/src/rj_strategy/src/agent/position.cpp
@@ -29,7 +29,13 @@ std::optional<RobotIntent> Position::get_task(WorldState& world_state,
         return intent;
     }
     // delegate to derived class to complete behavior
-    return derived_get_task(intent);
+    auto result = derived_get_task(intent);
+
+    if (debug_draw_enabled_ && debug_drawer_) {
+        debug_drawer_->publish();
+    }
+
+    return result;
 }
 
 void Position::set_time_left(double time_left) { time_left_ = time_left; }
@@ -84,6 +90,10 @@ bool Position::assert_world_state_valid() {
 
 void Position::set_client_handles(std::shared_ptr<ClientHandles> client_handles) {
     client_handles_ = client_handles;
+}
+
+void Position::set_debug_drawer(std::shared_ptr<rj_drawing::RosDebugDrawer> drawer) {
+    debug_drawer_ = std::move(drawer);
 }
 
 std::deque<communication::PosAgentRequestWrapper> Position::send_communication_request() {

--- a/src/rj_strategy/src/agent/position/defense.cpp
+++ b/src/rj_strategy/src/agent/position/defense.cpp
@@ -16,8 +16,7 @@ std::optional<RobotIntent> Defense::derived_get_task(RobotIntent intent) {
 
     if (debug_draw_enabled_ && debug_drawer_) {
         auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
-        constexpr double kLabelRadius = 0.15;
-        double angle = (robot_id_ * 2.0 * M_PI) / kRobotsPerTeam; 
+        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam; 
         rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle), kLabelRadius * std::sin(angle)};
 
         debug_drawer_->draw_text(position_name_ + "/" + std::string(state_to_name(current_state_)), robot_pos + label_offset, Qt::white);

--- a/src/rj_strategy/src/agent/position/defense.cpp
+++ b/src/rj_strategy/src/agent/position/defense.cpp
@@ -2,12 +2,10 @@
 
 namespace strategy {
 
-Defense::Defense(int r_id) : Position(r_id, "Defense") {
-    debug_draw_enabled_ = true;
-}
+Defense::Defense(int r_id) : Position(r_id, "Defense") { debug_draw_enabled_ = true; }
 
-Defense::Defense(Position&& other) : Position{std::move(other)} { 
-    position_name_ = "Defense"; 
+Defense::Defense(Position&& other) : Position{std::move(other)} {
+    position_name_ = "Defense";
     debug_draw_enabled_ = true;
 }
 
@@ -16,10 +14,12 @@ std::optional<RobotIntent> Defense::derived_get_task(RobotIntent intent) {
 
     if (debug_draw_enabled_ && debug_drawer_) {
         auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
-        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam; 
-        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle), kLabelRadius * std::sin(angle)};
+        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam;
+        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle),
+                                           kLabelRadius * std::sin(angle)};
 
-        debug_drawer_->draw_text(position_name_ + "/" + std::string(state_to_name(current_state_)), robot_pos + label_offset, Qt::white);
+        debug_drawer_->draw_text(position_name_ + "/" + std::string(state_to_name(current_state_)),
+                                 robot_pos + label_offset, Qt::white);
     }
 
     return state_to_task(intent);

--- a/src/rj_strategy/src/agent/position/defense.cpp
+++ b/src/rj_strategy/src/agent/position/defense.cpp
@@ -2,12 +2,27 @@
 
 namespace strategy {
 
-Defense::Defense(int r_id) : Position(r_id, "Defense") {}
+Defense::Defense(int r_id) : Position(r_id, "Defense") {
+    debug_draw_enabled_ = true;
+}
 
-Defense::Defense(Position&& other) : Position{std::move(other)} { position_name_ = "Defense"; }
+Defense::Defense(Position&& other) : Position{std::move(other)} { 
+    position_name_ = "Defense"; 
+    debug_draw_enabled_ = true;
+}
 
 std::optional<RobotIntent> Defense::derived_get_task(RobotIntent intent) {
     current_state_ = update_state();
+
+    if (debug_draw_enabled_ && debug_drawer_) {
+        auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
+        constexpr double kLabelRadius = 0.15;
+        double angle = (robot_id_ * 2.0 * M_PI) / kRobotsPerTeam; 
+        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle), kLabelRadius * std::sin(angle)};
+
+        debug_drawer_->draw_text(position_name_ + "/" + std::string(state_to_name(current_state_)), robot_pos + label_offset, Qt::white);
+    }
+
     return state_to_task(intent);
 }
 

--- a/src/rj_strategy/src/agent/position/goalie.cpp
+++ b/src/rj_strategy/src/agent/position/goalie.cpp
@@ -2,12 +2,27 @@
 
 namespace strategy {
 
-Goalie::Goalie(int r_id) : Position(r_id, "Goalie") {}
+Goalie::Goalie(int r_id) : Position(r_id, "Goalie") {
+    debug_draw_enabled_ = true;
+}
 
-Goalie::Goalie(Position&& other) : Position{std::move(other)} {}
+Goalie::Goalie(Position&& other) : Position{std::move(other)} {
+    position_name_ = "Goalie";
+    debug_draw_enabled_ = true;
+}
 
 std::optional<RobotIntent> Goalie::derived_get_task(RobotIntent intent) {
     latest_state_ = update_state();
+
+    if (debug_draw_enabled_ && debug_drawer_) {
+        auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
+        constexpr double kLabelRadius = 0.15;
+        double angle = (robot_id_ * 2.0 * M_PI) / kRobotsPerTeam; 
+        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle), kLabelRadius * std::sin(angle)};
+
+        debug_drawer_->draw_text(position_name_ + "/" + std::string(state_to_name(latest_state_)), robot_pos + label_offset, Qt::white);
+    }
+
     return state_to_task(intent);
 }
 

--- a/src/rj_strategy/src/agent/position/goalie.cpp
+++ b/src/rj_strategy/src/agent/position/goalie.cpp
@@ -2,9 +2,7 @@
 
 namespace strategy {
 
-Goalie::Goalie(int r_id) : Position(r_id, "Goalie") {
-    debug_draw_enabled_ = true;
-}
+Goalie::Goalie(int r_id) : Position(r_id, "Goalie") { debug_draw_enabled_ = true; }
 
 Goalie::Goalie(Position&& other) : Position{std::move(other)} {
     position_name_ = "Goalie";
@@ -16,10 +14,12 @@ std::optional<RobotIntent> Goalie::derived_get_task(RobotIntent intent) {
 
     if (debug_draw_enabled_ && debug_drawer_) {
         auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
-        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam; 
-        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle), kLabelRadius * std::sin(angle)};
+        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam;
+        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle),
+                                           kLabelRadius * std::sin(angle)};
 
-        debug_drawer_->draw_text(position_name_ + "/" + std::string(state_to_name(latest_state_)), robot_pos + label_offset, Qt::white);
+        debug_drawer_->draw_text(position_name_ + "/" + std::string(state_to_name(latest_state_)),
+                                 robot_pos + label_offset, Qt::white);
     }
 
     return state_to_task(intent);

--- a/src/rj_strategy/src/agent/position/goalie.cpp
+++ b/src/rj_strategy/src/agent/position/goalie.cpp
@@ -16,8 +16,7 @@ std::optional<RobotIntent> Goalie::derived_get_task(RobotIntent intent) {
 
     if (debug_draw_enabled_ && debug_drawer_) {
         auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
-        constexpr double kLabelRadius = 0.15;
-        double angle = (robot_id_ * 2.0 * M_PI) / kRobotsPerTeam; 
+        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam; 
         rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle), kLabelRadius * std::sin(angle)};
 
         debug_drawer_->draw_text(position_name_ + "/" + std::string(state_to_name(latest_state_)), robot_pos + label_offset, Qt::white);

--- a/src/rj_strategy/src/agent/position/offense.cpp
+++ b/src/rj_strategy/src/agent/position/offense.cpp
@@ -31,8 +31,7 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
     // Example of how to draw text on the debug drawer for position/strategy debugging
     if (debug_draw_enabled_ && debug_drawer_) {
         auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
-        constexpr double kLabelRadius = 0.15;
-        double angle = (robot_id_ * 2.0 * M_PI) / kRobotsPerTeam; 
+        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam; 
         rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle), kLabelRadius * std::sin(angle)};
 
         debug_drawer_->draw_text("Offense/" + std::string(state_to_name(current_state_)), robot_pos + label_offset, Qt::white);

--- a/src/rj_strategy/src/agent/position/offense.cpp
+++ b/src/rj_strategy/src/agent/position/offense.cpp
@@ -31,7 +31,11 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
     // Example of how to draw text on the debug drawer for position/strategy debugging
     if (debug_draw_enabled_ && debug_drawer_) {
         auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
-        debug_drawer_->draw_text(std::string(state_to_name(current_state_)), robot_pos);
+        constexpr double kLabelRadius = 0.15;
+        double angle = (robot_id_ * 2.0 * M_PI) / kRobotsPerTeam; 
+        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle), kLabelRadius * std::sin(angle)};
+
+        debug_drawer_->draw_text("Offense/" + std::string(state_to_name(current_state_)), robot_pos + label_offset, Qt::white);
     }
 
     // Calculate task based on state

--- a/src/rj_strategy/src/agent/position/offense.cpp
+++ b/src/rj_strategy/src/agent/position/offense.cpp
@@ -29,10 +29,12 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
     // Example of how to draw text on the debug drawer for position/strategy debugging
     if (debug_draw_enabled_ && debug_drawer_) {
         auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
-        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam; 
-        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle), kLabelRadius * std::sin(angle)};
+        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam;
+        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle),
+                                           kLabelRadius * std::sin(angle)};
 
-        debug_drawer_->draw_text("Offense/" + std::string(state_to_name(current_state_)), robot_pos + label_offset, Qt::white);
+        debug_drawer_->draw_text("Offense/" + std::string(state_to_name(current_state_)),
+                                 robot_pos + label_offset, Qt::white);
     }
 
     // Calculate task based on state

--- a/src/rj_strategy/src/agent/position/offense.cpp
+++ b/src/rj_strategy/src/agent/position/offense.cpp
@@ -12,8 +12,6 @@ Offense::Offense(Position&& other) : Position{std::move(other)}, seeker_{robot_i
 }
 
 std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
-
-
     // Get next state, and if different, reset clock
     State new_state = next_state();
 

--- a/src/rj_strategy/src/agent/position/offense.cpp
+++ b/src/rj_strategy/src/agent/position/offense.cpp
@@ -2,13 +2,18 @@
 
 namespace strategy {
 
-Offense::Offense(int r_id) : Position{r_id, "Offense"}, seeker_{r_id} {}
+Offense::Offense(int r_id) : Position{r_id, "Offense"}, seeker_{r_id} {
+    debug_draw_enabled_ = true;
+}
 
 Offense::Offense(Position&& other) : Position{std::move(other)}, seeker_{robot_id_} {
     position_name_ = "Offense";
+    debug_draw_enabled_ = true;
 }
 
 std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
+
+
     // Get next state, and if different, reset clock
     State new_state = next_state();
 
@@ -22,6 +27,11 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
     }
 
     current_state_ = new_state;
+
+    if (debug_draw_enabled_ && debug_drawer_) {
+        auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
+        debug_drawer_->draw_text(std::string(state_to_name(current_state_)), robot_pos);
+    }
 
     // Calculate task based on state
     return state_to_task(intent);

--- a/src/rj_strategy/src/agent/position/offense.cpp
+++ b/src/rj_strategy/src/agent/position/offense.cpp
@@ -28,6 +28,7 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
 
     current_state_ = new_state;
 
+    // Example of how to draw text on the debug drawer for position/strategy debugging
     if (debug_draw_enabled_ && debug_drawer_) {
         auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
         debug_drawer_->draw_text(std::string(state_to_name(current_state_)), robot_pos);

--- a/src/rj_strategy/src/agent/position/robot_factory_position.cpp
+++ b/src/rj_strategy/src/agent/position/robot_factory_position.cpp
@@ -8,8 +8,8 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id, rclcpp::Node::SharedPtr nod
     client_handles_->marking = std::make_unique<MarkingClient>(node, r_id);
     client_handles_->waller = std::make_unique<WallerClient>(node, r_id);
 
-    auto debug_draw_pub = node->create_publisher<rj_drawing_msgs::msg::DebugDraw>(
-        viz::topics::kDebugDrawTopic, 10);
+    auto debug_draw_pub =
+        node->create_publisher<rj_drawing_msgs::msg::DebugDraw>(viz::topics::kDebugDrawTopic, 10);
     strategy_debug_drawer_ = std::make_shared<rj_drawing::RosDebugDrawer>(
         debug_draw_pub, fmt::format("strategy_{}", r_id));
 

--- a/src/rj_strategy/src/agent/position/robot_factory_position.cpp
+++ b/src/rj_strategy/src/agent/position/robot_factory_position.cpp
@@ -8,6 +8,11 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id, rclcpp::Node::SharedPtr nod
     client_handles_->marking = std::make_unique<MarkingClient>(node, r_id);
     client_handles_->waller = std::make_unique<WallerClient>(node, r_id);
 
+    auto debug_draw_pub = node->create_publisher<rj_drawing_msgs::msg::DebugDraw>(
+        viz::topics::kDebugDrawTopic, 10);
+    strategy_debug_drawer_ = std::make_shared<rj_drawing::RosDebugDrawer>(
+        debug_draw_pub, fmt::format("strategy_{}", r_id));
+
     if (robot_id_ == 0) {
         current_position_ = std::make_unique<Goalie>(robot_id_);
     } else if (robot_id_ == 1 || robot_id_ == 2) {
@@ -17,10 +22,14 @@ RobotFactoryPosition::RobotFactoryPosition(int r_id, rclcpp::Node::SharedPtr nod
     }
 
     current_position_->set_client_handles(client_handles_);
+    current_position_->set_debug_drawer(strategy_debug_drawer_);
 }
 
 std::optional<RobotIntent> RobotFactoryPosition::derived_get_task([
     [maybe_unused]] RobotIntent intent) {
+    // Ensure the child position always has the debug drawer (survives position swaps)
+    current_position_->set_debug_drawer(strategy_debug_drawer_);
+
     if (robot_id_ == goalie_id_) {
         set_current_position<Goalie>();
         return current_position_->get_task(*last_world_state_, field_dimensions_,


### PR DESCRIPTION
**This addition to the stack is not necessary, but I believe will help tremendously towards debugging and adding additional visual features to the simulator**

Implementing debug_drawer among all instances of position/strategy for the sim:
- Position classes like offense.cpp, defence.cpp, seeker.cpp, solo_offense.cpp, and many more will now be capable of incorporating debug_drawer features (drawing circles/squares, inputting text, etc)
- This feature is linked to a flag variable (located in position.hpp called "debug_draw_enabled_") which is defaulted to false, but can be selectively enabled for specific position roles
- Example of enabling and incorporating this debugging feature is shown in offense.cpp, where offense bots will now showcase their current state when moving, avoiding the messy need to utilize SPDLOG_INFO and flood the terminal with print statements. If you want to remove this, just let me know with a comment and I can comment out the currently enabled example