### PR TITLE
clangd support for our stack: credit goes to nate

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,2 @@
 CompileFlags:
-    CompilationDatabase: build-release-debug/
+    CompilationDatabase: build/

--- a/colcon_defaults.yaml
+++ b/colcon_defaults.yaml
@@ -9,4 +9,4 @@ build:
 
 test:
     event-handlers:
-        - "console_conhesion+"
+        - "console_cohesion+"

--- a/colcon_defaults.yaml
+++ b/colcon_defaults.yaml
@@ -1,0 +1,12 @@
+build:
+    cmake-args:
+        - -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        - -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        - -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+    parallel-workers: 2
+    event-handlers:
+        - "console_cohesion+"
+
+test:
+    event-handlers:
+        - "console_conhesion+"


### PR DESCRIPTION
a very fast and easy intellisense/lsp built on clang compiler. rather than microsoft intellisense "guessing" stuff, this actually parses the whole repo.

download the clangd extension from vscode marketplace and set it to be your default intellisense. works like a charm! if you use neovim just install clangd. probably add setup for this in the new member workshops