### PR TITLE
Better build time

### DIFF
--- a/src/rj_benchmarking/CMakeLists.txt
+++ b/src/rj_benchmarking/CMakeLists.txt
@@ -41,6 +41,7 @@ set(BENCHMARKING_SRC
 add_library(${PROJECT_NAME} SHARED
     ${BENCHMARKING_SRC}
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC

--- a/src/rj_benchmarking/CMakeLists.txt
+++ b/src/rj_benchmarking/CMakeLists.txt
@@ -60,24 +60,12 @@ ament_target_dependencies(${PROJECT_NAME}
 
 # Benchmarking Node
 add_executable(${PROJECT_NAME}_node
-    ${BENCHMARKING_SRC}
     src/main.cpp
 )
 
-target_include_directories(${PROJECT_NAME}_node
-    PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-)
-
 target_link_libraries(${PROJECT_NAME}_node
-    PUBLIC
-    ${BENCHMARKING_LIBS}
-)
-
-ament_target_dependencies(${PROJECT_NAME}_node
-    PUBLIC
-    ${BENCHMARKING_DEPS}
+    PRIVATE
+    ${PROJECT_NAME}
 )
 
 install(

--- a/src/rj_common/CMakeLists.txt
+++ b/src/rj_common/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(${PROJECT_NAME} SHARED
   src/planning/trajectory.cpp
   src/radio/packet_convert.cpp
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 ament_target_dependencies(${PROJECT_NAME}
   PUBLIC

--- a/src/rj_control/CMakeLists.txt
+++ b/src/rj_control/CMakeLists.txt
@@ -72,7 +72,6 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 ament_target_dependencies(motion_control_node
-  PRIVATE
   rclcpp
   ${RJ_CONTROL_DEPS}
 )

--- a/src/rj_control/CMakeLists.txt
+++ b/src/rj_control/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(${PROJECT_NAME} SHARED
   src/motion_control.cpp
   src/pid.cpp
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 target_include_directories(motion_control_node
   PUBLIC
@@ -71,7 +72,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 ament_target_dependencies(motion_control_node
-  PUBLIC
+  PRIVATE
   rclcpp
   ${RJ_CONTROL_DEPS}
 )

--- a/src/rj_control/CMakeLists.txt
+++ b/src/rj_control/CMakeLists.txt
@@ -62,7 +62,6 @@ target_include_directories(${PROJECT_NAME}
 )
 
 target_link_libraries(motion_control_node
-  PRIVATE
   ${PROJECT_NAME}
 )
 

--- a/src/rj_control/CMakeLists.txt
+++ b/src/rj_control/CMakeLists.txt
@@ -41,12 +41,9 @@ set(RJ_CONTROL_DEPS
 
 add_executable(motion_control_node
   src/motion_control_node.cpp
-  src/motion_control.cpp
-  src/pid.cpp
 )
 
 add_library(${PROJECT_NAME} SHARED
-  src/motion_control_node.cpp
   src/motion_control.cpp
   src/pid.cpp
 )
@@ -64,8 +61,8 @@ target_include_directories(${PROJECT_NAME}
 )
 
 target_link_libraries(motion_control_node
-  PUBLIC
-  ${FLANN_LIBRARIES}
+  PRIVATE
+  ${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/src/rj_geometry/CMakeLists.txt
+++ b/src/rj_geometry/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(${PROJECT_NAME} SHARED
   src/stadium_shape.cpp
   src/transform_matrix.cpp
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC

--- a/src/rj_optimization/CMakeLists.txt
+++ b/src/rj_optimization/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(${PROJECT_NAME} SHARED
   src/parallel_gradient_ascent_1d.cpp
   src/python_function_wrapper.cpp
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC

--- a/src/rj_param_utils/CMakeLists.txt
+++ b/src/rj_param_utils/CMakeLists.txt
@@ -13,15 +13,6 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(fmt REQUIRED)
 
-add_executable(global_param_server_node
-  src/global_param_server.cpp
-  src/global_params.cpp
-  src/param.cpp
-  src/ros2_global_param_provider.cpp
-  src/ros2_local_param_provider.cpp
-  src/ros2_param_provider.cpp
-)
-
 add_library(${PROJECT_NAME} SHARED
   src/global_params.cpp
   src/param.cpp
@@ -31,11 +22,7 @@ add_library(${PROJECT_NAME} SHARED
   src/planning/planning_params.cpp
   src/vision/vision_params.cpp
 )
-
-ament_target_dependencies(global_param_server_node
-  rclcpp
-  fmt
-)
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 ament_target_dependencies(${PROJECT_NAME}
   rclcpp
@@ -46,21 +33,17 @@ target_link_libraries(${PROJECT_NAME}
   fmt
 )
 
-target_link_libraries(global_param_server_node
-  fmt
-)
-
-target_include_directories(global_param_server_node
-  PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
-
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
+
+add_executable(global_param_server_node
+  src/global_param_server.cpp
+)
+
+target_link_libraries(global_param_server_node PRIVATE ${PROJECT_NAME})
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 

--- a/src/rj_planning/CMakeLists.txt
+++ b/src/rj_planning/CMakeLists.txt
@@ -120,7 +120,7 @@ target_link_libraries(planner_node
 )
 
 ament_target_dependencies(planner_node
-  PUBLIC
+  PRIVATE
   ${RJ_PLANNING_DEPS}
 )
 

--- a/src/rj_planning/CMakeLists.txt
+++ b/src/rj_planning/CMakeLists.txt
@@ -104,7 +104,6 @@ ament_target_dependencies(${PROJECT_NAME}
 
 # Planner Node
 add_executable(planner_node
-  ${RJ_PLANNING_SRC}
   src/main.cpp
 )
 
@@ -115,8 +114,8 @@ target_include_directories(planner_node
 )
 
 target_link_libraries(planner_node
-  PUBLIC
-  ${RJ_PLANNING_LIBS}
+  PRIVATE
+  ${PROJECT_NAME}
 )
 
 ament_target_dependencies(planner_node

--- a/src/rj_planning/CMakeLists.txt
+++ b/src/rj_planning/CMakeLists.txt
@@ -115,7 +115,6 @@ target_include_directories(planner_node
 )
 
 target_link_libraries(planner_node
-  PRIVATE
   ${PROJECT_NAME}
 )
 

--- a/src/rj_planning/CMakeLists.txt
+++ b/src/rj_planning/CMakeLists.txt
@@ -120,7 +120,6 @@ target_link_libraries(planner_node
 )
 
 ament_target_dependencies(planner_node
-  PRIVATE
   ${RJ_PLANNING_DEPS}
 )
 

--- a/src/rj_planning/CMakeLists.txt
+++ b/src/rj_planning/CMakeLists.txt
@@ -85,6 +85,7 @@ set(RJ_PLANNING_SRC
 add_library(${PROJECT_NAME} SHARED
   ${RJ_PLANNING_SRC}
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC

--- a/src/rj_radio/CMakeLists.txt
+++ b/src/rj_radio/CMakeLists.txt
@@ -47,6 +47,7 @@ set(RJ_RADIO_DEPS
 add_library(${PROJECT_NAME} SHARED
   src/radio.cpp
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC

--- a/src/rj_radio/CMakeLists.txt
+++ b/src/rj_radio/CMakeLists.txt
@@ -44,55 +44,44 @@ set(RJ_RADIO_DEPS
   rj_constants
 )
 
-add_executable(network_radio_node
-  src/network_radio.cpp
+add_library(${PROJECT_NAME} SHARED
   src/radio.cpp
 )
 
-add_executable(sim_radio_node
-  src/sim_radio.cpp
-  src/radio.cpp
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(network_radio_node
+target_link_libraries(${PROJECT_NAME}
   PUBLIC
   spdlog
   Boost::boost
   ${FLANN_LIBRARIES}
 )
 
-target_link_libraries(sim_radio_node
-  PUBLIC
-  spdlog
-  Boost::boost
-  ${FLANN_LIBRARIES}
-)
-
-target_include_directories(network_radio_node
-  PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
-
-target_include_directories(sim_radio_node
-  PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
-
-ament_target_dependencies(network_radio_node
+ament_target_dependencies(${PROJECT_NAME}
   PUBLIC
   ${RJ_RADIO_DEPS}
 )
 
-ament_target_dependencies(sim_radio_node
-  PUBLIC
-  ${RJ_RADIO_DEPS}
-)
+add_executable(network_radio_node src/network_radio.cpp)
+add_executable(sim_radio_node src/sim_radio.cpp)
+
+target_link_libraries(network_radio_node PRIVATE ${PROJECT_NAME})
+target_link_libraries(sim_radio_node PRIVATE ${PROJECT_NAME})
 
 install(
   DIRECTORY include/
   DESTINATION include
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 install(

--- a/src/rj_referee/CMakeLists.txt
+++ b/src/rj_referee/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(${PROJECT_NAME} SHARED
   src/external_referee.cpp
   src/internal_referee.cpp
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 add_executable(external_referee_node
   src/external_referee_main.cpp

--- a/src/rj_referee/CMakeLists.txt
+++ b/src/rj_referee/CMakeLists.txt
@@ -45,15 +45,11 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 add_executable(external_referee_node
-  src/external_referee.cpp
   src/external_referee_main.cpp
-  src/referee_base.cpp
 )
 
 add_executable(internal_referee_node
-  src/internal_referee.cpp
   src/internal_referee_main.cpp
-  src/referee_base.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}
@@ -64,17 +60,13 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 target_link_libraries(external_referee_node
-  PUBLIC
-  Boost::boost
-  fmt
-  spdlog
+  PRIVATE
+  ${PROJECT_NAME}
 )
 
 target_link_libraries(internal_referee_node
-  PUBLIC
-  Boost::boost
-  fmt
-  spdlog
+  PRIVATE
+  ${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
@@ -83,29 +75,7 @@ target_include_directories(${PROJECT_NAME}
   $<INSTALL_INTERFACE:include>
 )
 
-target_include_directories(external_referee_node
-  PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
-
-target_include_directories(internal_referee_node
-  PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
-
 ament_target_dependencies(${PROJECT_NAME}
-  PUBLIC
-  ${RJ_REFEREE_DEPS}
-)
-
-ament_target_dependencies(external_referee_node
-  PUBLIC
-  ${RJ_REFEREE_DEPS}
-)
-
-ament_target_dependencies(internal_referee_node
   PUBLIC
   ${RJ_REFEREE_DEPS}
 )

--- a/src/rj_rrt/CMakeLists.txt
+++ b/src/rj_rrt/CMakeLists.txt
@@ -42,12 +42,12 @@ endif()
 add_library(${PROJECT_NAME} SHARED
     ${RJ_RRT_SRC}
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 add_executable(rrt_viewer
     # SRC Files
     src/rrt-viewer/main.cpp
     src/rrt-viewer/RRTWidget.cpp
-    ${RJ_RRT_SRC}
 
     # QT MOC Headers
     include/rj_rrt/rrt-viewer/RRTWidget.hpp
@@ -75,8 +75,8 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 target_link_libraries(rrt_viewer
-    PUBLIC
-    ${RJ_RRT_LIBS}
+    PRIVATE
+    ${PROJECT_NAME}
     Qt5::Core
     Qt5::Qml
     Qt5::Quick

--- a/src/rj_rrt/CMakeLists.txt
+++ b/src/rj_rrt/CMakeLists.txt
@@ -75,7 +75,6 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 target_link_libraries(rrt_viewer
-    PRIVATE
     ${PROJECT_NAME}
     Qt5::Core
     Qt5::Qml

--- a/src/rj_strategy/CMakeLists.txt
+++ b/src/rj_strategy/CMakeLists.txt
@@ -84,7 +84,6 @@ ament_target_dependencies(${PROJECT_NAME}
 
 # Straight Line Test Node
 add_executable(straight_line_test_node
-  ${RJ_STRATEGY_SRC}
   src/testing/straight_line_test.cpp
 )
 
@@ -94,14 +93,16 @@ target_include_directories(straight_line_test_node
   $<INSTALL_INTERFACE:include>
 )
 
+target_link_libraries(straight_line_test_node
+  ${PROJECT_NAME}
+)
+
 ament_target_dependencies(straight_line_test_node
   ${RJ_STRATEGY_DEPS}
 )
 
 # Kicker Picker Node
 add_executable(kicker_picker_node
-  ${RJ_STRATEGY_SRC}
-  src/coordinator/kicker_picker_client.cpp
   src/coordinator/kicker_picker.cpp
 )
 
@@ -111,14 +112,16 @@ target_include_directories(kicker_picker_node
   $<INSTALL_INTERFACE:include>
 )
 
+target_link_libraries(kicker_picker_node
+  ${PROJECT_NAME}
+)
+
 ament_target_dependencies(kicker_picker_node
   ${RJ_STRATEGY_DEPS}
 )
 
 # Marking Node
 add_executable(marking_node
-  ${RJ_STRATEGY_SRC}
-  src/coordinator/marking_client.cpp
   src/coordinator/marking.cpp
 )
 
@@ -129,8 +132,6 @@ target_include_directories(marking_node
 )
 # Waller Node
 add_executable(waller_node
-  ${RJ_STRATEGY_SRC}
-  src/coordinator/waller_client.cpp
   src/coordinator/waller.cpp
 )
 
@@ -138,6 +139,14 @@ target_include_directories(waller_node
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(marking_node
+  ${PROJECT_NAME}
+)
+
+target_link_libraries(waller_node
+  ${PROJECT_NAME}
 )
 
 ament_target_dependencies(marking_node
@@ -149,7 +158,6 @@ ament_target_dependencies(waller_node
 
 # Agent Action Clients
 add_executable(agent_action_clients
-  ${RJ_STRATEGY_SRC}
   src/agent/agent_action_client.cpp
 )
 
@@ -157,6 +165,10 @@ target_include_directories(agent_action_clients
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(agent_action_clients
+  ${PROJECT_NAME}
 )
 
 ament_target_dependencies(agent_action_clients

--- a/src/rj_strategy/CMakeLists.txt
+++ b/src/rj_strategy/CMakeLists.txt
@@ -70,6 +70,7 @@ set(RJ_STRATEGY_SRC
 add_library(${PROJECT_NAME} SHARED
   ${RJ_STRATEGY_SRC}
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC

--- a/src/rj_ui/CMakeLists.txt
+++ b/src/rj_ui/CMakeLists.txt
@@ -84,6 +84,18 @@ set(SRC_FILES
   qt/log_icons.qrc
 )
 
+set(RJ_UI_NODE_AUTOGEN_FILES
+  include/rj_ui/main_window.hpp
+  include/rj_ui/robot_status_widget.hpp
+  qt/MainWindow.ui
+  qt/RobotStatusWidget.ui
+)
+
+set(RJ_UI_LOG_VIEWER_AUTOGEN_FILES
+  include/rj_ui/log_viewer.hpp
+  qt/LogViewer.ui
+)
+
 set(RJ_UI_DEPS
   rclcpp
   Qt5
@@ -114,14 +126,13 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 add_executable(${PROJECT_NAME}_node
-  # Source Files
   src/main.cpp
-  ${SRC_FILES}
+  ${RJ_UI_NODE_AUTOGEN_FILES}
 )
 
 add_executable(log_viewer_node
   src/log_viewer_main.cpp
-  ${SRC_FILES}
+  ${RJ_UI_LOG_VIEWER_AUTOGEN_FILES}
 )
 
 target_include_directories(${PROJECT_NAME}_node
@@ -146,33 +157,13 @@ target_include_directories(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}_node
-  PUBLIC
-  Boost::boost
-  Qt5::Widgets
-  Qt5::Xml
-  Qt5::Core
-  Qt5::OpenGL
-  Qt5::Network
-  Qt5::Svg
-  protobuf::libprotobuf
-  spdlog
-  fmt
-  ${FLANN_LIBRARIES}
+  PRIVATE
+  ${PROJECT_NAME}
 )
 
 target_link_libraries(log_viewer_node
-  PUBLIC
-  Boost::boost
-  Qt5::Widgets
-  Qt5::Xml
-  Qt5::Core
-  Qt5::OpenGL
-  Qt5::Network
-  Qt5::Svg
-  protobuf::libprotobuf
-  spdlog
-  fmt
-  ${FLANN_LIBRARIES}
+  PRIVATE
+  ${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/src/rj_vision_filter/CMakeLists.txt
+++ b/src/rj_vision_filter/CMakeLists.txt
@@ -44,24 +44,6 @@ set(RJ_VISION_FILTER_DEPS
 
 add_executable(${PROJECT_NAME}_node
   src/main.cpp
-  src/ball/ball_bounce.cpp
-  src/ball/camera_ball.cpp
-  src/ball/kalman_ball.cpp
-  src/ball/world_ball.cpp
-  src/camera/camera.cpp
-  src/camera/world.cpp
-  src/filter/kalman_filter.cpp
-  src/filter/kalman_filter_2d.cpp
-  src/filter/kalman_filter3_d.cpp
-  src/kick/detector/fast_kick_detector.cpp
-  src/kick/detector/slow_kick_detector.cpp
-  src/kick/estimator/chip_kick_estimator.cpp
-  src/kick/estimator/flat_kick_estimator.cpp
-  src/kick/kick_event.cpp
-  src/robot/camera_robot.cpp
-  src/robot/kalman_robot.cpp
-  src/robot/world_robot.cpp
-  src/vision_filter.cpp
 )
 
 add_library(${PROJECT_NAME}
@@ -86,10 +68,8 @@ add_library(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}_node
-  PUBLIC
-  Boost::boost
-  Eigen3::Eigen
-  spdlog
+  PRIVATE
+  ${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/src/rj_vision_filter/CMakeLists.txt
+++ b/src/rj_vision_filter/CMakeLists.txt
@@ -93,7 +93,6 @@ target_include_directories(${PROJECT_NAME}
 )
 
 ament_target_dependencies(${PROJECT_NAME}_node
-  PRIVATE
   ${RJ_VISION_FILTER_DEPS}
 )
 

--- a/src/rj_vision_filter/CMakeLists.txt
+++ b/src/rj_vision_filter/CMakeLists.txt
@@ -93,7 +93,7 @@ target_include_directories(${PROJECT_NAME}
 )
 
 ament_target_dependencies(${PROJECT_NAME}_node
-  PUBLIC
+  PRIVATE
   ${RJ_VISION_FILTER_DEPS}
 )
 

--- a/src/rj_vision_filter/CMakeLists.txt
+++ b/src/rj_vision_filter/CMakeLists.txt
@@ -46,7 +46,7 @@ add_executable(${PROJECT_NAME}_node
   src/main.cpp
 )
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   src/ball/ball_bounce.cpp
   src/ball/camera_ball.cpp
   src/ball/kalman_ball.cpp
@@ -66,6 +66,7 @@ add_library(${PROJECT_NAME}
   src/robot/world_robot.cpp
   src/vision_filter.cpp
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 target_link_libraries(${PROJECT_NAME}_node
   PRIVATE

--- a/src/rj_vision_filter/CMakeLists.txt
+++ b/src/rj_vision_filter/CMakeLists.txt
@@ -69,7 +69,6 @@ add_library(${PROJECT_NAME} SHARED
 set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
 
 target_link_libraries(${PROJECT_NAME}_node
-  PRIVATE
   ${PROJECT_NAME}
 )
 


### PR DESCRIPTION
## Problem
Build times take too long, and I don't think we can use Aiden's computer for our builds. Ideally, we can build the stack without it taking 1/4 of our time in the shop.

Currently, multiple packages are building the same source files multiple times. In particular, packages were built once into a shared library, and another time for each executable. This leads to absurdly slow build times.

## Changes Made
Instead of having each executable rebuild all the relevant packages, we now only compile each executable's entry point (think ``main.cpp``) and then link things against the package's library. This means that any shared sources are just compiled once.

One example to think of (this helped me understand things a bit more):
For something like ``rj_vision_filter``, we used to have something like this:

```cmake
add_executable(rj_vision_filter_node
    src/main.cpp
    src/ball/ball_bounce.cpp  
    src/camera/camera.cpp
    ...many other files...
  )
```

AND we would also have something like this:

```cmake
add_library(rj_vision_filter
    src/ball/ball_bounce.cpp   
    src/camera/camera.cpp
    ...again, many other files...
  )
```

The issue here is that the same files just get compiled twice. This sucks. This PR proposes the following:

```cmake
add_executable(rj_vision_filter_node
    src/main.cpp               
  )
```

Notice how we just compile the entry point. And we leave the ``add_library`` part the same:

```cmake
add_library(rj_vision_filter
    src/ball/ball_bounce.cpp 
    src/camera/camera.cpp
    ..the other files..
  )
```

Basically every package was updated, but thanks to Cameron for pointing out these specific issues:
- ``rj_radio`` and ``rj_referee`` use the same shared logic (``radio.cpp``, ``referee_base.cpp``, etc), which is duplicated. This is now just compiled once into the library.
- ``rj_param_utils`` and ``global_param_server_node`` was recompiling a bunch of library source files. These just compile their own entry point now.

Another thing I found after looking at some other CMakeLists (for other ROS packages), they use this thing called Unity builds, which is specified with ``UNITY_BUILD_ON``. From my understanding, this merges ``.cpp`` files into 1 compilation unit, so the compiler doesn't have to work with things on a per-file basis.

Another change overall is just removing a bunch of redundant ``target_include_directories`` and ``ament_target_dependencies``. Everything is just inherited with the library now being PUBLIC.

## Result
Using our current Docker container, running ``make perf_docker`` on a fresh build took about 1.5 minutes.