### PR TITLE
Rules compliance and other fixes

### DIFF
--- a/src/rj_planning/src/planner_for_robot.cpp
+++ b/src/rj_planning/src/planner_for_robot.cpp
@@ -130,7 +130,7 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
             break;
         case PlayState::State::Stop:
             min_dist_from_ball = 0.5;
-            max_robot_speed = 1.5;
+            max_robot_speed = 1.4;
             max_dribbler_speed = 0;
             max_kick_speed = 0;
             break;
@@ -142,6 +142,15 @@ PlanRequest PlannerForRobot::make_request(const RobotIntent& intent) {
             max_dribbler_speed = 255;
             max_kick_speed = 15;
             break;
+        case PlayState::State::Ready:
+            if (play_state.is_their_restart() &&
+                (play_state.is_free_kick() || play_state.is_kickoff())) {
+                min_dist_from_ball = 0.5;
+                max_robot_speed = 1.4;
+                max_dribbler_speed = 0;
+                max_kick_speed = 0;
+                break;
+            }
         case PlayState::State::Playing:
         default:
 

--- a/src/rj_strategy/include/rj_strategy/agent/position.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position.hpp
@@ -99,6 +99,8 @@ public:
     // returns the current state of the robot
     virtual std::string get_current_state() = 0;
 
+    virtual std::string get_state_name() const { return "None"; }
+
     /**
      * @brief setter for time_left_
      */
@@ -351,7 +353,7 @@ protected:
 
     // Debug drawing support: shared across position swaps via move semantics
     std::shared_ptr<rj_drawing::RosDebugDrawer> debug_drawer_;
-    bool debug_draw_enabled_ = false;
+    bool debug_draw_enabled_ = true;
 
 private:
     /**

--- a/src/rj_strategy/include/rj_strategy/agent/position/defense.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/defense.hpp
@@ -40,6 +40,10 @@ public:
     void derived_acknowledge_ball_in_transit() override;
     std::string get_current_state() override;
 
+    std::string get_state_name() const override {
+        return std::string(state_to_name(current_state_));
+    }
+
     void die() override;
     void revive() override;
 

--- a/src/rj_strategy/include/rj_strategy/agent/position/goalie.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/goalie.hpp
@@ -13,6 +13,7 @@
 #include <rj_msgs/action/robot_move.hpp>
 
 #include "rj_strategy/agent/position.hpp"
+#include "rj_strategy/agent/position_utils.hpp"
 
 namespace strategy {
 

--- a/src/rj_strategy/include/rj_strategy/agent/position/goalie.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/goalie.hpp
@@ -33,7 +33,9 @@ public:
 
     std::string get_current_state() override;
 
-    std::string get_state_name() const override { return std::string(state_to_name(latest_state_)); }
+    std::string get_state_name() const override {
+        return std::string(state_to_name(latest_state_));
+    }
 
 private:
     // point goalie will aim for when clearing balls

--- a/src/rj_strategy/include/rj_strategy/agent/position/goalie.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/goalie.hpp
@@ -33,6 +33,8 @@ public:
 
     std::string get_current_state() override;
 
+    std::string get_state_name() const override { return std::string(state_to_name(latest_state_)); }
+
 private:
     // point goalie will aim for when clearing balls
     const rj_geometry::Point clear_point_{0.0, 4.5};

--- a/src/rj_strategy/include/rj_strategy/agent/position/offense.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/offense.hpp
@@ -42,6 +42,10 @@ public:
 
     std::string get_current_state() override;
 
+    std::string get_state_name() const override {
+        return std::string(state_to_name(current_state_));
+    }
+
 private:
     /**
      * @brief Overriden from Position. Calls next_state and then state_to_task on each tick.

--- a/src/rj_strategy/include/rj_strategy/agent/position/robot_factory_position.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/robot_factory_position.hpp
@@ -32,6 +32,7 @@
 #include "rj_strategy/agent/position/smartidling.hpp"
 #include "rj_strategy/agent/position/solo_offense.hpp"
 #include "rj_strategy/agent/position/zoner.hpp"
+#include "rj_strategy/agent/position_utils.hpp"
 
 namespace strategy {
 
@@ -130,9 +131,13 @@ private:
 
     PlayState last_play_state_{PlayState::halt()};
 
+    bool double_touch_lock_{false};
+
     void process_play_state();
 
     void update_position();
+
+    bool another_robot_touched_ball() const;
 
     void handle_stop();
 

--- a/src/rj_strategy/include/rj_strategy/agent/position/solo_offense.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position/solo_offense.hpp
@@ -31,6 +31,10 @@ public:
 
     std::string get_current_state() override;
 
+    std::string get_state_name() const override {
+        return std::string(state_to_name(current_state_));
+    }
+
 private:
     enum State {
         IDLE,     // The nothing doer

--- a/src/rj_strategy/include/rj_strategy/agent/position_utils.hpp
+++ b/src/rj_strategy/include/rj_strategy/agent/position_utils.hpp
@@ -229,7 +229,7 @@ inline rj_geometry::Point calculate_best_shot(const WorldState* world_state,
  * @return does it have ball
  */
 inline bool robot_has_ball(const WorldState* world_state, const RobotState& robot,
-                           double possession_radius = kRobotRadius) {
+                           double possession_radius = 2 * kRobotRadius) {
     // TODO: this function should probably account for rotation
     //       a robot cannot take dribble possession with its rear wheels
 
@@ -286,7 +286,13 @@ inline bool we_have_ball(const WorldState* world_state, double possession_radius
  */
 inline int calculate_kick_speed(double distance_to_target, double intended_velo_at_target) {
     // Without measurement of anything, we cannot make a cogent estimate of kick speed.
-    return 4;
+    if (distance_to_target < 0.6) {
+        return 5;
+    } else if (distance_to_target < 1.8) {
+        return 6;
+    }
+
+    return 7;
 
     // TODO: these numbers are imaginary; based on estimates, we NEED to measure
     // This is the approach we should take to kick speed, do not delete this.

--- a/src/rj_strategy/src/agent/position.cpp
+++ b/src/rj_strategy/src/agent/position.cpp
@@ -32,6 +32,12 @@ std::optional<RobotIntent> Position::get_task(WorldState& world_state,
     auto result = derived_get_task(intent);
 
     if (debug_draw_enabled_ && debug_drawer_) {
+        auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
+        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam;
+        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle),
+                                           kLabelRadius * std::sin(angle)};
+        debug_drawer_->draw_text(position_name_ + "/" + get_state_name(), robot_pos + label_offset,
+                                 Qt::white);
         debug_drawer_->publish();
     }
 

--- a/src/rj_strategy/src/agent/position/defense.cpp
+++ b/src/rj_strategy/src/agent/position/defense.cpp
@@ -2,25 +2,14 @@
 
 namespace strategy {
 
-Defense::Defense(int r_id) : Position(r_id, "Defense") { debug_draw_enabled_ = true; }
+Defense::Defense(int r_id) : Position(r_id, "Defense") {}
 
 Defense::Defense(Position&& other) : Position{std::move(other)} {
     position_name_ = "Defense";
-    debug_draw_enabled_ = true;
 }
 
 std::optional<RobotIntent> Defense::derived_get_task(RobotIntent intent) {
     current_state_ = update_state();
-
-    if (debug_draw_enabled_ && debug_drawer_) {
-        auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
-        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam;
-        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle),
-                                           kLabelRadius * std::sin(angle)};
-
-        debug_drawer_->draw_text(position_name_ + "/" + std::string(state_to_name(current_state_)),
-                                 robot_pos + label_offset, Qt::white);
-    }
 
     return state_to_task(intent);
 }

--- a/src/rj_strategy/src/agent/position/goalie.cpp
+++ b/src/rj_strategy/src/agent/position/goalie.cpp
@@ -2,25 +2,14 @@
 
 namespace strategy {
 
-Goalie::Goalie(int r_id) : Position(r_id, "Goalie") { debug_draw_enabled_ = true; }
+Goalie::Goalie(int r_id) : Position(r_id, "Goalie") {}
 
 Goalie::Goalie(Position&& other) : Position{std::move(other)} {
     position_name_ = "Goalie";
-    debug_draw_enabled_ = true;
 }
 
 std::optional<RobotIntent> Goalie::derived_get_task(RobotIntent intent) {
     latest_state_ = update_state();
-
-    if (debug_draw_enabled_ && debug_drawer_) {
-        auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
-        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam;
-        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle),
-                                           kLabelRadius * std::sin(angle)};
-
-        debug_drawer_->draw_text(position_name_ + "/" + std::string(state_to_name(latest_state_)),
-                                 robot_pos + label_offset, Qt::white);
-    }
 
     return state_to_task(intent);
 }

--- a/src/rj_strategy/src/agent/position/goalie.cpp
+++ b/src/rj_strategy/src/agent/position/goalie.cpp
@@ -119,7 +119,7 @@ std::optional<RobotIntent> Goalie::state_to_task(RobotIntent intent) {
         // TODO(Kevin): make intent hold a manip msg instead? to be cleaner?
         intent.shoot_mode = RobotIntent::ShootMode::CHIP;
         intent.trigger_mode = RobotIntent::TriggerMode::ON_BREAK_BEAM;
-        intent.kick_speed = 15.0;
+        intent.kick_speed = max_kick_speed();
         intent.dribbler_mode = RobotIntent::DribblerMode::ON;
         intent.is_active = true;
 

--- a/src/rj_strategy/src/agent/position/idle.cpp
+++ b/src/rj_strategy/src/agent/position/idle.cpp
@@ -4,7 +4,7 @@ namespace strategy {
 
 Idle::Idle(int r_id) : Position{r_id, "Idle"} {}
 
-Idle::Idle(Position&& other) : Position{std::move(other)} {}
+Idle::Idle(Position&& other) : Position{std::move(other)} { position_name_ = "Idle"; }
 
 std::string Idle::get_current_state() { return "Idle"; }
 

--- a/src/rj_strategy/src/agent/position/offense.cpp
+++ b/src/rj_strategy/src/agent/position/offense.cpp
@@ -2,13 +2,10 @@
 
 namespace strategy {
 
-Offense::Offense(int r_id) : Position{r_id, "Offense"}, seeker_{r_id} {
-    debug_draw_enabled_ = true;
-}
+Offense::Offense(int r_id) : Position{r_id, "Offense"}, seeker_{r_id} {}
 
 Offense::Offense(Position&& other) : Position{std::move(other)}, seeker_{robot_id_} {
     position_name_ = "Offense";
-    debug_draw_enabled_ = true;
 }
 
 std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
@@ -24,17 +21,6 @@ std::optional<RobotIntent> Offense::derived_get_task(RobotIntent intent) {
     }
 
     current_state_ = new_state;
-
-    // Example of how to draw text on the debug drawer for position/strategy debugging
-    if (debug_draw_enabled_ && debug_drawer_) {
-        auto robot_pos = last_world_state_->get_robot(true, robot_id_).pose.position();
-        double angle = (robot_id_ * label_angle_constant) / kRobotsPerTeam;
-        rj_geometry::Point label_offset = {kLabelRadius * std::cos(angle),
-                                           kLabelRadius * std::sin(angle)};
-
-        debug_drawer_->draw_text("Offense/" + std::string(state_to_name(current_state_)),
-                                 robot_pos + label_offset, Qt::white);
-    }
 
     // Calculate task based on state
     return state_to_task(intent);

--- a/src/rj_strategy/src/agent/position/penalty_non_kicker.cpp
+++ b/src/rj_strategy/src/agent/position/penalty_non_kicker.cpp
@@ -4,7 +4,9 @@ namespace strategy {
 
 PenaltyNonKicker::PenaltyNonKicker(int r_id) : Position{r_id, "PenaltyNonKicker"} {}
 
-PenaltyNonKicker::PenaltyNonKicker(Position&& other) : Position{std::move(other)} {}
+PenaltyNonKicker::PenaltyNonKicker(Position&& other) : Position{std::move(other)} {
+    position_name_ = "PenaltyNonKicker";
+}
 
 std::string PenaltyNonKicker::get_current_state() { return "PenaltyNonKicker"; }
 

--- a/src/rj_strategy/src/agent/position/penalty_player.cpp
+++ b/src/rj_strategy/src/agent/position/penalty_player.cpp
@@ -5,7 +5,9 @@ namespace strategy {
 // ALSO USED AS KickoffKicker
 PenaltyPlayer::PenaltyPlayer(int r_id) : Position(r_id, "PenaltyPlayer") {}
 
-PenaltyPlayer::PenaltyPlayer(Position&& other) : Position{std::move(other)} {}
+PenaltyPlayer::PenaltyPlayer(Position&& other) : Position{std::move(other)} {
+    position_name_ = "PenaltyPlayer";
+}
 
 std::optional<RobotIntent> PenaltyPlayer::derived_get_task(RobotIntent intent) {
     latest_state_ = update_state();

--- a/src/rj_strategy/src/agent/position/robot_factory_position.cpp
+++ b/src/rj_strategy/src/agent/position/robot_factory_position.cpp
@@ -42,7 +42,18 @@ std::optional<RobotIntent> RobotFactoryPosition::derived_get_task([
     // Every tick, update position based on PlayState
     update_position();
 
-    return current_position_->get_task(*last_world_state_, field_dimensions_, current_play_state_);
+    auto task =
+        current_position_->get_task(*last_world_state_, field_dimensions_, current_play_state_);
+
+    if (task.has_value() && current_play_state_.is_kickoff() &&
+        !client_handles_->kicker_picker->is_selected()) {
+        task->local_obstacles.add(
+            std::make_shared<rj_geometry::Rect>(field_dimensions_.their_half()));
+        task->local_obstacles.add(std::make_shared<rj_geometry::Circle>(
+            field_dimensions_.center_field_loc(), field_dimensions_.center_radius()));
+    }
+
+    return task;
 }
 
 void RobotFactoryPosition::process_play_state() {
@@ -54,6 +65,13 @@ void RobotFactoryPosition::process_play_state() {
             case PlayState::State::Playing: {
                 // We just became regular playing.
                 // set_default_position();
+
+                if (last_play_state_.is_our_restart() &&
+                    (last_play_state_.is_free_kick() || last_play_state_.is_kickoff()) &&
+                    client_handles_->kicker_picker->is_selected()) {
+                    double_touch_lock_ = true;
+                }
+
                 client_handles_->kicker_picker->leave_group();
                 break;
             }
@@ -93,7 +111,13 @@ void RobotFactoryPosition::process_play_state() {
     }
 }
 
-void RobotFactoryPosition::handle_stop() { set_default_position(); }
+void RobotFactoryPosition::handle_stop() {
+    set_default_position();
+
+    if (dynamic_cast<Offense*>(current_position_.get()) != nullptr) {
+        set_current_position<SmartIdle>();
+    }
+}
 
 void RobotFactoryPosition::handle_penalty_playing() {
     if (!(client_handles_->kicker_picker->am_i_member() &&
@@ -162,6 +186,16 @@ void RobotFactoryPosition::update_position() {
         return;
     }
 
+    if (double_touch_lock_) {
+        if (current_play_state_.state() != PlayState::State::Playing ||
+            another_robot_touched_ball()) {
+            double_touch_lock_ = false;
+        } else {
+            set_current_position<SmartIdle>();
+            return;
+        }
+    }
+
     switch (current_play_state_.state()) {
         case PlayState::State::Playing: {
             // We just became regular playing.
@@ -201,6 +235,24 @@ void RobotFactoryPosition::update_position() {
             break;
         }
     }
+}
+
+bool RobotFactoryPosition::another_robot_touched_ball() const {
+    if (they_have_ball(last_world_state_)) {
+        return true;
+    }
+
+    for (int i = 0; i < static_cast<int>(kNumShells); ++i) {
+        if (i == robot_id_) {
+            continue;
+        }
+
+        if (robot_has_ball(last_world_state_, last_world_state_->our_robots[i])) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void RobotFactoryPosition::set_default_position() {

--- a/src/rj_strategy/src/agent/position/smartidling.cpp
+++ b/src/rj_strategy/src/agent/position/smartidling.cpp
@@ -4,7 +4,9 @@ namespace strategy {
 
 SmartIdle::SmartIdle(int r_id) : Position{r_id, "SmartIdle"} {}
 
-SmartIdle::SmartIdle(Position&& other) : Position{std::move(other)} { position_name_ = "SmartIdle"; }
+SmartIdle::SmartIdle(Position&& other) : Position{std::move(other)} {
+    position_name_ = "SmartIdle";
+}
 
 std::string SmartIdle::get_current_state() { return "SmartIdle"; }
 

--- a/src/rj_strategy/src/agent/position/smartidling.cpp
+++ b/src/rj_strategy/src/agent/position/smartidling.cpp
@@ -4,7 +4,7 @@ namespace strategy {
 
 SmartIdle::SmartIdle(int r_id) : Position{r_id, "SmartIdle"} {}
 
-SmartIdle::SmartIdle(Position&& other) : Position{std::move(other)} {}
+SmartIdle::SmartIdle(Position&& other) : Position{std::move(other)} { position_name_ = "SmartIdle"; }
 
 std::string SmartIdle::get_current_state() { return "SmartIdle"; }
 


### PR DESCRIPTION
## Description
Some fixes

- **Defender distance (opponent restart):** Added a `Ready` case in `planner_for_robot.cpp` so all robots keep `min_dist_from_ball = 0.5` during an opponent free kick / kick-off

- **Stop speed cap:** Lowered the STOP `max_robot_speed` from `1.5 → 1.4` (`planner_for_robot.cpp`) for headroom under the stop-speed foul threshold.

- **Double touch:** `RobotFactoryPosition` now locks the free-kick/kick-off kicker into `SmartIdle` after it kicks, releasing when play stops or another robot touches the ball (`another_robot_touched_ball()`).

- **Kick-off positioning:** During a kick-off, non-kicker robots get the opponent half + center circle as `local_obstacles`, keeping them in our half and out of the circle; the selected kicker is exempt.

- **Ball speed:** Goalie clear changed from full power `15.0` to `max_kick_speed()` in `goalie.cpp`

- **Offense stealing during STOP** `handle_stop()` swaps any `Offense` robot to `SmartIdle`, stopping the drive-into-padding / escape-obstacle oscillation around the ball during stop.

- **Position Labels:** All positions have labels in the form of `POSITION/STATE` now

## Testing
Verified each of the changes using game controller testing. Noticed a few other small issues (marking) but will fix these on comp branch