### PR TITLE
Updating Source Bash to Pin Compiler Version to GCC 11. Also, adds more informative messages.

### DIFF
--- a/source.bash
+++ b/source.bash
@@ -1,16 +1,37 @@
-if [[ $SHELL == *"bash"* ]]; then
-    echo "bash detected, sourcing bash"
+# Welcome to our Robocup Setup Bash Script :)
+
+# Check if user already sourced
+if [[ -n "$AMENT_PREFIX_PATH" ]]; then
+    echo "WARNING: a workspace is already sourced in this shell." >&2
+    echo "  If you just deleted install or make clean, open a new terminal " >&2
+    echo "  stale paths cause PackageNotFoundError at launch." >&2
+fi
+
+# Pin compiler to GCC 11 to match /opt/ros/humble binaries
+if [[ -x /usr/bin/g++-11 && -x /usr/bin/gcc-11 ]]; then
+    export CC=/usr/bin/gcc-11
+    export CXX=/usr/bin/g++-11
+else
+    echo "ERROR: gcc-11/g++-11 not found. Install with: " >&2
+    echo "  sudo apt install gcc-11 g++-11" >&2
+    return 1
+fi
+
+# Running ROS Setup with shell detection
+if [[ -n "$BASH_VERSION" ]]; then
     source /opt/ros/humble/setup.bash
     if [[ -f install/setup.bash ]]; then
         source install/setup.bash
     fi
-fi
-
-if [[ $SHELL == *"zsh"* ]]; then
-    echo "zsh detected, sourcing zsh"
+elif [[ -n "$ZSH_VERSION" ]]; then
     source /opt/ros/humble/setup.zsh
     if [[ -f install/setup.zsh ]]; then
         source install/setup.zsh
     fi
+else
+    echo "ERROR: unsupported shell. This script needs bash or zsh." >&2
+    return 1
 fi
+
+echo "ROS Setup Complete!"
 

--- a/src/rj_benchmarking/README.md
+++ b/src/rj_benchmarking/README.md
@@ -1,7 +1,100 @@
-# Georgia Tech Robojackets Software: rj_benchmarking
+# Package Documentation
 
-Hello there
+Reusable assessment, refactor, and verification template.
 
-## License
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
 
-This project is licensed under the Apache License v2.0.  See the [LICENSE](LICENSE) file for more information.
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_benchmarking/README.md
+++ b/src/rj_benchmarking/README.md
@@ -1,0 +1,7 @@
+# Georgia Tech Robojackets Software: rj_benchmarking
+
+Hello there
+
+## License
+
+This project is licensed under the Apache License v2.0.  See the [LICENSE](LICENSE) file for more information.

--- a/src/rj_common/README.md
+++ b/src/rj_common/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_config_client/README.md
+++ b/src/rj_config_client/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_config_server/README.md
+++ b/src/rj_config_server/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_constants/README.md
+++ b/src/rj_constants/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_control/README.md
+++ b/src/rj_control/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_convert/README.md
+++ b/src/rj_convert/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_drawing_msgs/README.md
+++ b/src/rj_drawing_msgs/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_geometry/README.md
+++ b/src/rj_geometry/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_geometry_msgs/README.md
+++ b/src/rj_geometry_msgs/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_joystick/README.md
+++ b/src/rj_joystick/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_msgs/README.md
+++ b/src/rj_msgs/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_optimization/README.md
+++ b/src/rj_optimization/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_param_utils/README.md
+++ b/src/rj_param_utils/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_planning/README.md
+++ b/src/rj_planning/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_protos/README.md
+++ b/src/rj_protos/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_radio/README.md
+++ b/src/rj_radio/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_referee/README.md
+++ b/src/rj_referee/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_rrt/README copy.md
+++ b/src/rj_rrt/README copy.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_strategy/README.md
+++ b/src/rj_strategy/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_topic_utils/README.md
+++ b/src/rj_topic_utils/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_ui/README.md
+++ b/src/rj_ui/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_utils/README.md
+++ b/src/rj_utils/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_vision_filter/README.md
+++ b/src/rj_vision_filter/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.

--- a/src/rj_vision_receiver/README.md
+++ b/src/rj_vision_receiver/README.md
@@ -1,0 +1,100 @@
+# Package Documentation
+
+Reusable assessment, refactor, and verification template.
+
+| Package Details | Entry |
+| --- | --- |
+| **Package name** |  |
+| **Assigned owner(s)** |  |
+| **Reviewer(s)** |  |
+| **Date started revision** |  |
+| **Branch / tracking issue** |  |
+
+## Purpose of This Template
+
+Use one completed copy per package. Define what is changing, why it is changing, how the change affects the codebase, and how stability and efficiency will be verified. Complete this document with the assigned coder and reviewer before merging package changes.
+
+## 1. Package Identity and Tier
+
+Define the package's purpose and fixed architectural classification before work starts.
+
+| Field | Details |
+| --- | --- |
+| **Plain-language purpose** | _Explain what the package does so a new contributor can understand it._ |
+| **Codebase role** | _Describe where the package fits and what part of the system it supports._ |
+| **Current responsibilities** | _List the responsibilities currently owned by this package._ |
+| **Out of scope** | _State what this package must not own or attempt to solve._ |
+
+## 2. Dependency Rules
+
+Map package relationships before adding, deleting, or moving code. Dependency direction should remain downward through the tier stack.
+
+### Dependency Summary
+
+| Field | Details |
+| --- | --- |
+| **Depends on** | _Enter the explicit dependency list from `package.xml`._ |
+| **Depended on by** | _List packages, executables, or systems that consume this package._ |
+
+### Overlap and Coordination
+
+| Field | Details |
+| --- | --- |
+| **Shared boundaries** | _Identify code, messages, data models, or interfaces shared with another package._ |
+| **Coordination needed** | _List package / package owners, if any, who must coordinate before changes are merged._ |
+
+## 3. Functional Requirements
+
+Describe what the package must do before and after the work, including behavior under failure and compatibility constraints.
+
+| Field | Details |
+| --- | --- |
+| **Required behavior** | _Describe what the package must do when the work is complete._ |
+
+### Operational Expectations
+
+| Field | Details |
+| --- | --- |
+| **Failure behavior** | _Describe behavior when an upstream input, sensor, network link, radio, or other dependency fails._ |
+| **Recovery behavior** | _Describe automatic recovery, retry, fallback, and operator intervention requirements._ |
+| **Backward compatibility** | _Confirm topic names, message types, parameters, files, and launch behavior that must remain compatible._ |
+| **Configuration** | _List required parameters, defaults, validation rules, and configuration files._ |
+
+## 4. Stability and Efficiency
+
+Establish measurable baselines, identify failure risks, and compare the completed package against its prior state.
+
+### Memory and Allocation Assessment
+
+| Field | Details |
+| --- | --- |
+| **Concerns** | _Identify leaks, unnecessary heap allocations, repeated allocations, large buffers, invalid indexing, uninitialized state, or repetitive work._ |
+
+### Build-Time Comparison
+
+| Measurement | Time Measurement | Method / Notes |
+| --- | --- | --- |
+| Clean selected-package build |  | `colcon build --packages-select <package>` |
+| Incremental build |  | Enter the method. |
+| Other |  | Enter details. |
+
+### Test Coverage and Runtime Quality
+
+| Field | Details |
+| --- | --- |
+| **Existing coverage** | _Describe current unit, integration, smoke, simulation, and regression tests._ |
+| **Unit testing** | _Describe what unit tests were used on this package and how._ |
+| **Coverage gaps** | _List untested algorithms, branches, failure paths, and outlier cases._ |
+| **Observed outliers** | _Record flaky behavior, nondeterminism, timing spikes, or unexpected results._ |
+
+## 5. Change Plan and Sign-Off (As per creation of this documentation)
+
+Summarize the agreed scope, codebase impact, implementation sequence, and final decision.
+
+| Field | Details |
+| --- | --- |
+| **Why is it changing?** | _State the problem, evidence, and desired outcome._ |
+| **Codebase impact** | _Describe affected packages, nodes, launch files, interfaces, developers, and runtime behavior._ |
+| **Success criteria** | _List objective conditions that demonstrate the work is complete and effective._ |
+
+The final review checklist will be on ClickUp.


### PR DESCRIPTION
## Description
Updating Source Bash to Pin Compiler Version to GCC 11. Also, adds more informative messages.

## Steps to Test
### Test Case 1: Happy Path
1. `cd robocup-software`
2. `. ./source.bash`

**Expected result:** ROS Setup Complete!

### Test Case 2: Redundant Path
1. `cd robocup-software`
2. `. ./source.bash`
3. `. ./source.bash`

**Expected result:** 
WARNING: a workspace is already sourced in this shell.
  If you just deleted install or make clean, open a new terminal
  stale paths cause PackageNotFoundError at launch.
ROS Setup Complete!

Try other tests based off the file code!

## Key Files to Review
* source.bash

## Review Checklist

- [ ] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [ ] **Remove extra print statements**: Any print statements used for debugging should be removed
- [ ] **Tag reviewers**: Tag some people for review and ping them on Slack