### PR TITLE
Updating Source Bash to Pin Compiler Version to GCC 11. Also, adds more informative messages.

### DIFF
--- a/source.bash
+++ b/source.bash
@@ -1,16 +1,37 @@
-if [[ $SHELL == *"bash"* ]]; then
-    echo "bash detected, sourcing bash"
+# Welcome to our Robocup Setup Bash Script :)
+
+# Check if user already sourced
+if [[ -n "$AMENT_PREFIX_PATH" ]]; then
+    echo "WARNING: a workspace is already sourced in this shell." >&2
+    echo "  If you just deleted install or make clean, open a new terminal " >&2
+    echo "  stale paths cause PackageNotFoundError at launch." >&2
+fi
+
+# Pin compiler to GCC 11 to match /opt/ros/humble binaries
+if [[ -x /usr/bin/g++-11 && -x /usr/bin/gcc-11 ]]; then
+    export CC=/usr/bin/gcc-11
+    export CXX=/usr/bin/g++-11
+else
+    echo "ERROR: gcc-11/g++-11 not found. Install with: " >&2
+    echo "  sudo apt install gcc-11 g++-11" >&2
+    return 1
+fi
+
+# Running ROS Setup with shell detection
+if [[ -n "$BASH_VERSION" ]]; then
     source /opt/ros/humble/setup.bash
     if [[ -f install/setup.bash ]]; then
         source install/setup.bash
     fi
-fi
-
-if [[ $SHELL == *"zsh"* ]]; then
-    echo "zsh detected, sourcing zsh"
+elif [[ -n "$ZSH_VERSION" ]]; then
     source /opt/ros/humble/setup.zsh
     if [[ -f install/setup.zsh ]]; then
         source install/setup.zsh
     fi
+else
+    echo "ERROR: unsupported shell. This script needs bash or zsh." >&2
+    return 1
 fi
+
+echo "ROS Setup Complete!"
 


### PR DESCRIPTION
## Description
Updating Source Bash to Pin Compiler Version to GCC 11. Also, adds more informative messages.

## Steps to Test
### Test Case 1: Happy Path
1. `cd robocup-software`
2. `. ./source.bash`

**Expected result:** ROS Setup Complete!

### Test Case 2: Redundant Path
1. `cd robocup-software`
2. `. ./source.bash`
3. `. ./source.bash`

**Expected result:** 
WARNING: a workspace is already sourced in this shell.
  If you just deleted install or make clean, open a new terminal
  stale paths cause PackageNotFoundError at launch.
ROS Setup Complete!

Try other tests based off the file code!

## Key Files to Review
* source.bash

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack